### PR TITLE
:recycle: Use default Django Rest Framework throttling for ratelimiting

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -210,6 +210,12 @@ REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
     ],
+    "DEFAULT_THROTTLE_CLASSES": [
+        "rest_framework.throttling.AnonRateThrottle",
+    ],
+    "DEFAULT_THROTTLE_RATES": {
+        "anon": "5/minute",
+    },
     "DEFAULT_RENDERER_CLASSES": REST_FRAMEWORK_DEFAULT_RENDERER_CLASSES,
     "EXCEPTION_HANDLER": "zane_api.views.auth.custom_exception_handler",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,6 +10,6 @@
     "makemigration": "source ./venv/bin/activate && python manage.py makemigrations",
     "migrate": "source ./venv/bin/activate && python manage.py migrate",
     "openapi": "source ./venv/bin/activate && python manage.py spectacular --color --file ../openapi/schema.yml",
-    "freeze": "source ./venv/bin/activate && pip freeze > requirements.txt"
+    "freeze": "source ./venv/bin/activate && uv pip freeze > requirements.txt"
   }
 }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -18,7 +18,6 @@ django-celery-beat==2.6.0
 django-celery-results==2.5.1
 django-compat==1.0.15
 django-filter==23.5
-django-ratelimit==4.1.0
 django-timezone-field==6.1.0
 djangorestframework==3.14.0
 docker==7.0.0

--- a/backend/zane_api/tests/auth.py
+++ b/backend/zane_api/tests/auth.py
@@ -42,7 +42,7 @@ class AuthLoginViewTests(AuthAPITestCase):
                 data={},
             )
         self.assertEqual(status.HTTP_429_TOO_MANY_REQUESTS, response.status_code)
-        self.assertIsNotNone(response.json().get("errors", None))
+        self.assertIsNotNone(response.json().get("errors"))
 
 
 class AuthMeViewTests(AuthAPITestCase):

--- a/backend/zane_api/views/auth.py
+++ b/backend/zane_api/views/auth.py
@@ -93,8 +93,6 @@ class LoginView(APIView):
         },
         operation_id="login",
     )
-    # @method_decorator(ratelimit(key="ip", rate="5/m"))
-    # @method_decorator(ratelimit(key="post:username", rate="5/m"))
     def post(self, request: Request) -> Response:
         form = LoginRequestSerializer(data=request.data)
         if form.is_valid():

--- a/backend/zane_api/views/auth.py
+++ b/backend/zane_api/views/auth.py
@@ -3,11 +3,9 @@ from typing import Any
 from django.contrib.auth import authenticate, login, logout
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
-from django_ratelimit.decorators import ratelimit
-from django_ratelimit.exceptions import Ratelimited
 from drf_spectacular.utils import extend_schema
 from rest_framework import status, permissions
-from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied, Throttled
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -19,16 +17,18 @@ EMPTY_RESPONSE: dict = {}
 
 
 def custom_exception_handler(exception: Any, context: Any) -> Response:
-    if isinstance(exception, Ratelimited):
+    if isinstance(exception, Throttled):
         return Response(
             {
                 "errors": {
                     "root": [
-                        "Too Many Requests",
+                        f"You made too Many requests in a short amount of time, "
+                        f"Please wait for {exception.wait} seconds before retrying your action.",
                     ]
                 }
             },
             status=status.HTTP_429_TOO_MANY_REQUESTS,
+            headers={"Retry-After": exception.wait},
         )
 
     if isinstance(exception, NotAuthenticated):
@@ -93,8 +93,8 @@ class LoginView(APIView):
         },
         operation_id="login",
     )
-    @method_decorator(ratelimit(key="ip", rate="5/m"))
-    @method_decorator(ratelimit(key="post:username", rate="5/m"))
+    # @method_decorator(ratelimit(key="ip", rate="5/m"))
+    # @method_decorator(ratelimit(key="post:username", rate="5/m"))
     def post(self, request: Request) -> Response:
         form = LoginRequestSerializer(data=request.data)
         if form.is_valid():


### PR DESCRIPTION
## Description

This PR removes the usage of `django-ratelimit` with Django Rest Framework throttling, the response returned by DRF is way more actionable than what `django-ratelimit` gives us and allows us to show messages like this one : 
  
<img width="579" alt="image" src="https://github.com/zane-ops/zane-ops/assets/38298743/6d7b0cb3-aa25-461e-9197-29bac451a4ea">

I also added the ratelimit to all endpoints for unauthenticated users by default as an another security firewall.

closes #68 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
