### PR TITLE
♻️  Use DRF Standardized Errors for errors returned by the API

### DIFF
--- a/backend/backend/api_description.py
+++ b/backend/backend/api_description.py
@@ -1,0 +1,79 @@
+API_DESCRIPTION = """
+
+## Overview
+
+ZaneOps is a self-hosted, open source platform as a service for hosting static sites, web apps, 
+databases, CRONS, Workers using docker swarm as the engine.
+
+## Errors
+
+### 405 Method Not Allowed
+
+This is returned when an endpoint is called with an unexpected http method. For example, if updating a user requires
+a POST request and a PATCH is issued instead, this error is returned. Here's how it looks like:
+
+```json
+{
+  "type": "client_error",
+  "errors": [
+    {
+      "code": "method_not_allowed",
+      "detail": "Method “patch” not allowed.",
+      "attr": null
+    }
+  ]
+}
+```
+
+### 406 Not Acceptable
+
+This is returned if the `Accept` header is submitted and contains a value other than `application/json`. Here's how the
+response would look:
+
+```json
+{
+  "type": "client_error",
+  "errors": [
+    {
+      "code": "not_acceptable",
+      "detail": "Could not satisfy the request Accept header.",
+      "attr": null
+    }
+  ]
+}
+```
+
+### 415 Unsupported Media Type
+
+This is returned when the request content type is not json. Here's how the response would look:
+
+```json
+{
+  "type": "client_error",
+  "errors": [
+    {
+      "code": "not_acceptable",
+      "detail": "Unsupported media type “application/xml” in request.",
+      "attr": null
+    }
+  ]
+}
+```
+
+### 500 Internal Server Error
+
+This is returned when the API server encounters an unexpected error. Here's how the response would look:
+
+```json
+{
+  "type": "server_error",
+  "errors": [
+    {
+      "code": "error",
+      "detail": "A server error occurred.",
+      "attr": null
+    }
+  ]
+}
+```
+"""

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -232,7 +232,11 @@ DRF_STANDARDIZED_ERRORS = {
         "403",
         "404",
         "429",
+        "409",
     ],
+    "ERROR_SCHEMAS": {
+        "409": "zane_api.serializers.ErrorResponse409Serializer",
+    },
 }
 
 # DRF SPECTACULAR, for OpenAPI schema generation
@@ -255,6 +259,7 @@ SPECTACULAR_SETTINGS = {
         "ErrorCode415Enum": "drf_standardized_errors.openapi_serializers.ErrorCode415Enum.choices",
         "ErrorCode429Enum": "drf_standardized_errors.openapi_serializers.ErrorCode429Enum.choices",
         "ErrorCode500Enum": "drf_standardized_errors.openapi_serializers.ErrorCode500Enum.choices",
+        "ErrorCode409Enum": "zane_api.serializers.ErrorCode409Enum.choices",
     },
     "POSTPROCESSING_HOOKS": [
         "drf_standardized_errors.openapi_hooks.postprocess_schema_enums"

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -73,6 +73,7 @@ INSTALLED_APPS = [
     "drf_spectacular",
     "django_celery_results",
     "django_celery_beat",
+    "drf_standardized_errors",
 ]
 
 MIDDLEWARE = [
@@ -217,7 +218,8 @@ REST_FRAMEWORK = {
         "anon": "5/minute",
     },
     "DEFAULT_RENDERER_CLASSES": REST_FRAMEWORK_DEFAULT_RENDERER_CLASSES,
-    "EXCEPTION_HANDLER": "zane_api.views.auth.custom_exception_handler",
+    # "EXCEPTION_HANDLER": "zane_api.views.auth.custom_exception_handler",
+    "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -232,11 +232,7 @@ DRF_STANDARDIZED_ERRORS = {
         "403",
         "404",
         "429",
-        "409",
     ],
-    "ERROR_SCHEMAS": {
-        "409": "zane_api.serializers.ErrorResponse409Serializer",
-    },
 }
 
 # DRF SPECTACULAR, for OpenAPI schema generation
@@ -259,7 +255,6 @@ SPECTACULAR_SETTINGS = {
         "ErrorCode415Enum": "drf_standardized_errors.openapi_serializers.ErrorCode415Enum.choices",
         "ErrorCode429Enum": "drf_standardized_errors.openapi_serializers.ErrorCode429Enum.choices",
         "ErrorCode500Enum": "drf_standardized_errors.openapi_serializers.ErrorCode500Enum.choices",
-        "ErrorCode409Enum": "zane_api.serializers.ErrorCode409Enum.choices",
     },
     "POSTPROCESSING_HOOKS": [
         "drf_standardized_errors.openapi_hooks.postprocess_schema_enums"

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -13,6 +13,8 @@ https://docs.djangoproject.com/en/5.0/ref/settings/
 import os
 from pathlib import Path
 
+from .api_description import API_DESCRIPTION
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -229,19 +231,16 @@ DRF_STANDARDIZED_ERRORS = {
         "401",
         "403",
         "404",
-        "405",
-        "415",
         "429",
-        "500",
     ],
 }
 
 # DRF SPECTACULAR, for OpenAPI schema generation
 
+
 SPECTACULAR_SETTINGS = {
     "TITLE": "ZaneOps API",
-    "DESCRIPTION": "ZaneOps is a self-hosted, open source platform as a service for hosting static sites, web apps, "
-    "databases, CRONS, Workers using docker swarm as the engine.",
+    "DESCRIPTION": API_DESCRIPTION,
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
     "ENUM_NAME_OVERRIDES": {

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -218,8 +218,7 @@ REST_FRAMEWORK = {
         "anon": "5/minute",
     },
     "DEFAULT_RENDERER_CLASSES": REST_FRAMEWORK_DEFAULT_RENDERER_CLASSES,
-    # "EXCEPTION_HANDLER": "zane_api.views.auth.custom_exception_handler",
-    "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler",
+    "EXCEPTION_HANDLER": "zane_api.views.custom_exception_handler",
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -218,17 +218,48 @@ REST_FRAMEWORK = {
         "anon": "5/minute",
     },
     "DEFAULT_RENDERER_CLASSES": REST_FRAMEWORK_DEFAULT_RENDERER_CLASSES,
-    "EXCEPTION_HANDLER": "zane_api.views.custom_exception_handler",
-    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    "EXCEPTION_HANDLER": "drf_standardized_errors.handler.exception_handler",
+    "DEFAULT_SCHEMA_CLASS": "drf_standardized_errors.openapi.AutoSchema",
+}
+
+DRF_STANDARDIZED_ERRORS = {
+    "EXCEPTION_HANDLER_CLASS": "zane_api.views.CustomExceptionHandler",
+    "ALLOWED_ERROR_STATUS_CODES": [
+        "400",
+        "401",
+        "403",
+        "404",
+        "405",
+        "415",
+        "429",
+        "500",
+    ],
 }
 
 # DRF SPECTACULAR, for OpenAPI schema generation
 
 SPECTACULAR_SETTINGS = {
     "TITLE": "ZaneOps API",
-    "DESCRIPTION": "Your deployment, simplified. Everything handled for you.",
+    "DESCRIPTION": "ZaneOps is a self-hosted, open source platform as a service for hosting static sites, web apps, "
+    "databases, CRONS, Workers using docker swarm as the engine.",
     "VERSION": "1.0.0",
     "SERVE_INCLUDE_SCHEMA": False,
+    "ENUM_NAME_OVERRIDES": {
+        "ValidationErrorEnum": "drf_standardized_errors.openapi_serializers.ValidationErrorEnum.choices",
+        "ClientErrorEnum": "drf_standardized_errors.openapi_serializers.ClientErrorEnum.choices",
+        "ServerErrorEnum": "drf_standardized_errors.openapi_serializers.ServerErrorEnum.choices",
+        "ErrorCode401Enum": "drf_standardized_errors.openapi_serializers.ErrorCode401Enum.choices",
+        "ErrorCode403Enum": "drf_standardized_errors.openapi_serializers.ErrorCode403Enum.choices",
+        "ErrorCode404Enum": "drf_standardized_errors.openapi_serializers.ErrorCode404Enum.choices",
+        "ErrorCode405Enum": "drf_standardized_errors.openapi_serializers.ErrorCode405Enum.choices",
+        "ErrorCode406Enum": "drf_standardized_errors.openapi_serializers.ErrorCode406Enum.choices",
+        "ErrorCode415Enum": "drf_standardized_errors.openapi_serializers.ErrorCode415Enum.choices",
+        "ErrorCode429Enum": "drf_standardized_errors.openapi_serializers.ErrorCode429Enum.choices",
+        "ErrorCode500Enum": "drf_standardized_errors.openapi_serializers.ErrorCode500Enum.choices",
+    },
+    "POSTPROCESSING_HOOKS": [
+        "drf_standardized_errors.openapi_hooks.postprocess_schema_enums"
+    ],
 }
 
 # For having colorized output in tests

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,6 +22,7 @@ django-timezone-field==6.1.0
 djangorestframework==3.14.0
 docker==7.0.0
 drf-spectacular==0.27.1
+drf-standardized-errors==0.13.0
 faker==24.2.0
 flower==2.0.1
 gunicorn==21.2.0

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -2,7 +2,7 @@ import os
 
 from django.contrib.auth.models import User
 from django.db.models import TextChoices
-from drf_standardized_errors.openapi_serializers import ServerErrorEnum
+from drf_standardized_errors.openapi_serializers import ClientErrorEnum
 from rest_framework import serializers
 from rest_framework.serializers import *
 
@@ -21,7 +21,7 @@ class Error409Serializer(serializers.Serializer):
 
 
 class ErrorResponse409Serializer(serializers.Serializer):
-    type = serializers.ChoiceField(choices=ServerErrorEnum.choices)
+    type = serializers.ChoiceField(choices=ClientErrorEnum.choices)
     errors = Error409Serializer(many=True)
 
 

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -25,18 +25,6 @@ class ErrorResponse409Serializer(serializers.Serializer):
     errors = Error409Serializer(many=True)
 
 
-class StringListField(ListField):
-    child = CharField()
-
-
-class BaseErrorSerializer(Serializer):
-    root = StringListField(required=False)
-
-
-class BaseErrorResponseSerializer(Serializer):
-    errors = BaseErrorSerializer()
-
-
 class URLPathField(CharField):
     default_validators = [validate_url_path]
 
@@ -110,7 +98,3 @@ class DockerServiceSerializer(ModelSerializer):
             "ports",
             "env_variables",
         ]
-
-
-class ForbiddenResponseSerializer(BaseErrorResponseSerializer):
-    pass

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -1,10 +1,28 @@
 import os
 
 from django.contrib.auth.models import User
+from django.db.models import TextChoices
+from drf_standardized_errors.openapi_serializers import ServerErrorEnum
+from rest_framework import serializers
 from rest_framework.serializers import *
 
 from . import models
 from .validators import validate_url_path, validate_url_domain
+
+
+class ErrorCode409Enum(TextChoices):
+    RESOURCE_CONFLICT = "resource_conflict"
+
+
+class Error409Serializer(serializers.Serializer):
+    code = serializers.ChoiceField(choices=ErrorCode409Enum.choices)
+    detail = serializers.CharField()
+    attr = serializers.CharField(allow_null=True)
+
+
+class ErrorResponse409Serializer(serializers.Serializer):
+    type = serializers.ChoiceField(choices=ServerErrorEnum.choices)
+    errors = Error409Serializer(many=True)
 
 
 class StringListField(ListField):

--- a/backend/zane_api/tests/auth.py
+++ b/backend/zane_api/tests/auth.py
@@ -21,7 +21,6 @@ class AuthLoginViewTests(AuthAPITestCase):
             data={"username": "user", "password": "bad_password"},
         )
         self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
-        self.assertIsNotNone(response.json().get("errors"))
 
     def test_bad_request(self):
         response = self.client.post(
@@ -29,7 +28,6 @@ class AuthLoginViewTests(AuthAPITestCase):
             data={},
         )
         self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
-        self.assertIsNotNone(response.json().get("errors"))
 
     def test_login_ratelimit(self):
         for _ in range(6):
@@ -38,7 +36,6 @@ class AuthLoginViewTests(AuthAPITestCase):
                 data={},
             )
         self.assertEqual(status.HTTP_429_TOO_MANY_REQUESTS, response.status_code)
-        self.assertIsNotNone(response.json().get("errors"))
 
 
 class AuthMeViewTests(AuthAPITestCase):

--- a/backend/zane_api/tests/auth.py
+++ b/backend/zane_api/tests/auth.py
@@ -1,3 +1,5 @@
+import json
+
 from django.urls import reverse
 from rest_framework import status
 
@@ -42,6 +44,7 @@ class AuthLoginViewTests(AuthAPITestCase):
                 data={},
             )
         self.assertEqual(status.HTTP_429_TOO_MANY_REQUESTS, response.status_code)
+        print(json.dumps(response.json(), indent=2))
         self.assertIsNotNone(response.json().get("errors"))
 
 

--- a/backend/zane_api/tests/auth.py
+++ b/backend/zane_api/tests/auth.py
@@ -1,5 +1,3 @@
-import json
-
 from django.urls import reverse
 from rest_framework import status
 
@@ -44,7 +42,7 @@ class AuthLoginViewTests(AuthAPITestCase):
                 data={},
             )
         self.assertEqual(status.HTTP_429_TOO_MANY_REQUESTS, response.status_code)
-        print(json.dumps(response.json(), indent=2))
+
         self.assertIsNotNone(response.json().get("errors"))
 
 

--- a/backend/zane_api/tests/auth.py
+++ b/backend/zane_api/tests/auth.py
@@ -21,19 +21,15 @@ class AuthLoginViewTests(AuthAPITestCase):
             data={"username": "user", "password": "bad_password"},
         )
         self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
-        self.assertIsNotNone(response.json().get("errors", None))
+        self.assertIsNotNone(response.json().get("errors"))
 
     def test_bad_request(self):
         response = self.client.post(
             reverse("zane_api:auth.login"),
             data={},
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-        errors = response.json().get("errors", None)
-
-        self.assertIsNotNone(errors)
-        self.assertIn("username", errors)
-        self.assertIn("password", errors)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertIsNotNone(response.json().get("errors"))
 
     def test_login_ratelimit(self):
         for _ in range(6):
@@ -42,7 +38,6 @@ class AuthLoginViewTests(AuthAPITestCase):
                 data={},
             )
         self.assertEqual(status.HTTP_429_TOO_MANY_REQUESTS, response.status_code)
-
         self.assertIsNotNone(response.json().get("errors"))
 
 

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -125,12 +125,14 @@ class FakeDockerClient:
     def events(self, decode: bool, filters: dict):
         return []
 
-    def containers_run(
-        self, image: str, ports: dict[str, tuple[str, int]], command: str, remove: bool
-    ):
-        _, port = list(ports.values())[0]
-        if port == self.PORT_USED_BY_HOST:
-            raise docker.errors.APIError(f"Port {port} is already used")
+    def containers_run(self, command: str, *args, **kwargs):
+        ports: dict[str, tuple[str, int]] = kwargs.get("ports")
+        if ports is not None:
+            _, port = list(ports.values())[0]
+            if port == self.PORT_USED_BY_HOST:
+                raise docker.errors.APIError(f"Port {port} is already used")
+        if command == "du -sb /data":
+            return "72689062\t/data".encode(encoding="utf-8")
 
     def volumes_create(self, name: str, labels: dict, **kwargs):
         self.volume_map[name] = FakeDockerClient.FakeVolume(

--- a/backend/zane_api/tests/docker.py
+++ b/backend/zane_api/tests/docker.py
@@ -1,53 +1,9 @@
-from typing import List
-from unittest.mock import patch, Mock, MagicMock
+from unittest.mock import patch, Mock
 
-import docker.errors
 from django.urls import reverse
 from rest_framework import status
 
-from .base import AuthAPITestCase
-from ..docker_operations import DockerImageResultFromRegistry
-
-
-class FakeDockerClient:
-    def __init__(self):
-        self.containers = MagicMock()
-        self.images = MagicMock()
-
-        self.containers.run = self.containers_run
-        self.images.search = self.images_search
-
-    @staticmethod
-    def containers_run(
-        image: str, ports: dict[str, tuple[str, int]], command: str, remove: bool
-    ):
-        _, port = list(ports.values())[0]
-        if port == 90:
-            raise docker.errors.APIError("Port 90 is already used")
-
-    @staticmethod
-    def images_search(term: str, limit: int) -> List[DockerImageResultFromRegistry]:
-        return [
-            {
-                "name": "caddy",
-                "is_official": True,
-                "is_automated": True,
-                "description": "Caddy 2 is a powerful, enterprise-ready,"
-                " open source web server with automatic HTTPS written in Go",
-            },
-            {
-                "description": "caddy webserver optimized for usage within the SIWECOS project",
-                "is_automated": False,
-                "is_official": False,
-                "name": "siwecos/caddy",
-                "star_count": 0,
-            },
-        ]
-
-    @staticmethod
-    def login(username: str, password: str, **kwargs):
-        if username != "user" or password != "password":
-            raise docker.errors.APIError("Bad Credentials")
+from .base import AuthAPITestCase, FakeDockerClient
 
 
 class DockerViewTests(AuthAPITestCase):
@@ -55,7 +11,9 @@ class DockerViewTests(AuthAPITestCase):
         super().setUp()
         self.loginUser()
 
-    @patch("zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient())
+    @patch(
+        "zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient()
+    )
     def test_search_docker_images(self, mock_fake_docker: Mock):
         response = self.client.get(
             reverse("zane_api:docker.image_search"), QUERY_STRING="q=caddy"
@@ -67,24 +25,30 @@ class DockerViewTests(AuthAPITestCase):
         self.assertEqual(images[0]["full_image"], "library/caddy:latest")
         self.assertEqual(images[1]["full_image"], "siwecos/caddy:latest")
 
-    @patch("zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient())
+    @patch(
+        "zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient()
+    )
     def test_search_query_empty(self, _: Mock):
         response = self.client.get(reverse("zane_api:docker.image_search"))
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
-    @patch("zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient())
+    @patch(
+        "zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient()
+    )
     def test_success_validate_credentials(self, _: Mock):
         response = self.client.post(
             reverse("zane_api:docker.login"),
             data={
-                "username": "user",
-                "password": "password",
+                "username": "fredkiss3",
+                "password": "s3cret",
             },
         )
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
-    @patch("zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient())
+    @patch(
+        "zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient()
+    )
     def test_bad_credentials(self, _: Mock):
         response = self.client.post(
             reverse("zane_api:docker.login"),
@@ -96,7 +60,9 @@ class DockerViewTests(AuthAPITestCase):
 
         self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
-    @patch("zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient())
+    @patch(
+        "zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient()
+    )
     def test_bad_request_for_credentials(self, _: Mock):
         response = self.client.post(
             reverse("zane_api:docker.login"),
@@ -105,30 +71,34 @@ class DockerViewTests(AuthAPITestCase):
             },
         )
 
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
 
 class DockerPortMappingViewTests(AuthAPITestCase):
-    @patch("zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient())
+    @patch(
+        "zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient()
+    )
     def test_successfull(self, _: Mock):
         self.loginUser()
         response = self.client.post(
             reverse("zane_api:docker.check_port_mapping"),
             data={
-                "port": 8080,
+                "port": 8082,
             },
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(response.json().get("available"), True)
 
-    @patch("zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient())
+    @patch(
+        "zane_api.docker_operations.get_docker_client", return_value=FakeDockerClient()
+    )
     def test_unavailable_port(self, _: Mock):
         self.loginUser()
         response = self.client.post(
             reverse("zane_api:docker.check_port_mapping"),
             data={
-                "port": 90,
+                "port": FakeDockerClient.PORT_USED_BY_HOST,
             },
         )
-        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(response.json().get("available"), False)

--- a/backend/zane_api/tests/project.py
+++ b/backend/zane_api/tests/project.py
@@ -203,9 +203,6 @@ class ProjectCreateViewTests(AuthAPITestCase):
             data={"slug": "zane-ops"},
         )
         self.assertEqual(status.HTTP_409_CONFLICT, response.status_code)
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
-        self.assertIsNotNone(errors.get("slug"))
         self.assertEqual(1, Project.objects.count())
 
     @patch(
@@ -218,9 +215,7 @@ class ProjectCreateViewTests(AuthAPITestCase):
             reverse("zane_api:projects.list"),
             data={"slug": "zane Ops"},
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-        self.assertIsNotNone(response.json().get("errors"))
-        self.assertIsNotNone(response.json().get("errors").get("slug"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @patch(
         "zane_api.docker_operations.get_docker_client",
@@ -269,8 +264,7 @@ class ProjectUpdateViewTests(AuthAPITestCase):
             data={"slug": "Zane Ops"},
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-        self.assertIsNotNone(response.json().get("errors").get("slug"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     def test_non_existent(self):
         self.loginUser()

--- a/backend/zane_api/tests/service.py
+++ b/backend/zane_api/tests/service.py
@@ -216,11 +216,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
-        self.assertIsNotNone(errors.get("ports"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
         created_service: DockerRegistryService = DockerRegistryService.objects.filter(
             slug="nosql-db"
@@ -260,10 +256,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
-        self.assertIsNotNone(errors.get("ports"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
         created_service: DockerRegistryService = DockerRegistryService.objects.filter(
             slug="adminer"
@@ -534,10 +527,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("ports"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @patch("zane_api.tasks.expose_docker_service_to_http")
     @patch(
@@ -554,8 +544,8 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             "slug": "adminer-ui",
             "image": "adminer:latest",
             "ports": [
-                {"public": 8080, "forwarded": 8080},
-                {"public": 8080, "forwarded": 8080},
+                {"public": 8081, "forwarded": 8080},
+                {"public": 8081, "forwarded": 8080},
             ],
         }
 
@@ -564,10 +554,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("ports"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @patch("zane_api.tasks.expose_docker_service_to_http")
     @patch(
@@ -597,10 +584,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("urls"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @patch("zane_api.tasks.expose_docker_service_to_http")
     @patch(
@@ -627,10 +611,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("volumes"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @patch("zane_api.tasks.expose_docker_service_to_http")
     @patch(
@@ -659,10 +640,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("urls"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @patch("zane_api.tasks.expose_docker_service_to_http")
     @patch(
@@ -691,10 +669,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("urls"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @patch("zane_api.tasks.expose_docker_service_to_http")
     @patch(
@@ -794,10 +769,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("credentials"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
         created_service: DockerRegistryService = DockerRegistryService.objects.filter(
             slug="main-app"
@@ -831,10 +803,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("image"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
         created_service: DockerRegistryService = DockerRegistryService.objects.filter(
             slug="main-app"
@@ -870,10 +839,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("image"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
         created_service: DockerRegistryService = DockerRegistryService.objects.filter(
             slug="main-app"
@@ -901,10 +867,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("image"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
         created_service: DockerRegistryService = DockerRegistryService.objects.filter(
             slug="main-app"
@@ -925,10 +888,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps({}),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
         created_service: DockerRegistryService = DockerRegistryService.objects.filter(
             slug="main-app"
@@ -957,10 +917,6 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             content_type="application/json",
         )
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
-
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
-        self.assertIsNotNone(errors.get("root"))
 
         created_service: DockerRegistryService = DockerRegistryService.objects.filter(
             slug="main-app"
@@ -991,9 +947,6 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             content_type="application/json",
         )
         self.assertEqual(status.HTTP_409_CONFLICT, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("slug"))
 
     @patch("zane_api.tasks.expose_docker_service_to_http")
     @patch(
@@ -1027,10 +980,7 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
             data=json.dumps(create_service_payload),
             content_type="application/json",
         )
-        self.assertEqual(status.HTTP_422_UNPROCESSABLE_ENTITY, response.status_code)
-
-        errors = response.json()["errors"]
-        self.assertIsNotNone(errors.get("urls"))
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
 
     @patch("zane_api.tasks.expose_docker_service_to_http")
     @patch(
@@ -1119,9 +1069,6 @@ class DockerGetServiceViewTest(AuthAPITestCase):
             ),
         )
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
-        self.assertIsNotNone(errors.get("root"))
 
     @patch(
         "zane_api.docker_operations.get_docker_client",
@@ -1143,9 +1090,6 @@ class DockerGetServiceViewTest(AuthAPITestCase):
             ),
         )
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
-        self.assertIsNotNone(errors.get("root"))
 
 
 class DockerServiceArchiveViewTest(AuthAPITestCase):
@@ -1426,9 +1370,6 @@ class DockerServiceArchiveViewTest(AuthAPITestCase):
             )
         )
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
-        self.assertIsNotNone(errors.get("root"))
 
     @patch(
         "zane_api.docker_operations.get_docker_client",
@@ -1443,6 +1384,3 @@ class DockerServiceArchiveViewTest(AuthAPITestCase):
             )
         )
         self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
-        errors = response.json().get("errors")
-        self.assertIsNotNone(errors)
-        self.assertIsNotNone(errors.get("root"))

--- a/backend/zane_api/views/__init__.py
+++ b/backend/zane_api/views/__init__.py
@@ -1,4 +1,5 @@
 from .auth import *
+from .base import *
 from .docker import *
 from .docker_services import *
 from .domain import *

--- a/backend/zane_api/views/auth.py
+++ b/backend/zane_api/views/auth.py
@@ -90,6 +90,12 @@ class CSRFCookieView(APIView):
     serializer_class = CSRFSerializer
     permission_classes = [permissions.AllowAny]
 
+    @extend_schema(
+        responses={
+            401: None,
+        },
+        operation_id="getCSRF",
+    )
     @method_decorator(ensure_csrf_cookie)
     def get(self, _: Request) -> Response:
         response = CSRFSerializer(data={"details": "CSRF cookie set"})

--- a/backend/zane_api/views/auth.py
+++ b/backend/zane_api/views/auth.py
@@ -8,9 +8,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from .base import EMPTY_RESPONSE
 from .. import serializers
-
-EMPTY_RESPONSE: dict = {}
 
 
 class LoginSuccessResponseSerializer(serializers.Serializer):

--- a/backend/zane_api/views/auth.py
+++ b/backend/zane_api/views/auth.py
@@ -2,6 +2,7 @@ from django.contrib.auth import authenticate, login, logout
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import ensure_csrf_cookie
 from drf_spectacular.utils import extend_schema
+from rest_framework import exceptions
 from rest_framework import status, permissions
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -23,62 +24,30 @@ class LoginRequestSerializer(serializers.Serializer):
     password = serializers.CharField(required=True, min_length=1, max_length=255)
 
 
-class LoginErrorSerializer(serializers.BaseErrorSerializer):
-    username = serializers.StringListField(required=False)
-    password = serializers.StringListField(required=False)
-
-
-class LoginErrorResponseSerializer(serializers.Serializer):
-    errors = LoginErrorSerializer()
-
-
 class LoginView(APIView):
     permission_classes = [permissions.AllowAny]
-    success_serializer_class = LoginSuccessResponseSerializer
-    error_serializer_class = LoginErrorResponseSerializer
+    serializer_class = LoginSuccessResponseSerializer
 
     @extend_schema(
         request=LoginRequestSerializer,
         responses={
-            201: success_serializer_class,
-            422: error_serializer_class,
-            401: error_serializer_class,
-            429: error_serializer_class,
+            201: LoginSuccessResponseSerializer,
         },
         operation_id="login",
     )
     def post(self, request: Request) -> Response:
         form = LoginRequestSerializer(data=request.data)
-        if form.is_valid():
+        if form.is_valid(raise_exception=True):
             data = form.data
             user = authenticate(
                 username=data.get("username"), password=data.get("password")
             )
             if user is not None:
                 login(request, user)
-                response = self.success_serializer_class(data={"success": True})
+                response = LoginSuccessResponseSerializer(data={"success": True})
                 if response.is_valid():
                     return Response(response.data, status=status.HTTP_201_CREATED)
-            else:
-                response = self.error_serializer_class(
-                    {
-                        "errors": {
-                            "root": [
-                                "Invalid username or password",
-                            ]
-                        },
-                    }
-                )
-                return Response(
-                    response.data,
-                    status=status.HTTP_401_UNAUTHORIZED,
-                )
-        else:
-            response = self.error_serializer_class({"errors": form.errors})
-            return Response(
-                response.data,
-                status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            )
+            raise exceptions.AuthenticationFailed(detail="Invalid username or password")
 
 
 class AuthedSuccessResponseSerializer(serializers.Serializer):
@@ -87,13 +56,8 @@ class AuthedSuccessResponseSerializer(serializers.Serializer):
 
 class AuthedView(APIView):
     serializer_class = AuthedSuccessResponseSerializer
-    error_serializer_class = serializers.ForbiddenResponseSerializer
 
     @extend_schema(
-        responses={
-            200: serializer_class,
-            403: error_serializer_class,
-        },
         operation_id="getAuthedUser",
     )
     def get(self, request: Request):
@@ -104,12 +68,9 @@ class AuthedView(APIView):
 
 
 class AuthLogoutView(APIView):
-    error_serializer_class = serializers.ForbiddenResponseSerializer
-
     @extend_schema(
         responses={
             204: None,
-            403: error_serializer_class,
         },
         operation_id="logout",
     )
@@ -128,7 +89,6 @@ class CSRFCookieView(APIView):
     """
 
     serializer_class = CSRFSerializer
-
     permission_classes = [permissions.AllowAny]
 
     @method_decorator(ensure_csrf_cookie)
@@ -137,8 +97,3 @@ class CSRFCookieView(APIView):
 
         if response.is_valid():
             return Response(response.data)
-
-        return Response(
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            data={"errors": {"root": response.errors}},
-        )

--- a/backend/zane_api/views/auth.py
+++ b/backend/zane_api/views/auth.py
@@ -1,14 +1,8 @@
-from typing import Any
-
 from django.contrib.auth import authenticate, login, logout
 from django.utils.decorators import method_decorator
-from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import ensure_csrf_cookie
 from drf_spectacular.utils import extend_schema
-# from rest_framework.views import exception_handler
-from drf_standardized_errors.handler import exception_handler
 from rest_framework import status, permissions
-from rest_framework.exceptions import NotAuthenticated, PermissionDenied, Throttled
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -16,50 +10,6 @@ from rest_framework.views import APIView
 from .. import serializers
 
 EMPTY_RESPONSE: dict = {}
-
-
-class CustomPermissionDenied(PermissionDenied):
-    status_code = status.HTTP_401_UNAUTHORIZED
-
-
-class CustomNotAuthenticated(NotAuthenticated):
-    default_detail = _(
-        "Authentication required. Please log in to access this resource."
-    )
-
-
-def custom_exception_handler(exception: Any, context: Any) -> Response:
-    if isinstance(exception, Throttled):
-        return Response(
-            {
-                "errors": {
-                    "root": [
-                        f"You made too Many requests in a short amount of time, "
-                        f"Please wait for {exception.wait} seconds before retrying your action.",
-                    ]
-                }
-            },
-            status=status.HTTP_429_TOO_MANY_REQUESTS,
-            headers={"Retry-After": exception.wait},
-        )
-
-    if isinstance(exception, NotAuthenticated):
-        response = serializers.ForbiddenResponseSerializer(
-            {
-                "errors": {
-                    "root": [
-                        "Authentication required. Please log in to access this resource."
-                    ]
-                }
-            }
-        )
-        return Response(
-            response.data,
-            status=status.HTTP_401_UNAUTHORIZED,
-        )
-    if isinstance(exception, PermissionDenied):
-        exception = CustomPermissionDenied()
-    return exception_handler(exception, context)
 
 
 class LoginSuccessResponseSerializer(serializers.Serializer):

--- a/backend/zane_api/views/base.py
+++ b/backend/zane_api/views/base.py
@@ -10,6 +10,15 @@ class CustomThrottledException(exceptions.Throttled):
     )
 
 
+class ResourceConflict(exceptions.APIException):
+    status_code = 409
+    default_detail = (
+        "The action you tried to perform is not possible because"
+        " another resource already exists with the same ID."
+    )
+    default_code = "resource_conflict"
+
+
 class CustomExceptionHandler(ExceptionHandler):
     def convert_known_exceptions(self, exc: Exception) -> Exception:
         if isinstance(exc, exceptions.Throttled):

--- a/backend/zane_api/views/base.py
+++ b/backend/zane_api/views/base.py
@@ -1,0 +1,28 @@
+from typing import Any
+
+from drf_standardized_errors.handler import exception_handler
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied, Throttled
+from rest_framework.response import Response
+
+
+class CustomThrottledException(Throttled):
+    extra_detail_plural = ""
+    extra_detail_singular = ""
+
+
+def custom_exception_handler(exception: Any, context: Any) -> Response:
+    if isinstance(exception, Throttled):
+        exception = CustomThrottledException(
+            wait=exception.wait,
+            detail="You made too Many requests in a short amount of time, "
+            f"Please wait for {exception.wait} seconds before retrying your action.",
+        )
+    if isinstance(exception, NotAuthenticated):
+        exception.detail = NotAuthenticated(
+            detail="Authentication required. Please log in to access this resource.",
+            code=exception.default_code,
+        )
+    if isinstance(exception, PermissionDenied):
+        exception.status_code = status.HTTP_401_UNAUTHORIZED
+    return exception_handler(exception, context)

--- a/backend/zane_api/views/base.py
+++ b/backend/zane_api/views/base.py
@@ -1,28 +1,26 @@
-from typing import Any
-
-from drf_standardized_errors.handler import exception_handler
-from rest_framework import status
-from rest_framework.exceptions import NotAuthenticated, PermissionDenied, Throttled
-from rest_framework.response import Response
+from drf_standardized_errors.handler import ExceptionHandler
+from rest_framework import exceptions, status
 
 
-class CustomThrottledException(Throttled):
-    extra_detail_plural = ""
-    extra_detail_singular = ""
+class CustomThrottledException(exceptions.Throttled):
+    default_detail = "You made too Many requests in a short amount of time,"
+    extra_detail_plural = "Please wait for {wait} seconds before retrying your action."
+    extra_detail_singular = (
+        "Please wait for {wait} seconds before retrying your action."
+    )
 
 
-def custom_exception_handler(exception: Any, context: Any) -> Response:
-    if isinstance(exception, Throttled):
-        exception = CustomThrottledException(
-            wait=exception.wait,
-            detail="You made too Many requests in a short amount of time, "
-            f"Please wait for {exception.wait} seconds before retrying your action.",
-        )
-    if isinstance(exception, NotAuthenticated):
-        exception = NotAuthenticated(
-            detail="Authentication required. Please log in to access this resource.",
-            code=exception.default_code,
-        )
-    if isinstance(exception, PermissionDenied):
-        exception.status_code = status.HTTP_401_UNAUTHORIZED
-    return exception_handler(exception, context)
+class CustomExceptionHandler(ExceptionHandler):
+    def convert_known_exceptions(self, exc: Exception) -> Exception:
+        if isinstance(exc, exceptions.Throttled):
+            return CustomThrottledException(wait=exc.wait)
+        if isinstance(exc, exceptions.AuthenticationFailed):
+            exc.status_code = status.HTTP_401_UNAUTHORIZED
+        if (
+            isinstance(exc, exceptions.NotAuthenticated)
+            and exc.detail == exc.default_detail
+        ):
+            exc = exceptions.NotAuthenticated(
+                detail="Authentication required. Please log in to access this resource.",
+            )
+        return super().convert_known_exceptions(exc)

--- a/backend/zane_api/views/base.py
+++ b/backend/zane_api/views/base.py
@@ -19,7 +19,7 @@ def custom_exception_handler(exception: Any, context: Any) -> Response:
             f"Please wait for {exception.wait} seconds before retrying your action.",
         )
     if isinstance(exception, NotAuthenticated):
-        exception.detail = NotAuthenticated(
+        exception = NotAuthenticated(
             detail="Authentication required. Please log in to access this resource.",
             code=exception.default_code,
         )

--- a/backend/zane_api/views/base.py
+++ b/backend/zane_api/views/base.py
@@ -1,6 +1,8 @@
 from drf_standardized_errors.handler import ExceptionHandler
 from rest_framework import exceptions, status
 
+EMPTY_RESPONSE = {}
+
 
 class CustomThrottledException(exceptions.Throttled):
     default_detail = "You made too Many requests in a short amount of time,"

--- a/backend/zane_api/views/docker.py
+++ b/backend/zane_api/views/docker.py
@@ -19,52 +19,32 @@ class DockerImageSerializer(serializers.Serializer):
     description = serializers.CharField()
 
 
-class DockerSuccessResponseSerializer(serializers.Serializer):
+class DockerImageSearchResponseSerializer(serializers.Serializer):
     images = DockerImageSerializer(many=True)
 
 
-class DockerImageListSearchSerializer(serializers.Serializer):
+class DockerImageSearchParamsSerializer(serializers.Serializer):
     q = serializers.CharField(required=True)
 
 
-class DockerImageSearchErrorSerializer(serializers.BaseErrorSerializer):
-    q = serializers.StringListField(required=False)
-
-
-class DockerImageSearchErrorResponseSerializer(serializers.Serializer):
-    errors = DockerImageSearchErrorSerializer()
-
-
 class DockerImageSearchView(APIView):
-    serializer_class = DockerSuccessResponseSerializer
-    forbidden_serializer_class = serializers.ForbiddenResponseSerializer
-    error_serializer_class = DockerImageSearchErrorResponseSerializer
+    serializer_class = DockerImageSearchResponseSerializer
 
     @extend_schema(
         parameters=[
-            DockerImageListSearchSerializer,
+            DockerImageSearchParamsSerializer,
         ],
-        responses={
-            200: serializer_class,
-            403: forbidden_serializer_class,
-            422: error_serializer_class,
-        },
         operation_id="searchDockerRegistry",
     )
     def get(self, request: Request):
         query_params = request.query_params.dict()
-        form = DockerImageListSearchSerializer(data=query_params)
+        form = DockerImageSearchParamsSerializer(data=query_params)
 
-        if form.is_valid():
+        if form.is_valid(raise_exception=True):
             params = form.data
             result = search_images_docker_hub(term=params["q"])
-            response = self.serializer_class({"images": result})
+            response = DockerImageSearchResponseSerializer({"images": result})
             return Response(response.data, status=status.HTTP_200_OK)
-
-        return Response(
-            status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            data={"errors": form.errors},
-        )
 
 
 class DockerLoginSuccessResponseSerializer(serializers.Serializer):
@@ -77,16 +57,6 @@ class DockerLoginRequestSerializer(serializers.Serializer):
     registry_url = serializers.URLField(required=False)
 
 
-class DockerLoginErrorSerializer(serializers.BaseErrorSerializer):
-    username = serializers.StringListField(required=False)
-    password = serializers.StringListField(required=False)
-    registry_url = serializers.StringListField(required=False)
-
-
-class DockerLoginErrorResponseSerializer(serializers.Serializer):
-    errors = DockerLoginErrorSerializer()
-
-
 class DockerLoginView(APIView):
     serializer_class = DockerLoginSuccessResponseSerializer
 
@@ -97,7 +67,7 @@ class DockerLoginView(APIView):
     def post(self, request: Request):
         form = DockerLoginRequestSerializer(data=request.data)
 
-        if form.is_valid():
+        if form.is_valid(raise_exception=True):
             data = form.data
             try:
                 login_to_docker_registry(**data)
@@ -107,13 +77,8 @@ class DockerLoginView(APIView):
                 response = self.serializer_class({"success": True})
                 return Response(response.data, status=status.HTTP_200_OK)
 
-        return Response(
-            status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            data={"errors": form.errors},
-        )
 
-
-class DockerPortCheckSuccessResponseSerializer(serializers.Serializer):
+class DockerPortCheckResponseSerializer(serializers.Serializer):
     available = serializers.BooleanField()
 
 
@@ -121,43 +86,22 @@ class DockerPortCheckRequestSerializer(serializers.Serializer):
     port = serializers.IntegerField(required=True, min_value=0)
 
 
-class DockerPortCheckErrorSerializer(serializers.BaseErrorSerializer):
-    port = serializers.StringListField(required=False)
-
-
-class DockerPortCheckErrorResponseSerializer(serializers.Serializer):
-    errors = DockerPortCheckErrorSerializer()
-
-
 class DockerPortCheckView(APIView):
-    serializer_class = DockerPortCheckSuccessResponseSerializer
-    forbidden_serializer_class = serializers.ForbiddenResponseSerializer
-    error_serializer_class = DockerPortCheckErrorResponseSerializer
+    serializer_class = DockerPortCheckResponseSerializer
 
     @extend_schema(
         request=DockerPortCheckRequestSerializer,
-        responses={
-            200: serializer_class,
-            400: serializer_class,
-            403: forbidden_serializer_class,
-            422: error_serializer_class,
-        },
         operation_id="checkIfPortIsAvailable",
     )
     def post(self, request: Request):
         form = DockerPortCheckRequestSerializer(data=request.data)
 
-        if form.is_valid():
+        if form.is_valid(raise_exception=True):
             data = form.data
             result = check_if_port_is_available_on_host(port=data["port"])
 
-            response = self.serializer_class({"available": result})
+            response = DockerPortCheckResponseSerializer({"available": result})
             return Response(
                 response.data,
-                status=status.HTTP_200_OK if result else status.HTTP_400_BAD_REQUEST,
+                status=status.HTTP_200_OK,
             )
-
-        return Response(
-            status=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            data={"errors": form.errors},
-        )

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -389,7 +389,6 @@ class CreateDockerServiceAPIView(APIView):
 
 class GetDockerServiceAPIView(APIView):
     serializer_class = DockerServiceResponseSerializer
-    error_serializer_class = serializers.BaseErrorResponseSerializer
 
     @extend_schema(
         request=DockerServiceCreateRequestSerializer,

--- a/backend/zane_api/views/domain.py
+++ b/backend/zane_api/views/domain.py
@@ -1,6 +1,5 @@
 from django.conf import settings
 from drf_spectacular.utils import extend_schema
-from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -14,13 +13,8 @@ class GetRootDomainSerializer(serializers.Serializer):
 
 class GetRootDomainView(APIView):
     serializer_class = GetRootDomainSerializer
-    error_serializer_class = serializers.ForbiddenResponseSerializer
 
     @extend_schema(
-        responses={
-            200: serializer_class,
-            403: error_serializer_class,
-        },
         operation_id="getRootDomain",
     )
     def get(self, _: Request) -> Response:
@@ -28,8 +22,3 @@ class GetRootDomainView(APIView):
 
         if response.is_valid():
             return Response(response.data)
-
-        return Response(
-            status=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            data={"errors": {"root": response.errors}},
-        )

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -155,6 +155,7 @@ class ProjectsListView(APIView):
         request=ProjectCreateRequestSerializer,
         responses={
             201: SingleProjectResponseSerializer,
+            409: serializers.ErrorResponse409Serializer,
         },
         operation_id="createProject",
     )
@@ -175,21 +176,6 @@ class ProjectsListView(APIView):
                     detail=f"A project with the slug '{slug}' already exist,"
                     f" please use another one for this project."
                 )
-            # except Exception as e:
-            #     with transaction.atomic():
-            #         newly_created_project = Project.objects.get(slug=slug)
-            #         if newly_created_project is not None:
-            #             newly_created_project.delete()
-            #     response = self.error_serializer_class(
-            #         {
-            #             "errors": {
-            #                 "root": [str(e)],
-            #             }
-            #         }
-            #     )
-            #     return Response(
-            #         response.data, status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            #     )
             else:
                 create_docker_resources_for_project.apply_async(
                     (slug,), task_id=new_project.create_task_id
@@ -207,6 +193,9 @@ class ProjectDetailsView(APIView):
 
     @extend_schema(
         request=ProjectUpdateRequestSerializer,
+        responses={
+            409: serializers.ErrorResponse409Serializer,
+        },
         operation_id="updateProjectName",
     )
     def patch(self, request: Request, slug: str) -> Response:

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -12,7 +12,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from . import EMPTY_RESPONSE, ResourceConflict
+from .base import EMPTY_RESPONSE, ResourceConflict
 from .. import serializers
 from ..models import (
     Project,

--- a/frontend/src/api/v1.ts
+++ b/frontend/src/api/v1.ts
@@ -34,6 +34,9 @@ export interface paths {
     get: operations["getProjectList"];
     post: operations["createProject"];
   };
+  "/api/projects/{project_slug}/archive-service/docker/{service_slug}/": {
+    delete: operations["archiveDockerService"];
+  };
   "/api/projects/{project_slug}/create-service/docker/": {
     post: operations["createDockerService"];
   };
@@ -45,7 +48,7 @@ export interface paths {
     delete: operations["archiveSingleProject"];
     patch: operations["updateProjectName"];
   };
-  "/api/volumes/{slug}/size/": {
+  "/api/volumes/{volume_id}/size/": {
     get: operations["getVolumeSize"];
   };
 }
@@ -58,6 +61,8 @@ export interface components {
       projects: components["schemas"]["Project"][];
       total_count: number;
     };
+    ArchiveDockerServiceErrorResponse400: components["schemas"]["ParseErrorResponse"];
+    ArchiveSingleProjectErrorResponse400: components["schemas"]["ParseErrorResponse"];
     ArchivedProject: {
       slug?: string;
       /** Format: date-time */
@@ -79,11 +84,429 @@ export interface components {
     CSRF: {
       details: string;
     };
+    /**
+     * @description * `client_error` - Client Error
+     * @enum {string}
+     */
+    ClientErrorEnum: "client_error";
+    CreateDockerServiceCommandErrorComponent: {
+      /**
+       * @description * `command` - command
+       * @enum {string}
+       */
+      attr: "command";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceCredentialsNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `credentials.non_field_errors` - credentials.non_field_errors
+       * @enum {string}
+       */
+      attr: "credentials.non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "invalid" | "null";
+      detail: string;
+    };
+    CreateDockerServiceCredentialsPasswordErrorComponent: {
+      /**
+       * @description * `credentials.password` - credentials.password
+       * @enum {string}
+       */
+      attr: "credentials.password";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceCredentialsRegistryUrlErrorComponent: {
+      /**
+       * @description * `credentials.registry_url` - credentials.registry_url
+       * @enum {string}
+       */
+      attr: "credentials.registry_url";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceCredentialsUsernameErrorComponent: {
+      /**
+       * @description * `credentials.username` - credentials.username
+       * @enum {string}
+       */
+      attr: "credentials.username";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceEnvErrorComponent: {
+      /**
+       * @description * `env` - env
+       * @enum {string}
+       */
+      attr: "env";
+      /**
+       * @description * `not_a_dict` - not_a_dict
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "not_a_dict" | "null";
+      detail: string;
+    };
+    CreateDockerServiceEnvKEYErrorComponent: {
+      /**
+       * @description * `env.KEY` - env.KEY
+       * @enum {string}
+       */
+      attr: "env.KEY";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceError: components["schemas"]["CreateDockerServiceNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceSlugErrorComponent"] | components["schemas"]["CreateDockerServiceImageErrorComponent"] | components["schemas"]["CreateDockerServiceCommandErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsUsernameErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsPasswordErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsRegistryUrlErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsINDEXDomainErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsINDEXBasePathErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsINDEXStripPrefixErrorComponent"] | components["schemas"]["CreateDockerServicePortsNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServicePortsINDEXPublicErrorComponent"] | components["schemas"]["CreateDockerServicePortsINDEXForwardedErrorComponent"] | components["schemas"]["CreateDockerServiceEnvErrorComponent"] | components["schemas"]["CreateDockerServiceEnvKEYErrorComponent"] | components["schemas"]["CreateDockerServiceVolumesNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceVolumesINDEXNameErrorComponent"] | components["schemas"]["CreateDockerServiceVolumesINDEXMountPathErrorComponent"];
+    CreateDockerServiceErrorResponse400: components["schemas"]["CreateDockerServiceValidationError"] | components["schemas"]["ParseErrorResponse"];
+    CreateDockerServiceImageErrorComponent: {
+      /**
+       * @description * `image` - image
+       * @enum {string}
+       */
+      attr: "image";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `non_field_errors` - non_field_errors
+       * @enum {string}
+       */
+      attr: "non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * @enum {string}
+       */
+      code: "invalid";
+      detail: string;
+    };
+    CreateDockerServicePortsINDEXForwardedErrorComponent: {
+      /**
+       * @description * `ports.INDEX.forwarded` - ports.INDEX.forwarded
+       * @enum {string}
+       */
+      attr: "ports.INDEX.forwarded";
+      /**
+       * @description * `invalid` - invalid
+       * * `max_string_length` - max_string_length
+       * * `null` - null
+       * * `required` - required
+       * @enum {string}
+       */
+      code: "invalid" | "max_string_length" | "null" | "required";
+      detail: string;
+    };
+    CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `ports.INDEX.non_field_errors` - ports.INDEX.non_field_errors
+       * @enum {string}
+       */
+      attr: "ports.INDEX.non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "invalid" | "null";
+      detail: string;
+    };
+    CreateDockerServicePortsINDEXPublicErrorComponent: {
+      /**
+       * @description * `ports.INDEX.public` - ports.INDEX.public
+       * @enum {string}
+       */
+      attr: "ports.INDEX.public";
+      /**
+       * @description * `invalid` - invalid
+       * * `max_string_length` - max_string_length
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "invalid" | "max_string_length" | "null";
+      detail: string;
+    };
+    CreateDockerServicePortsNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `ports.non_field_errors` - ports.non_field_errors
+       * @enum {string}
+       */
+      attr: "ports.non_field_errors";
+      /**
+       * @description * `not_a_list` - not_a_list
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "not_a_list" | "null";
+      detail: string;
+    };
+    CreateDockerServiceSlugErrorComponent: {
+      /**
+       * @description * `slug` - slug
+       * @enum {string}
+       */
+      attr: "slug";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceUrlsINDEXBasePathErrorComponent: {
+      /**
+       * @description * `urls.INDEX.base_path` - urls.INDEX.base_path
+       * @enum {string}
+       */
+      attr: "urls.INDEX.base_path";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceUrlsINDEXDomainErrorComponent: {
+      /**
+       * @description * `urls.INDEX.domain` - urls.INDEX.domain
+       * @enum {string}
+       */
+      attr: "urls.INDEX.domain";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `urls.INDEX.non_field_errors` - urls.INDEX.non_field_errors
+       * @enum {string}
+       */
+      attr: "urls.INDEX.non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "invalid" | "null";
+      detail: string;
+    };
+    CreateDockerServiceUrlsINDEXStripPrefixErrorComponent: {
+      /**
+       * @description * `urls.INDEX.strip_prefix` - urls.INDEX.strip_prefix
+       * @enum {string}
+       */
+      attr: "urls.INDEX.strip_prefix";
+      /**
+       * @description * `invalid` - invalid
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "invalid" | "null";
+      detail: string;
+    };
+    CreateDockerServiceUrlsNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `urls.non_field_errors` - urls.non_field_errors
+       * @enum {string}
+       */
+      attr: "urls.non_field_errors";
+      /**
+       * @description * `not_a_list` - not_a_list
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "not_a_list" | "null";
+      detail: string;
+    };
+    CreateDockerServiceValidationError: {
+      type: components["schemas"]["ValidationErrorEnum"];
+      errors: components["schemas"]["CreateDockerServiceError"][];
+    };
+    CreateDockerServiceVolumesINDEXMountPathErrorComponent: {
+      /**
+       * @description * `volumes.INDEX.mount_path` - volumes.INDEX.mount_path
+       * @enum {string}
+       */
+      attr: "volumes.INDEX.mount_path";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceVolumesINDEXNameErrorComponent: {
+      /**
+       * @description * `volumes.INDEX.name` - volumes.INDEX.name
+       * @enum {string}
+       */
+      attr: "volumes.INDEX.name";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `volumes.INDEX.non_field_errors` - volumes.INDEX.non_field_errors
+       * @enum {string}
+       */
+      attr: "volumes.INDEX.non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "invalid" | "null";
+      detail: string;
+    };
+    CreateDockerServiceVolumesNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `volumes.non_field_errors` - volumes.non_field_errors
+       * @enum {string}
+       */
+      attr: "volumes.non_field_errors";
+      /**
+       * @description * `not_a_list` - not_a_list
+       * * `null` - null
+       * @enum {string}
+       */
+      code: "not_a_list" | "null";
+      detail: string;
+    };
+    CreateProjectError: components["schemas"]["CreateProjectNonFieldErrorsErrorComponent"] | components["schemas"]["CreateProjectSlugErrorComponent"];
+    CreateProjectErrorResponse400: components["schemas"]["CreateProjectValidationError"] | components["schemas"]["ParseErrorResponse"];
+    CreateProjectNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `non_field_errors` - non_field_errors
+       * @enum {string}
+       */
+      attr: "non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * @enum {string}
+       */
+      code: "invalid";
+      detail: string;
+    };
+    CreateProjectSlugErrorComponent: {
+      /**
+       * @description * `slug` - slug
+       * @enum {string}
+       */
+      attr: "slug";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    CreateProjectValidationError: {
+      type: components["schemas"]["ValidationErrorEnum"];
+      errors: components["schemas"]["CreateProjectError"][];
+    };
     CredentialError: {
       username?: string[];
       password?: string[];
       registry_url?: string[];
     };
+    CsrfRetrieveErrorResponse400: components["schemas"]["ParseErrorResponse"];
     DockerCredentialsRequest: {
       username: string;
       password: string;
@@ -92,6 +515,10 @@ export interface components {
        * @default registry-1.docker.io/v2
        */
       registry_url?: string;
+    };
+    DockerEnvVariable: {
+      key: string;
+      value: string;
     };
     DockerImage: {
       full_image: string;
@@ -104,14 +531,56 @@ export interface components {
     DockerImageSearchErrorResponse: {
       errors: components["schemas"]["DockerImageSearchError"];
     };
-    DockerLoginError: {
-      root?: string[];
-      username?: string[];
-      password?: string[];
-      registry_url?: string[];
+    DockerLoginError: components["schemas"]["DockerLoginNonFieldErrorsErrorComponent"] | components["schemas"]["DockerLoginUsernameErrorComponent"] | components["schemas"]["DockerLoginPasswordErrorComponent"] | components["schemas"]["DockerLoginRegistryUrlErrorComponent"];
+    DockerLoginErrorResponse400: components["schemas"]["DockerLoginValidationError"] | components["schemas"]["ParseErrorResponse"];
+    DockerLoginNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `non_field_errors` - non_field_errors
+       * @enum {string}
+       */
+      attr: "non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * @enum {string}
+       */
+      code: "invalid";
+      detail: string;
     };
-    DockerLoginErrorResponse: {
-      errors: components["schemas"]["DockerLoginError"];
+    DockerLoginPasswordErrorComponent: {
+      /**
+       * @description * `password` - password
+       * @enum {string}
+       */
+      attr: "password";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    DockerLoginRegistryUrlErrorComponent: {
+      /**
+       * @description * `registry_url` - registry_url
+       * @enum {string}
+       */
+      attr: "registry_url";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
+      detail: string;
     };
     DockerLoginRequest: {
       username: string;
@@ -121,6 +590,29 @@ export interface components {
     };
     DockerLoginSuccessResponse: {
       success: boolean;
+    };
+    DockerLoginUsernameErrorComponent: {
+      /**
+       * @description * `username` - username
+       * @enum {string}
+       */
+      attr: "username";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    DockerLoginValidationError: {
+      type: components["schemas"]["ValidationErrorEnum"];
+      errors: components["schemas"]["DockerLoginError"][];
     };
     DockerPortCheckError: {
       root?: string[];
@@ -144,14 +636,13 @@ export interface components {
       /** Format: date-time */
       updated_at: string;
       volumes: readonly components["schemas"]["Volume"][];
-      name: string;
-      archived?: boolean;
       command?: string | null;
       ports: readonly components["schemas"]["PortConfiguration"][];
+      env_variables: components["schemas"]["DockerEnvVariable"][];
     };
     DockerServiceCreateError: {
       root?: string[];
-      name?: string[];
+      slug?: string[];
       image?: string[];
       command?: string[];
       credentials?: components["schemas"]["CredentialError"];
@@ -164,7 +655,7 @@ export interface components {
       errors: components["schemas"]["DockerServiceCreateError"];
     };
     DockerServiceCreateRequest: {
-      name: string;
+      slug?: string;
       image: string;
       command?: string;
       credentials?: components["schemas"]["DockerCredentialsRequest"];
@@ -184,19 +675,81 @@ export interface components {
     DockerSuccessResponse: {
       images: components["schemas"]["DockerImage"][];
     };
+    Error401: {
+      code: components["schemas"]["ErrorCode401Enum"];
+      detail: string;
+      attr: string | null;
+    };
+    Error429: {
+      code: components["schemas"]["ErrorCode429Enum"];
+      detail: string;
+      attr: string | null;
+    };
+    /**
+     * @description * `authentication_failed` - Authentication Failed
+     * * `not_authenticated` - Not Authenticated
+     * @enum {string}
+     */
+    ErrorCode401Enum: "authentication_failed" | "not_authenticated";
+    /**
+     * @description * `throttled` - Throttled
+     * @enum {string}
+     */
+    ErrorCode429Enum: "throttled";
+    ErrorResponse401: {
+      type: components["schemas"]["ClientErrorEnum"];
+      errors: components["schemas"]["Error401"][];
+    };
+    ErrorResponse429: {
+      type: components["schemas"]["ClientErrorEnum"];
+      errors: components["schemas"]["Error429"][];
+    };
     ForbiddenResponse: {
       errors: components["schemas"]["BaseError"];
     };
+    GetAuthedUserErrorResponse400: components["schemas"]["ParseErrorResponse"];
+    GetDockerServiceErrorResponse400: components["schemas"]["ParseErrorResponse"];
+    GetProjectListErrorResponse400: components["schemas"]["ParseErrorResponse"];
     GetRootDomain: {
       domain: string;
     };
-    LoginError: {
-      root?: string[];
-      username?: string[];
-      password?: string[];
+    GetRootDomainErrorResponse400: components["schemas"]["ParseErrorResponse"];
+    GetSingleProjectErrorResponse400: components["schemas"]["ParseErrorResponse"];
+    GetVolumeSizeErrorResponse400: components["schemas"]["ParseErrorResponse"];
+    LoginError: components["schemas"]["LoginNonFieldErrorsErrorComponent"] | components["schemas"]["LoginUsernameErrorComponent"] | components["schemas"]["LoginPasswordErrorComponent"];
+    LoginErrorResponse400: components["schemas"]["LoginValidationError"] | components["schemas"]["ParseErrorResponse"];
+    LoginNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `non_field_errors` - non_field_errors
+       * @enum {string}
+       */
+      attr: "non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * @enum {string}
+       */
+      code: "invalid";
+      detail: string;
     };
-    LoginErrorResponse: {
-      errors: components["schemas"]["LoginError"];
+    LoginPasswordErrorComponent: {
+      /**
+       * @description * `password` - password
+       * @enum {string}
+       */
+      attr: "password";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `min_length` - min_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "min_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
     };
     LoginRequest: {
       username: string;
@@ -204,6 +757,45 @@ export interface components {
     };
     LoginSuccessResponse: {
       success: boolean;
+    };
+    LoginUsernameErrorComponent: {
+      /**
+       * @description * `username` - username
+       * @enum {string}
+       */
+      attr: "username";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `min_length` - min_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "min_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    LoginValidationError: {
+      type: components["schemas"]["ValidationErrorEnum"];
+      errors: components["schemas"]["LoginError"][];
+    };
+    LogoutErrorResponse400: components["schemas"]["ParseErrorResponse"];
+    ParseError: {
+      code: components["schemas"]["ParseErrorCodeEnum"];
+      detail: string;
+      attr: string | null;
+    };
+    /**
+     * @description * `parse_error` - Parse Error
+     * @enum {string}
+     */
+    ParseErrorCodeEnum: "parse_error";
+    ParseErrorResponse: {
+      type: components["schemas"]["ClientErrorEnum"];
+      errors: components["schemas"]["ParseError"][];
     };
     PatchedProjectUpdateRequest: {
       slug?: string;
@@ -240,6 +832,7 @@ export interface components {
       root?: string[];
       slug?: string[];
     };
+    SearchDockerRegistryErrorResponse400: components["schemas"]["ParseErrorResponse"];
     ServicePortsRequest: {
       /** @default 80 */
       public?: number;
@@ -265,6 +858,44 @@ export interface components {
       domain?: string[];
       base_path?: string[];
     };
+    UpdateProjectNameError: components["schemas"]["UpdateProjectNameNonFieldErrorsErrorComponent"] | components["schemas"]["UpdateProjectNameSlugErrorComponent"];
+    UpdateProjectNameErrorResponse400: components["schemas"]["UpdateProjectNameValidationError"] | components["schemas"]["ParseErrorResponse"];
+    UpdateProjectNameNonFieldErrorsErrorComponent: {
+      /**
+       * @description * `non_field_errors` - non_field_errors
+       * @enum {string}
+       */
+      attr: "non_field_errors";
+      /**
+       * @description * `invalid` - invalid
+       * @enum {string}
+       */
+      code: "invalid";
+      detail: string;
+    };
+    UpdateProjectNameSlugErrorComponent: {
+      /**
+       * @description * `slug` - slug
+       * @enum {string}
+       */
+      attr: "slug";
+      /**
+       * @description * `blank` - blank
+       * * `invalid` - invalid
+       * * `max_length` - max_length
+       * * `null` - null
+       * * `null_characters_not_allowed` - null_characters_not_allowed
+       * * `required` - required
+       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+       * @enum {string}
+       */
+      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      detail: string;
+    };
+    UpdateProjectNameValidationError: {
+      type: components["schemas"]["ValidationErrorEnum"];
+      errors: components["schemas"]["UpdateProjectNameError"][];
+    };
     User: {
       /** @description Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only. */
       username: string;
@@ -276,12 +907,17 @@ export interface components {
        */
       is_staff?: boolean;
     };
+    /**
+     * @description * `validation_error` - Validation Error
+     * @enum {string}
+     */
+    ValidationErrorEnum: "validation_error";
     Volume: {
       /** Format: date-time */
       created_at: string;
       /** Format: date-time */
       updated_at: string;
-      slug: string;
+      id?: string;
       name: string;
       containerPath: string;
     };
@@ -320,19 +956,19 @@ export interface operations {
           "application/json": components["schemas"]["LoginSuccessResponse"];
         };
       };
-      401: {
+      400: {
         content: {
-          "application/json": components["schemas"]["LoginErrorResponse"];
+          "application/json": components["schemas"]["LoginErrorResponse400"];
         };
       };
-      422: {
+      401: {
         content: {
-          "application/json": components["schemas"]["LoginErrorResponse"];
+          "application/json": components["schemas"]["ErrorResponse401"];
         };
       };
       429: {
         content: {
-          "application/json": components["schemas"]["LoginErrorResponse"];
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -343,9 +979,19 @@ export interface operations {
       204: {
         content: never;
       };
-      403: {
+      400: {
         content: {
-          "application/json": components["schemas"]["ForbiddenResponse"];
+          "application/json": components["schemas"]["LogoutErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -357,9 +1003,19 @@ export interface operations {
           "application/json": components["schemas"]["AuthedSuccessResponse"];
         };
       };
-      403: {
+      400: {
         content: {
-          "application/json": components["schemas"]["ForbiddenResponse"];
+          "application/json": components["schemas"]["GetAuthedUserErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -370,6 +1026,21 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["CSRF"];
+        };
+      };
+      400: {
+        content: {
+          "application/json": components["schemas"]["CsrfRetrieveErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -393,6 +1064,11 @@ export interface operations {
           "application/json": components["schemas"]["DockerPortCheckSuccessResponse"];
         };
       };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -401,6 +1077,11 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["DockerPortCheckErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -417,6 +1098,16 @@ export interface operations {
           "application/json": components["schemas"]["DockerSuccessResponse"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["SearchDockerRegistryErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -425,6 +1116,11 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["DockerImageSearchErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -443,19 +1139,19 @@ export interface operations {
           "application/json": components["schemas"]["DockerLoginSuccessResponse"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["DockerLoginErrorResponse400"];
+        };
+      };
       401: {
         content: {
-          "application/json": components["schemas"]["DockerLoginErrorResponse"];
+          "application/json": components["schemas"]["ErrorResponse401"];
         };
       };
-      403: {
+      429: {
         content: {
-          "application/json": components["schemas"]["ForbiddenResponse"];
-        };
-      };
-      422: {
-        content: {
-          "application/json": components["schemas"]["DockerLoginErrorResponse"];
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -467,9 +1163,24 @@ export interface operations {
           "application/json": components["schemas"]["GetRootDomain"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["GetRootDomainErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -498,6 +1209,16 @@ export interface operations {
           "application/json": components["schemas"]["ProjectSuccessResponse"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["GetProjectListErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -506,6 +1227,11 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["ProjetCreateErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -524,6 +1250,16 @@ export interface operations {
           "application/json": components["schemas"]["SingleProjectSuccessResponse"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["CreateProjectErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -539,9 +1275,53 @@ export interface operations {
           "application/json": components["schemas"]["ProjetCreateErrorResponse"];
         };
       };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
+        };
+      };
       500: {
         content: {
           "application/json": components["schemas"]["ProjetCreateErrorResponse"];
+        };
+      };
+    };
+  };
+  archiveDockerService: {
+    parameters: {
+      path: {
+        project_slug: string;
+        service_slug: string;
+      };
+    };
+    responses: {
+      /** @description No response body */
+      204: {
+        content: never;
+      };
+      400: {
+        content: {
+          "application/json": components["schemas"]["ArchiveDockerServiceErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
+      403: {
+        content: {
+          "application/json": components["schemas"]["ForbiddenResponse"];
+        };
+      };
+      404: {
+        content: {
+          "application/json": components["schemas"]["BaseErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -565,6 +1345,16 @@ export interface operations {
           "application/json": components["schemas"]["DockerServiceCreateSuccessResponse"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["CreateDockerServiceErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -578,6 +1368,11 @@ export interface operations {
       409: {
         content: {
           "application/json": components["schemas"]["DockerServiceCreateErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -595,6 +1390,16 @@ export interface operations {
           "application/json": components["schemas"]["DockerServiceCreateSuccessResponse"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["GetDockerServiceErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -603,6 +1408,11 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["BaseErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -619,6 +1429,16 @@ export interface operations {
           "application/json": components["schemas"]["SingleProjectSuccessResponse"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["GetSingleProjectErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -627,6 +1447,11 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["ProjectUpdateErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -642,6 +1467,16 @@ export interface operations {
       200: {
         content: never;
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["ArchiveSingleProjectErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -650,6 +1485,11 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["BaseErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
       500: {
@@ -678,6 +1518,16 @@ export interface operations {
           "application/json": components["schemas"]["SingleProjectSuccessResponse"];
         };
       };
+      400: {
+        content: {
+          "application/json": components["schemas"]["UpdateProjectNameErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
+        };
+      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -693,18 +1543,33 @@ export interface operations {
           "application/json": components["schemas"]["ProjectUpdateErrorResponse"];
         };
       };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
+        };
+      };
     };
   };
   getVolumeSize: {
     parameters: {
       path: {
-        slug: string;
+        volume_id: string;
       };
     };
     responses: {
       200: {
         content: {
           "application/json": components["schemas"]["VolumeGetSizeSuccessResponse"];
+        };
+      };
+      400: {
+        content: {
+          "application/json": components["schemas"]["GetVolumeSizeErrorResponse400"];
+        };
+      };
+      401: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse401"];
         };
       };
       403: {
@@ -715,6 +1580,11 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["BaseErrorResponse"];
+        };
+      };
+      429: {
+        content: {
+          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };

--- a/frontend/src/api/v1.ts
+++ b/frontend/src/api/v1.ts
@@ -34,9 +34,6 @@ export interface paths {
     get: operations["getProjectList"];
     post: operations["createProject"];
   };
-  "/api/projects/{project_slug}/archive-service/docker/{service_slug}/": {
-    delete: operations["archiveDockerService"];
-  };
   "/api/projects/{project_slug}/create-service/docker/": {
     post: operations["createDockerService"];
   };
@@ -48,7 +45,7 @@ export interface paths {
     delete: operations["archiveSingleProject"];
     patch: operations["updateProjectName"];
   };
-  "/api/volumes/{volume_id}/size/": {
+  "/api/volumes/{slug}/size/": {
     get: operations["getVolumeSize"];
   };
 }
@@ -61,8 +58,6 @@ export interface components {
       projects: components["schemas"]["Project"][];
       total_count: number;
     };
-    ArchiveDockerServiceErrorResponse400: components["schemas"]["ParseErrorResponse"];
-    ArchiveSingleProjectErrorResponse400: components["schemas"]["ParseErrorResponse"];
     ArchivedProject: {
       slug?: string;
       /** Format: date-time */
@@ -84,429 +79,11 @@ export interface components {
     CSRF: {
       details: string;
     };
-    /**
-     * @description * `client_error` - Client Error
-     * @enum {string}
-     */
-    ClientErrorEnum: "client_error";
-    CreateDockerServiceCommandErrorComponent: {
-      /**
-       * @description * `command` - command
-       * @enum {string}
-       */
-      attr: "command";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceCredentialsNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `credentials.non_field_errors` - credentials.non_field_errors
-       * @enum {string}
-       */
-      attr: "credentials.non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "invalid" | "null";
-      detail: string;
-    };
-    CreateDockerServiceCredentialsPasswordErrorComponent: {
-      /**
-       * @description * `credentials.password` - credentials.password
-       * @enum {string}
-       */
-      attr: "credentials.password";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceCredentialsRegistryUrlErrorComponent: {
-      /**
-       * @description * `credentials.registry_url` - credentials.registry_url
-       * @enum {string}
-       */
-      attr: "credentials.registry_url";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceCredentialsUsernameErrorComponent: {
-      /**
-       * @description * `credentials.username` - credentials.username
-       * @enum {string}
-       */
-      attr: "credentials.username";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceEnvErrorComponent: {
-      /**
-       * @description * `env` - env
-       * @enum {string}
-       */
-      attr: "env";
-      /**
-       * @description * `not_a_dict` - not_a_dict
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "not_a_dict" | "null";
-      detail: string;
-    };
-    CreateDockerServiceEnvKEYErrorComponent: {
-      /**
-       * @description * `env.KEY` - env.KEY
-       * @enum {string}
-       */
-      attr: "env.KEY";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceError: components["schemas"]["CreateDockerServiceNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceSlugErrorComponent"] | components["schemas"]["CreateDockerServiceImageErrorComponent"] | components["schemas"]["CreateDockerServiceCommandErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsUsernameErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsPasswordErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsRegistryUrlErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsINDEXDomainErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsINDEXBasePathErrorComponent"] | components["schemas"]["CreateDockerServiceUrlsINDEXStripPrefixErrorComponent"] | components["schemas"]["CreateDockerServicePortsNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServicePortsINDEXPublicErrorComponent"] | components["schemas"]["CreateDockerServicePortsINDEXForwardedErrorComponent"] | components["schemas"]["CreateDockerServiceEnvErrorComponent"] | components["schemas"]["CreateDockerServiceEnvKEYErrorComponent"] | components["schemas"]["CreateDockerServiceVolumesNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceVolumesINDEXNameErrorComponent"] | components["schemas"]["CreateDockerServiceVolumesINDEXMountPathErrorComponent"];
-    CreateDockerServiceErrorResponse400: components["schemas"]["CreateDockerServiceValidationError"] | components["schemas"]["ParseErrorResponse"];
-    CreateDockerServiceImageErrorComponent: {
-      /**
-       * @description * `image` - image
-       * @enum {string}
-       */
-      attr: "image";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `non_field_errors` - non_field_errors
-       * @enum {string}
-       */
-      attr: "non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * @enum {string}
-       */
-      code: "invalid";
-      detail: string;
-    };
-    CreateDockerServicePortsINDEXForwardedErrorComponent: {
-      /**
-       * @description * `ports.INDEX.forwarded` - ports.INDEX.forwarded
-       * @enum {string}
-       */
-      attr: "ports.INDEX.forwarded";
-      /**
-       * @description * `invalid` - invalid
-       * * `max_string_length` - max_string_length
-       * * `null` - null
-       * * `required` - required
-       * @enum {string}
-       */
-      code: "invalid" | "max_string_length" | "null" | "required";
-      detail: string;
-    };
-    CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `ports.INDEX.non_field_errors` - ports.INDEX.non_field_errors
-       * @enum {string}
-       */
-      attr: "ports.INDEX.non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "invalid" | "null";
-      detail: string;
-    };
-    CreateDockerServicePortsINDEXPublicErrorComponent: {
-      /**
-       * @description * `ports.INDEX.public` - ports.INDEX.public
-       * @enum {string}
-       */
-      attr: "ports.INDEX.public";
-      /**
-       * @description * `invalid` - invalid
-       * * `max_string_length` - max_string_length
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "invalid" | "max_string_length" | "null";
-      detail: string;
-    };
-    CreateDockerServicePortsNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `ports.non_field_errors` - ports.non_field_errors
-       * @enum {string}
-       */
-      attr: "ports.non_field_errors";
-      /**
-       * @description * `not_a_list` - not_a_list
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "not_a_list" | "null";
-      detail: string;
-    };
-    CreateDockerServiceSlugErrorComponent: {
-      /**
-       * @description * `slug` - slug
-       * @enum {string}
-       */
-      attr: "slug";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceUrlsINDEXBasePathErrorComponent: {
-      /**
-       * @description * `urls.INDEX.base_path` - urls.INDEX.base_path
-       * @enum {string}
-       */
-      attr: "urls.INDEX.base_path";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceUrlsINDEXDomainErrorComponent: {
-      /**
-       * @description * `urls.INDEX.domain` - urls.INDEX.domain
-       * @enum {string}
-       */
-      attr: "urls.INDEX.domain";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `urls.INDEX.non_field_errors` - urls.INDEX.non_field_errors
-       * @enum {string}
-       */
-      attr: "urls.INDEX.non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "invalid" | "null";
-      detail: string;
-    };
-    CreateDockerServiceUrlsINDEXStripPrefixErrorComponent: {
-      /**
-       * @description * `urls.INDEX.strip_prefix` - urls.INDEX.strip_prefix
-       * @enum {string}
-       */
-      attr: "urls.INDEX.strip_prefix";
-      /**
-       * @description * `invalid` - invalid
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "invalid" | "null";
-      detail: string;
-    };
-    CreateDockerServiceUrlsNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `urls.non_field_errors` - urls.non_field_errors
-       * @enum {string}
-       */
-      attr: "urls.non_field_errors";
-      /**
-       * @description * `not_a_list` - not_a_list
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "not_a_list" | "null";
-      detail: string;
-    };
-    CreateDockerServiceValidationError: {
-      type: components["schemas"]["ValidationErrorEnum"];
-      errors: components["schemas"]["CreateDockerServiceError"][];
-    };
-    CreateDockerServiceVolumesINDEXMountPathErrorComponent: {
-      /**
-       * @description * `volumes.INDEX.mount_path` - volumes.INDEX.mount_path
-       * @enum {string}
-       */
-      attr: "volumes.INDEX.mount_path";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceVolumesINDEXNameErrorComponent: {
-      /**
-       * @description * `volumes.INDEX.name` - volumes.INDEX.name
-       * @enum {string}
-       */
-      attr: "volumes.INDEX.name";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `volumes.INDEX.non_field_errors` - volumes.INDEX.non_field_errors
-       * @enum {string}
-       */
-      attr: "volumes.INDEX.non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "invalid" | "null";
-      detail: string;
-    };
-    CreateDockerServiceVolumesNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `volumes.non_field_errors` - volumes.non_field_errors
-       * @enum {string}
-       */
-      attr: "volumes.non_field_errors";
-      /**
-       * @description * `not_a_list` - not_a_list
-       * * `null` - null
-       * @enum {string}
-       */
-      code: "not_a_list" | "null";
-      detail: string;
-    };
-    CreateProjectError: components["schemas"]["CreateProjectNonFieldErrorsErrorComponent"] | components["schemas"]["CreateProjectSlugErrorComponent"];
-    CreateProjectErrorResponse400: components["schemas"]["CreateProjectValidationError"] | components["schemas"]["ParseErrorResponse"];
-    CreateProjectNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `non_field_errors` - non_field_errors
-       * @enum {string}
-       */
-      attr: "non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * @enum {string}
-       */
-      code: "invalid";
-      detail: string;
-    };
-    CreateProjectSlugErrorComponent: {
-      /**
-       * @description * `slug` - slug
-       * @enum {string}
-       */
-      attr: "slug";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    CreateProjectValidationError: {
-      type: components["schemas"]["ValidationErrorEnum"];
-      errors: components["schemas"]["CreateProjectError"][];
-    };
     CredentialError: {
       username?: string[];
       password?: string[];
       registry_url?: string[];
     };
-    CsrfRetrieveErrorResponse400: components["schemas"]["ParseErrorResponse"];
     DockerCredentialsRequest: {
       username: string;
       password: string;
@@ -515,10 +92,6 @@ export interface components {
        * @default registry-1.docker.io/v2
        */
       registry_url?: string;
-    };
-    DockerEnvVariable: {
-      key: string;
-      value: string;
     };
     DockerImage: {
       full_image: string;
@@ -531,56 +104,14 @@ export interface components {
     DockerImageSearchErrorResponse: {
       errors: components["schemas"]["DockerImageSearchError"];
     };
-    DockerLoginError: components["schemas"]["DockerLoginNonFieldErrorsErrorComponent"] | components["schemas"]["DockerLoginUsernameErrorComponent"] | components["schemas"]["DockerLoginPasswordErrorComponent"] | components["schemas"]["DockerLoginRegistryUrlErrorComponent"];
-    DockerLoginErrorResponse400: components["schemas"]["DockerLoginValidationError"] | components["schemas"]["ParseErrorResponse"];
-    DockerLoginNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `non_field_errors` - non_field_errors
-       * @enum {string}
-       */
-      attr: "non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * @enum {string}
-       */
-      code: "invalid";
-      detail: string;
+    DockerLoginError: {
+      root?: string[];
+      username?: string[];
+      password?: string[];
+      registry_url?: string[];
     };
-    DockerLoginPasswordErrorComponent: {
-      /**
-       * @description * `password` - password
-       * @enum {string}
-       */
-      attr: "password";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    DockerLoginRegistryUrlErrorComponent: {
-      /**
-       * @description * `registry_url` - registry_url
-       * @enum {string}
-       */
-      attr: "registry_url";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
-      detail: string;
+    DockerLoginErrorResponse: {
+      errors: components["schemas"]["DockerLoginError"];
     };
     DockerLoginRequest: {
       username: string;
@@ -590,29 +121,6 @@ export interface components {
     };
     DockerLoginSuccessResponse: {
       success: boolean;
-    };
-    DockerLoginUsernameErrorComponent: {
-      /**
-       * @description * `username` - username
-       * @enum {string}
-       */
-      attr: "username";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    DockerLoginValidationError: {
-      type: components["schemas"]["ValidationErrorEnum"];
-      errors: components["schemas"]["DockerLoginError"][];
     };
     DockerPortCheckError: {
       root?: string[];
@@ -636,13 +144,14 @@ export interface components {
       /** Format: date-time */
       updated_at: string;
       volumes: readonly components["schemas"]["Volume"][];
+      name: string;
+      archived?: boolean;
       command?: string | null;
       ports: readonly components["schemas"]["PortConfiguration"][];
-      env_variables: components["schemas"]["DockerEnvVariable"][];
     };
     DockerServiceCreateError: {
       root?: string[];
-      slug?: string[];
+      name?: string[];
       image?: string[];
       command?: string[];
       credentials?: components["schemas"]["CredentialError"];
@@ -655,7 +164,7 @@ export interface components {
       errors: components["schemas"]["DockerServiceCreateError"];
     };
     DockerServiceCreateRequest: {
-      slug?: string;
+      name: string;
       image: string;
       command?: string;
       credentials?: components["schemas"]["DockerCredentialsRequest"];
@@ -675,81 +184,19 @@ export interface components {
     DockerSuccessResponse: {
       images: components["schemas"]["DockerImage"][];
     };
-    Error401: {
-      code: components["schemas"]["ErrorCode401Enum"];
-      detail: string;
-      attr: string | null;
-    };
-    Error429: {
-      code: components["schemas"]["ErrorCode429Enum"];
-      detail: string;
-      attr: string | null;
-    };
-    /**
-     * @description * `authentication_failed` - Authentication Failed
-     * * `not_authenticated` - Not Authenticated
-     * @enum {string}
-     */
-    ErrorCode401Enum: "authentication_failed" | "not_authenticated";
-    /**
-     * @description * `throttled` - Throttled
-     * @enum {string}
-     */
-    ErrorCode429Enum: "throttled";
-    ErrorResponse401: {
-      type: components["schemas"]["ClientErrorEnum"];
-      errors: components["schemas"]["Error401"][];
-    };
-    ErrorResponse429: {
-      type: components["schemas"]["ClientErrorEnum"];
-      errors: components["schemas"]["Error429"][];
-    };
     ForbiddenResponse: {
       errors: components["schemas"]["BaseError"];
     };
-    GetAuthedUserErrorResponse400: components["schemas"]["ParseErrorResponse"];
-    GetDockerServiceErrorResponse400: components["schemas"]["ParseErrorResponse"];
-    GetProjectListErrorResponse400: components["schemas"]["ParseErrorResponse"];
     GetRootDomain: {
       domain: string;
     };
-    GetRootDomainErrorResponse400: components["schemas"]["ParseErrorResponse"];
-    GetSingleProjectErrorResponse400: components["schemas"]["ParseErrorResponse"];
-    GetVolumeSizeErrorResponse400: components["schemas"]["ParseErrorResponse"];
-    LoginError: components["schemas"]["LoginNonFieldErrorsErrorComponent"] | components["schemas"]["LoginUsernameErrorComponent"] | components["schemas"]["LoginPasswordErrorComponent"];
-    LoginErrorResponse400: components["schemas"]["LoginValidationError"] | components["schemas"]["ParseErrorResponse"];
-    LoginNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `non_field_errors` - non_field_errors
-       * @enum {string}
-       */
-      attr: "non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * @enum {string}
-       */
-      code: "invalid";
-      detail: string;
+    LoginError: {
+      root?: string[];
+      username?: string[];
+      password?: string[];
     };
-    LoginPasswordErrorComponent: {
-      /**
-       * @description * `password` - password
-       * @enum {string}
-       */
-      attr: "password";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `min_length` - min_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "min_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
+    LoginErrorResponse: {
+      errors: components["schemas"]["LoginError"];
     };
     LoginRequest: {
       username: string;
@@ -757,45 +204,6 @@ export interface components {
     };
     LoginSuccessResponse: {
       success: boolean;
-    };
-    LoginUsernameErrorComponent: {
-      /**
-       * @description * `username` - username
-       * @enum {string}
-       */
-      attr: "username";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `min_length` - min_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "min_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    LoginValidationError: {
-      type: components["schemas"]["ValidationErrorEnum"];
-      errors: components["schemas"]["LoginError"][];
-    };
-    LogoutErrorResponse400: components["schemas"]["ParseErrorResponse"];
-    ParseError: {
-      code: components["schemas"]["ParseErrorCodeEnum"];
-      detail: string;
-      attr: string | null;
-    };
-    /**
-     * @description * `parse_error` - Parse Error
-     * @enum {string}
-     */
-    ParseErrorCodeEnum: "parse_error";
-    ParseErrorResponse: {
-      type: components["schemas"]["ClientErrorEnum"];
-      errors: components["schemas"]["ParseError"][];
     };
     PatchedProjectUpdateRequest: {
       slug?: string;
@@ -832,7 +240,6 @@ export interface components {
       root?: string[];
       slug?: string[];
     };
-    SearchDockerRegistryErrorResponse400: components["schemas"]["ParseErrorResponse"];
     ServicePortsRequest: {
       /** @default 80 */
       public?: number;
@@ -858,44 +265,6 @@ export interface components {
       domain?: string[];
       base_path?: string[];
     };
-    UpdateProjectNameError: components["schemas"]["UpdateProjectNameNonFieldErrorsErrorComponent"] | components["schemas"]["UpdateProjectNameSlugErrorComponent"];
-    UpdateProjectNameErrorResponse400: components["schemas"]["UpdateProjectNameValidationError"] | components["schemas"]["ParseErrorResponse"];
-    UpdateProjectNameNonFieldErrorsErrorComponent: {
-      /**
-       * @description * `non_field_errors` - non_field_errors
-       * @enum {string}
-       */
-      attr: "non_field_errors";
-      /**
-       * @description * `invalid` - invalid
-       * @enum {string}
-       */
-      code: "invalid";
-      detail: string;
-    };
-    UpdateProjectNameSlugErrorComponent: {
-      /**
-       * @description * `slug` - slug
-       * @enum {string}
-       */
-      attr: "slug";
-      /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
-       * * `max_length` - max_length
-       * * `null` - null
-       * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
-       * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-       * @enum {string}
-       */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
-      detail: string;
-    };
-    UpdateProjectNameValidationError: {
-      type: components["schemas"]["ValidationErrorEnum"];
-      errors: components["schemas"]["UpdateProjectNameError"][];
-    };
     User: {
       /** @description Required. 150 characters or fewer. Letters, digits and @/./+/-/_ only. */
       username: string;
@@ -907,17 +276,12 @@ export interface components {
        */
       is_staff?: boolean;
     };
-    /**
-     * @description * `validation_error` - Validation Error
-     * @enum {string}
-     */
-    ValidationErrorEnum: "validation_error";
     Volume: {
       /** Format: date-time */
       created_at: string;
       /** Format: date-time */
       updated_at: string;
-      id?: string;
+      slug: string;
       name: string;
       containerPath: string;
     };
@@ -956,19 +320,19 @@ export interface operations {
           "application/json": components["schemas"]["LoginSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["LoginErrorResponse400"];
-        };
-      };
       401: {
         content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
+          "application/json": components["schemas"]["LoginErrorResponse"];
+        };
+      };
+      422: {
+        content: {
+          "application/json": components["schemas"]["LoginErrorResponse"];
         };
       };
       429: {
         content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
+          "application/json": components["schemas"]["LoginErrorResponse"];
         };
       };
     };
@@ -979,19 +343,9 @@ export interface operations {
       204: {
         content: never;
       };
-      400: {
+      403: {
         content: {
-          "application/json": components["schemas"]["LogoutErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
+          "application/json": components["schemas"]["ForbiddenResponse"];
         };
       };
     };
@@ -1003,19 +357,9 @@ export interface operations {
           "application/json": components["schemas"]["AuthedSuccessResponse"];
         };
       };
-      400: {
+      403: {
         content: {
-          "application/json": components["schemas"]["GetAuthedUserErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
+          "application/json": components["schemas"]["ForbiddenResponse"];
         };
       };
     };
@@ -1026,21 +370,6 @@ export interface operations {
       200: {
         content: {
           "application/json": components["schemas"]["CSRF"];
-        };
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["CsrfRetrieveErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1064,11 +393,6 @@ export interface operations {
           "application/json": components["schemas"]["DockerPortCheckSuccessResponse"];
         };
       };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1077,11 +401,6 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["DockerPortCheckErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1098,16 +417,6 @@ export interface operations {
           "application/json": components["schemas"]["DockerSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["SearchDockerRegistryErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1116,11 +425,6 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["DockerImageSearchErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1139,19 +443,19 @@ export interface operations {
           "application/json": components["schemas"]["DockerLoginSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["DockerLoginErrorResponse400"];
-        };
-      };
       401: {
         content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
+          "application/json": components["schemas"]["DockerLoginErrorResponse"];
         };
       };
-      429: {
+      403: {
         content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
+          "application/json": components["schemas"]["ForbiddenResponse"];
+        };
+      };
+      422: {
+        content: {
+          "application/json": components["schemas"]["DockerLoginErrorResponse"];
         };
       };
     };
@@ -1163,24 +467,9 @@ export interface operations {
           "application/json": components["schemas"]["GetRootDomain"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["GetRootDomainErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1209,16 +498,6 @@ export interface operations {
           "application/json": components["schemas"]["ProjectSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["GetProjectListErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1227,11 +506,6 @@ export interface operations {
       422: {
         content: {
           "application/json": components["schemas"]["ProjetCreateErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1250,16 +524,6 @@ export interface operations {
           "application/json": components["schemas"]["SingleProjectSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["CreateProjectErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1275,53 +539,9 @@ export interface operations {
           "application/json": components["schemas"]["ProjetCreateErrorResponse"];
         };
       };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
-        };
-      };
       500: {
         content: {
           "application/json": components["schemas"]["ProjetCreateErrorResponse"];
-        };
-      };
-    };
-  };
-  archiveDockerService: {
-    parameters: {
-      path: {
-        project_slug: string;
-        service_slug: string;
-      };
-    };
-    responses: {
-      /** @description No response body */
-      204: {
-        content: never;
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ArchiveDockerServiceErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
-      403: {
-        content: {
-          "application/json": components["schemas"]["ForbiddenResponse"];
-        };
-      };
-      404: {
-        content: {
-          "application/json": components["schemas"]["BaseErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1345,16 +565,6 @@ export interface operations {
           "application/json": components["schemas"]["DockerServiceCreateSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["CreateDockerServiceErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1368,11 +578,6 @@ export interface operations {
       409: {
         content: {
           "application/json": components["schemas"]["DockerServiceCreateErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1390,16 +595,6 @@ export interface operations {
           "application/json": components["schemas"]["DockerServiceCreateSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["GetDockerServiceErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1408,11 +603,6 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["BaseErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1429,16 +619,6 @@ export interface operations {
           "application/json": components["schemas"]["SingleProjectSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["GetSingleProjectErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1447,11 +627,6 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["ProjectUpdateErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };
@@ -1467,16 +642,6 @@ export interface operations {
       200: {
         content: never;
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["ArchiveSingleProjectErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1485,11 +650,6 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["BaseErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
       500: {
@@ -1518,16 +678,6 @@ export interface operations {
           "application/json": components["schemas"]["SingleProjectSuccessResponse"];
         };
       };
-      400: {
-        content: {
-          "application/json": components["schemas"]["UpdateProjectNameErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
-        };
-      };
       403: {
         content: {
           "application/json": components["schemas"]["ForbiddenResponse"];
@@ -1543,33 +693,18 @@ export interface operations {
           "application/json": components["schemas"]["ProjectUpdateErrorResponse"];
         };
       };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
-        };
-      };
     };
   };
   getVolumeSize: {
     parameters: {
       path: {
-        volume_id: string;
+        slug: string;
       };
     };
     responses: {
       200: {
         content: {
           "application/json": components["schemas"]["VolumeGetSizeSuccessResponse"];
-        };
-      };
-      400: {
-        content: {
-          "application/json": components["schemas"]["GetVolumeSizeErrorResponse400"];
-        };
-      };
-      401: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse401"];
         };
       };
       403: {
@@ -1580,11 +715,6 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["BaseErrorResponse"];
-        };
-      };
-      429: {
-        content: {
-          "application/json": components["schemas"]["ErrorResponse429"];
         };
       };
     };

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -32,7 +32,12 @@ export function getFormErrorsFromResponseData<
     errors: ValidationErrorDetail[];
   }
     ? T["errors"][number]["attr"]
-    : never,
+    : T extends {
+          type: "client_error";
+          errors: ClientErrorDetail[];
+        }
+      ? "non_field_errors"
+      : never,
   string[]
 > {
   const errors: Record<string, string[]> = {};

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -4,3 +4,52 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+type ValidationErrorDetail = {
+  attr: "non_field_errors" | (string & {});
+  code: string;
+  detail: string;
+};
+
+type ClientErrorDetail = {
+  code: string;
+  detail: string;
+  attr: string | null;
+};
+
+export function getFormErrorsFromResponseData<
+  T extends
+    | {
+        type: string;
+        errors: ValidationErrorDetail[] | ClientErrorDetail[];
+      }
+    | undefined
+>(
+  data: T
+): Record<
+  T extends {
+    type: "validation_error";
+    errors: ValidationErrorDetail[];
+  }
+    ? T["errors"][number]["attr"]
+    : never,
+  string[]
+> {
+  const errors: Record<string, string[]> = {};
+
+  if (data?.type === "validation_error") {
+    for (const error of data.errors) {
+      const key = error.attr;
+      if (key) {
+        if (!errors[key]) {
+          errors[key] = [];
+        }
+        errors[key].push(error.detail);
+      }
+    }
+  } else if (data?.type === "client_error" || data?.type === "server_error") {
+    errors["non_field_errors"] = data.errors.map((e) => e.detail);
+  }
+
+  return errors as any;
+}

--- a/frontend/src/routes/login.lazy.tsx
+++ b/frontend/src/routes/login.lazy.tsx
@@ -13,6 +13,7 @@ import { Logo } from "~/components/logo";
 import { MetaTitle } from "~/components/meta-title";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { userKeys } from "~/key-factories";
+import { getFormErrorsFromResponseData } from "~/lib/utils";
 
 export const Route = createLazyFileRoute("/login")({
   component: Login
@@ -51,6 +52,8 @@ function Login() {
     return null;
   }
 
+  const errors = getFormErrorsFromResponseData(data);
+
   return (
     <>
       <MetaTitle title="Login" />
@@ -81,11 +84,11 @@ function Login() {
             Log in
           </h1>
           <div className="card flex flex-col gap-3">
-            {data?.errors?.root && (
+            {errors.non_field_errors && (
               <Alert variant="destructive">
                 <AlertCircle className="h-4 w-4" />
                 <AlertTitle>Error</AlertTitle>
-                <AlertDescription>{data.errors.root}</AlertDescription>
+                <AlertDescription>{errors.non_field_errors}</AlertDescription>
               </Alert>
             )}
 
@@ -94,9 +97,9 @@ function Login() {
               <Form.Control asChild>
                 <Input placeholder="ex: JohnDoe" name="username" type="text" />
               </Form.Control>
-              {data?.errors?.username && (
+              {errors.username && (
                 <Form.Message className="text-red-500 text-sm">
-                  {data.errors.username}
+                  {errors.username}
                 </Form.Message>
               )}
             </Form.Field>
@@ -106,9 +109,9 @@ function Login() {
               <Form.Control asChild>
                 <Input type="password" name="password" />
               </Form.Control>
-              {data?.errors?.password && (
+              {errors.password && (
                 <Form.Message className="text-red-500 text-sm">
-                  {data.errors.password}
+                  {errors.password}
                 </Form.Message>
               )}
             </Form.Field>

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -25,7 +25,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "noErrorTruncation": true
   },
   "include": ["src", "./src/tanstack-router.d.ts"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -2,8 +2,28 @@ openapi: 3.0.3
 info:
   title: ZaneOps API
   version: 1.0.0
-  description: ZaneOps is a self-hosted, open source platform as a service for hosting
-    static sites, web apps, databases, CRONS, Workers using docker swarm as the engine.
+  description: "\n\n## Overview\n\nZaneOps is a self-hosted, open source platform\
+    \ as a service for hosting static sites, web apps, \ndatabases, CRONS, Workers\
+    \ using docker swarm as the engine.\n\n## Errors\n\n### 405 Method Not Allowed\n\
+    \nThis is returned when an endpoint is called with an unexpected http method.\
+    \ For example, if updating a user requires\na POST request and a PATCH is issued\
+    \ instead, this error is returned. Here's how it looks like:\n\n```json\n{\n \
+    \ \"type\": \"client_error\",\n  \"errors\": [\n    {\n      \"code\": \"method_not_allowed\"\
+    ,\n      \"detail\": \"Method “patch” not allowed.\",\n      \"attr\": null\n\
+    \    }\n  ]\n}\n```\n\n### 406 Not Acceptable\n\nThis is returned if the `Accept`\
+    \ header is submitted and contains a value other than `application/json`. Here's\
+    \ how the\nresponse would look:\n\n```json\n{\n  \"type\": \"client_error\",\n\
+    \  \"errors\": [\n    {\n      \"code\": \"not_acceptable\",\n      \"detail\"\
+    : \"Could not satisfy the request Accept header.\",\n      \"attr\": null\n  \
+    \  }\n  ]\n}\n```\n\n### 415 Unsupported Media Type\n\nThis is returned when the\
+    \ request content type is not json. Here's how the response would look:\n\n```json\n\
+    {\n  \"type\": \"client_error\",\n  \"errors\": [\n    {\n      \"code\": \"not_acceptable\"\
+    ,\n      \"detail\": \"Unsupported media type “application/xml” in request.\"\
+    ,\n      \"attr\": null\n    }\n  ]\n}\n```\n\n### 500 Internal Server Error\n\
+    \nThis is returned when the API server encounters an unexpected error. Here's\
+    \ how the response would look:\n\n```json\n{\n  \"type\": \"server_error\",\n\
+    \  \"errors\": [\n    {\n      \"code\": \"error\",\n      \"detail\": \"A server\
+    \ error occurred.\",\n      \"attr\": null\n    }\n  ]\n}\n```\n"
 paths:
   /api/auth/login/:
     post:
@@ -53,34 +73,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -93,20 +85,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '201':
@@ -150,34 +128,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -190,20 +140,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '204':
@@ -243,34 +179,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -283,20 +191,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -342,34 +236,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -382,20 +248,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -445,34 +297,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -485,20 +309,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -575,34 +385,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -615,20 +397,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -704,34 +472,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -744,20 +484,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -801,34 +527,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -841,20 +539,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -952,34 +636,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -992,20 +648,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -1077,34 +719,6 @@ paths:
                     errors:
                     - code: not_authenticated
                       detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
                       attr: null
           description: ''
         '429':
@@ -1215,34 +829,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -1255,20 +841,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '204':
@@ -1355,34 +927,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -1395,20 +939,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '404':
@@ -1499,34 +1029,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -1539,20 +1041,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '404':
@@ -1631,34 +1119,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -1671,20 +1131,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -1773,34 +1219,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -1813,20 +1231,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -1908,34 +1312,6 @@ paths:
                     errors:
                     - code: not_authenticated
                       detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
                       attr: null
           description: ''
         '429':
@@ -2038,34 +1414,6 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
-        '405':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse405'
-              examples:
-                MethodNotAllowed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: method_not_allowed
-                      detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '415':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse415'
-              examples:
-                UnsupportedMediaType:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: unsupported_media_type
-                      detail: Unsupported media type "application/json" in request.
-                      attr: null
-          description: ''
         '429':
           content:
             application/json:
@@ -2078,20 +1426,6 @@ paths:
                     errors:
                     - code: throttled
                       detail: Request was throttled.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse500'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
                       attr: null
           description: ''
         '200':
@@ -3404,53 +2738,11 @@ components:
       - attr
       - code
       - detail
-    Error405:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode405Enum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
-    Error415:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode415Enum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
     Error429:
       type: object
       properties:
         code:
           $ref: '#/components/schemas/ErrorCode429Enum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
-    Error500:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode500Enum'
         detail:
           type: string
         attr:
@@ -3468,26 +2760,11 @@ components:
       description: |-
         * `authentication_failed` - Authentication Failed
         * `not_authenticated` - Not Authenticated
-    ErrorCode405Enum:
-      enum:
-      - method_not_allowed
-      type: string
-      description: '* `method_not_allowed` - Method Not Allowed'
-    ErrorCode415Enum:
-      enum:
-      - unsupported_media_type
-      type: string
-      description: '* `unsupported_media_type` - Unsupported Media Type'
     ErrorCode429Enum:
       enum:
       - throttled
       type: string
       description: '* `throttled` - Throttled'
-    ErrorCode500Enum:
-      enum:
-      - error
-      type: string
-      description: '* `error` - Error'
     ErrorResponse401:
       type: object
       properties:
@@ -3500,30 +2777,6 @@ components:
       required:
       - errors
       - type
-    ErrorResponse405:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ClientErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error405'
-      required:
-      - errors
-      - type
-    ErrorResponse415:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ClientErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error415'
-      required:
-      - errors
-      - type
     ErrorResponse429:
       type: object
       properties:
@@ -3533,18 +2786,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Error429'
-      required:
-      - errors
-      - type
-    ErrorResponse500:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ServerErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error500'
       required:
       - errors
       - type
@@ -3882,11 +3123,6 @@ components:
         propertyName: type
         mapping:
           client_error: '#/components/schemas/ParseErrorResponse'
-    ServerErrorEnum:
-      enum:
-      - server_error
-      type: string
-      description: '* `server_error` - Server Error'
     ServicePortsRequest:
       type: object
       properties:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -2,7 +2,8 @@ openapi: 3.0.3
 info:
   title: ZaneOps API
   version: 1.0.0
-  description: Your deployment, simplified. Everything handled for you.
+  description: ZaneOps is a self-hosted, open source platform as a service for hosting
+    static sites, web apps, databases, CRONS, Workers using docker swarm as the engine.
 paths:
   /api/auth/login/:
     post:
@@ -64,20 +65,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -177,20 +164,6 @@ paths:
                       detail: Method "get" not allowed.
                       attr: null
           description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
-                      attr: null
-          description: ''
         '415':
           content:
             application/json:
@@ -235,20 +208,6 @@ paths:
           description: ''
         '204':
           description: No response body
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
   /api/auth/me/:
     get:
       operationId: getAuthedUser
@@ -296,20 +255,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -360,20 +305,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/AuthedSuccessResponse'
           description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
   /api/csrf/:
     get:
       operationId: csrf_retrieve
@@ -423,20 +354,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -540,20 +457,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -686,20 +589,6 @@ paths:
                       detail: Method "get" not allowed.
                       attr: null
           description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
-                      attr: null
-          description: ''
         '415':
           content:
             application/json:
@@ -829,20 +718,6 @@ paths:
                       detail: Method "get" not allowed.
                       attr: null
           description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
-                      attr: null
-          description: ''
         '415':
           content:
             application/json:
@@ -938,20 +813,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -1105,20 +966,6 @@ paths:
                       detail: Method "get" not allowed.
                       attr: null
           description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
-                      attr: null
-          description: ''
         '415':
           content:
             application/json:
@@ -1244,20 +1091,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -1394,20 +1227,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -1548,20 +1367,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -1708,20 +1513,6 @@ paths:
                       detail: Method "get" not allowed.
                       attr: null
           description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
-                      attr: null
-          description: ''
         '415':
           content:
             application/json:
@@ -1852,20 +1643,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -2010,20 +1787,6 @@ paths:
                       detail: Method "get" not allowed.
                       attr: null
           description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
-                      attr: null
-          description: ''
         '415':
           content:
             application/json:
@@ -2161,20 +1924,6 @@ paths:
                       detail: Method "get" not allowed.
                       attr: null
           description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
-                      attr: null
-          description: ''
         '415':
           content:
             application/json:
@@ -2301,20 +2050,6 @@ paths:
                     errors:
                     - code: method_not_allowed
                       detail: Method "get" not allowed.
-                      attr: null
-          description: ''
-        '406':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse406'
-              examples:
-                NotAcceptable:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_acceptable
-                      detail: Could not satisfy the request Accept header.
                       attr: null
           description: ''
         '415':
@@ -3683,20 +3418,6 @@ components:
       - attr
       - code
       - detail
-    Error406:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode406Enum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
     Error415:
       type: object
       properties:
@@ -3752,11 +3473,6 @@ components:
       - method_not_allowed
       type: string
       description: '* `method_not_allowed` - Method Not Allowed'
-    ErrorCode406Enum:
-      enum:
-      - not_acceptable
-      type: string
-      description: '* `not_acceptable` - Not Acceptable'
     ErrorCode415Enum:
       enum:
       - unsupported_media_type
@@ -3793,18 +3509,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Error405'
-      required:
-      - errors
-      - type
-    ErrorResponse406:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ClientErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error406'
       required:
       - errors
       - type

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -2,7 +2,28 @@ openapi: 3.0.3
 info:
   title: ZaneOps API
   version: 1.0.0
-  description: Your deployment, simplified. Everything handled for you.
+  description: "\n\n## Overview\n\nZaneOps is a self-hosted, open source platform\
+    \ as a service for hosting static sites, web apps, \ndatabases, CRONS, Workers\
+    \ using docker swarm as the engine.\n\n## Errors\n\n### 405 Method Not Allowed\n\
+    \nThis is returned when an endpoint is called with an unexpected http method.\
+    \ For example, if updating a user requires\na POST request and a PATCH is issued\
+    \ instead, this error is returned. Here's how it looks like:\n\n```json\n{\n \
+    \ \"type\": \"client_error\",\n  \"errors\": [\n    {\n      \"code\": \"method_not_allowed\"\
+    ,\n      \"detail\": \"Method “patch” not allowed.\",\n      \"attr\": null\n\
+    \    }\n  ]\n}\n```\n\n### 406 Not Acceptable\n\nThis is returned if the `Accept`\
+    \ header is submitted and contains a value other than `application/json`. Here's\
+    \ how the\nresponse would look:\n\n```json\n{\n  \"type\": \"client_error\",\n\
+    \  \"errors\": [\n    {\n      \"code\": \"not_acceptable\",\n      \"detail\"\
+    : \"Could not satisfy the request Accept header.\",\n      \"attr\": null\n  \
+    \  }\n  ]\n}\n```\n\n### 415 Unsupported Media Type\n\nThis is returned when the\
+    \ request content type is not json. Here's how the response would look:\n\n```json\n\
+    {\n  \"type\": \"client_error\",\n  \"errors\": [\n    {\n      \"code\": \"not_acceptable\"\
+    ,\n      \"detail\": \"Unsupported media type “application/xml” in request.\"\
+    ,\n      \"attr\": null\n    }\n  ]\n}\n```\n\n### 500 Internal Server Error\n\
+    \nThis is returned when the API server encounters an unexpected error. Here's\
+    \ how the response would look:\n\n```json\n{\n  \"type\": \"server_error\",\n\
+    \  \"errors\": [\n    {\n      \"code\": \"error\",\n      \"detail\": \"A server\
+    \ error occurred.\",\n      \"attr\": null\n    }\n  ]\n}\n```\n"
 paths:
   /api/auth/login/:
     post:
@@ -25,29 +46,52 @@ paths:
       - cookieAuth: []
       - {}
       responses:
-        '201':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginSuccessResponse'
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoginErrorResponse'
+                $ref: '#/components/schemas/LoginErrorResponse400'
           description: ''
         '401':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
           description: ''
         '429':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginSuccessResponse'
           description: ''
   /api/auth/logout/:
     delete:
@@ -57,14 +101,49 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '204':
-          description: No response body
-        '403':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
+                $ref: '#/components/schemas/LogoutErrorResponse400'
           description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '204':
+          description: No response body
   /api/auth/me/:
     get:
       operationId: getAuthedUser
@@ -73,17 +152,52 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAuthedUserErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuthedSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
           description: ''
   /api/csrf/:
     get:
@@ -95,6 +209,47 @@ paths:
       - cookieAuth: []
       - {}
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CsrfRetrieveErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -121,6 +276,41 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -138,6 +328,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '422':
           content:
@@ -160,6 +358,47 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchDockerRegistryErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -171,6 +410,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '422':
           content:
@@ -198,29 +445,52 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '200':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerLoginSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockerLoginErrorResponse'
+                $ref: '#/components/schemas/DockerLoginErrorResponse400'
           description: ''
         '401':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerLoginErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockerLoginSuccessResponse'
           description: ''
   /api/domain/root/:
     get:
@@ -230,6 +500,47 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRootDomainErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -241,6 +552,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/projects/:
     get:
@@ -290,23 +609,52 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetProjectListErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjetCreateErrorResponse'
+                $ref: '#/components/schemas/ProjectListResponse'
           description: ''
     post:
       operationId: createProject
@@ -326,35 +674,58 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateProjectErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '201':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SingleProjectSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjetCreateErrorResponse'
+                $ref: '#/components/schemas/SingleProjectResponse'
           description: ''
         '409':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjetCreateErrorResponse'
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjetCreateErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
   /api/projects/{project_slug}/archive-service/docker/{service_slug}/:
     delete:
@@ -377,6 +748,47 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArchiveDockerServiceErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '204':
           description: No response body
         '404':
@@ -384,12 +796,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/projects/{project_slug}/create-service/docker/:
     post:
@@ -418,11 +846,60 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateDockerServiceErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DockerServiceCreateErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
         '409':
           content:
@@ -441,6 +918,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/projects/{project_slug}/service-details/docker/{service_slug}/:
     get:
@@ -463,11 +948,60 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetDockerServiceErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
         '200':
           content:
@@ -480,6 +1014,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/projects/{slug}/:
     get:
@@ -496,23 +1038,66 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '200':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SingleProjectSuccessResponse'
+                $ref: '#/components/schemas/GetSingleProjectErrorResponse400'
           description: ''
-        '403':
+        '401':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
           description: ''
         '404':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SingleProjectResponse'
           description: ''
     patch:
       operationId: updateProjectName
@@ -539,29 +1124,66 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '200':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SingleProjectSuccessResponse'
+                $ref: '#/components/schemas/UpdateProjectNameErrorResponse400'
           description: ''
-        '403':
+        '401':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
           description: ''
         '404':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
     delete:
       operationId: archiveSingleProject
@@ -577,26 +1199,63 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '200':
-          description: No response body
-        '403':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
+                $ref: '#/components/schemas/ArchiveSingleProjectErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
           description: ''
         '404':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
-        '500':
+        '429':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BaseErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
           description: ''
+        '200':
+          description: No response body
   /api/volumes/{volume_id}/size/:
     get:
       operationId: getVolumeSize
@@ -612,6 +1271,47 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetVolumeSizeErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -623,12 +1323,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
 components:
   schemas:
@@ -644,6 +1360,20 @@ components:
       required:
       - projects
       - total_count
+    ArchiveDockerServiceErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    ArchiveSingleProjectErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     ArchivedProject:
       type: object
       properties:
@@ -699,6 +1429,761 @@ components:
           type: string
       required:
       - details
+    ClientErrorEnum:
+      enum:
+      - client_error
+      type: string
+      description: '* `client_error` - Client Error'
+    CreateDockerServiceCommandErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - command
+          type: string
+          description: '* `command` - command'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceCredentialsNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - credentials.non_field_errors
+          type: string
+          description: '* `credentials.non_field_errors` - credentials.non_field_errors'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceCredentialsPasswordErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - credentials.password
+          type: string
+          description: '* `credentials.password` - credentials.password'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceCredentialsRegistryUrlErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - credentials.registry_url
+          type: string
+          description: '* `credentials.registry_url` - credentials.registry_url'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceCredentialsUsernameErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - credentials.username
+          type: string
+          description: '* `credentials.username` - credentials.username'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceEnvErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - env
+          type: string
+          description: '* `env` - env'
+        code:
+          enum:
+          - not_a_dict
+          - 'null'
+          type: string
+          description: |-
+            * `not_a_dict` - not_a_dict
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceEnvKEYErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - env.KEY
+          type: string
+          description: '* `env.KEY` - env.KEY'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceError:
+      oneOf:
+      - $ref: '#/components/schemas/CreateDockerServiceNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceSlugErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceImageErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCommandErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCredentialsNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCredentialsUsernameErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCredentialsPasswordErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCredentialsRegistryUrlErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXDomainErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXBasePathErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXStripPrefixErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServicePortsNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXPublicErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXForwardedErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceEnvErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceEnvKEYErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceVolumesNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXNameErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXMountPathErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/CreateDockerServiceNonFieldErrorsErrorComponent'
+          slug: '#/components/schemas/CreateDockerServiceSlugErrorComponent'
+          image: '#/components/schemas/CreateDockerServiceImageErrorComponent'
+          command: '#/components/schemas/CreateDockerServiceCommandErrorComponent'
+          credentials.non_field_errors: '#/components/schemas/CreateDockerServiceCredentialsNonFieldErrorsErrorComponent'
+          credentials.username: '#/components/schemas/CreateDockerServiceCredentialsUsernameErrorComponent'
+          credentials.password: '#/components/schemas/CreateDockerServiceCredentialsPasswordErrorComponent'
+          credentials.registry_url: '#/components/schemas/CreateDockerServiceCredentialsRegistryUrlErrorComponent'
+          urls.non_field_errors: '#/components/schemas/CreateDockerServiceUrlsNonFieldErrorsErrorComponent'
+          urls.INDEX.non_field_errors: '#/components/schemas/CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent'
+          urls.INDEX.domain: '#/components/schemas/CreateDockerServiceUrlsINDEXDomainErrorComponent'
+          urls.INDEX.base_path: '#/components/schemas/CreateDockerServiceUrlsINDEXBasePathErrorComponent'
+          urls.INDEX.strip_prefix: '#/components/schemas/CreateDockerServiceUrlsINDEXStripPrefixErrorComponent'
+          ports.non_field_errors: '#/components/schemas/CreateDockerServicePortsNonFieldErrorsErrorComponent'
+          ports.INDEX.non_field_errors: '#/components/schemas/CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent'
+          ports.INDEX.public: '#/components/schemas/CreateDockerServicePortsINDEXPublicErrorComponent'
+          ports.INDEX.forwarded: '#/components/schemas/CreateDockerServicePortsINDEXForwardedErrorComponent'
+          env: '#/components/schemas/CreateDockerServiceEnvErrorComponent'
+          env.KEY: '#/components/schemas/CreateDockerServiceEnvKEYErrorComponent'
+          volumes.non_field_errors: '#/components/schemas/CreateDockerServiceVolumesNonFieldErrorsErrorComponent'
+          volumes.INDEX.non_field_errors: '#/components/schemas/CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent'
+          volumes.INDEX.name: '#/components/schemas/CreateDockerServiceVolumesINDEXNameErrorComponent'
+          volumes.INDEX.mount_path: '#/components/schemas/CreateDockerServiceVolumesINDEXMountPathErrorComponent'
+    CreateDockerServiceErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/CreateDockerServiceValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/CreateDockerServiceValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    CreateDockerServiceImageErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - image
+          type: string
+          description: '* `image` - image'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServicePortsINDEXForwardedErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - ports.INDEX.forwarded
+          type: string
+          description: '* `ports.INDEX.forwarded` - ports.INDEX.forwarded'
+        code:
+          enum:
+          - invalid
+          - max_string_length
+          - 'null'
+          - required
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `max_string_length` - max_string_length
+            * `null` - null
+            * `required` - required
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - ports.INDEX.non_field_errors
+          type: string
+          description: '* `ports.INDEX.non_field_errors` - ports.INDEX.non_field_errors'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServicePortsINDEXPublicErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - ports.INDEX.public
+          type: string
+          description: '* `ports.INDEX.public` - ports.INDEX.public'
+        code:
+          enum:
+          - invalid
+          - max_string_length
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `max_string_length` - max_string_length
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServicePortsNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - ports.non_field_errors
+          type: string
+          description: '* `ports.non_field_errors` - ports.non_field_errors'
+        code:
+          enum:
+          - not_a_list
+          - 'null'
+          type: string
+          description: |-
+            * `not_a_list` - not_a_list
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceSlugErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - slug
+          type: string
+          description: '* `slug` - slug'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsINDEXBasePathErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.INDEX.base_path
+          type: string
+          description: '* `urls.INDEX.base_path` - urls.INDEX.base_path'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsINDEXDomainErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.INDEX.domain
+          type: string
+          description: '* `urls.INDEX.domain` - urls.INDEX.domain'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.INDEX.non_field_errors
+          type: string
+          description: '* `urls.INDEX.non_field_errors` - urls.INDEX.non_field_errors'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsINDEXStripPrefixErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.INDEX.strip_prefix
+          type: string
+          description: '* `urls.INDEX.strip_prefix` - urls.INDEX.strip_prefix'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.non_field_errors
+          type: string
+          description: '* `urls.non_field_errors` - urls.non_field_errors'
+        code:
+          enum:
+          - not_a_list
+          - 'null'
+          type: string
+          description: |-
+            * `not_a_list` - not_a_list
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateDockerServiceError'
+      required:
+      - errors
+      - type
+    CreateDockerServiceVolumesINDEXMountPathErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - volumes.INDEX.mount_path
+          type: string
+          description: '* `volumes.INDEX.mount_path` - volumes.INDEX.mount_path'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceVolumesINDEXNameErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - volumes.INDEX.name
+          type: string
+          description: '* `volumes.INDEX.name` - volumes.INDEX.name'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - volumes.INDEX.non_field_errors
+          type: string
+          description: '* `volumes.INDEX.non_field_errors` - volumes.INDEX.non_field_errors'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceVolumesNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - volumes.non_field_errors
+          type: string
+          description: '* `volumes.non_field_errors` - volumes.non_field_errors'
+        code:
+          enum:
+          - not_a_list
+          - 'null'
+          type: string
+          description: |-
+            * `not_a_list` - not_a_list
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateProjectError:
+      oneOf:
+      - $ref: '#/components/schemas/CreateProjectNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateProjectSlugErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/CreateProjectNonFieldErrorsErrorComponent'
+          slug: '#/components/schemas/CreateProjectSlugErrorComponent'
+    CreateProjectErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/CreateProjectValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/CreateProjectValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    CreateProjectNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateProjectSlugErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - slug
+          type: string
+          description: '* `slug` - slug'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateProjectValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateProjectError'
+      required:
+      - errors
+      - type
     CredentialError:
       type: object
       properties:
@@ -714,6 +2199,13 @@ components:
           type: array
           items:
             type: string
+    CsrfRetrieveErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     DockerCredentialsRequest:
       type: object
       properties:
@@ -772,31 +2264,106 @@ components:
       required:
       - errors
     DockerLoginError:
+      oneOf:
+      - $ref: '#/components/schemas/DockerLoginNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/DockerLoginUsernameErrorComponent'
+      - $ref: '#/components/schemas/DockerLoginPasswordErrorComponent'
+      - $ref: '#/components/schemas/DockerLoginRegistryUrlErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/DockerLoginNonFieldErrorsErrorComponent'
+          username: '#/components/schemas/DockerLoginUsernameErrorComponent'
+          password: '#/components/schemas/DockerLoginPasswordErrorComponent'
+          registry_url: '#/components/schemas/DockerLoginRegistryUrlErrorComponent'
+    DockerLoginErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/DockerLoginValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/DockerLoginValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    DockerLoginNonFieldErrorsErrorComponent:
       type: object
       properties:
-        root:
-          type: array
-          items:
-            type: string
-        username:
-          type: array
-          items:
-            type: string
-        password:
-          type: array
-          items:
-            type: string
-        registry_url:
-          type: array
-          items:
-            type: string
-    DockerLoginErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/DockerLoginError'
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
       required:
-      - errors
+      - attr
+      - code
+      - detail
+    DockerLoginPasswordErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - password
+          type: string
+          description: '* `password` - password'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    DockerLoginRegistryUrlErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - registry_url
+          type: string
+          description: '* `registry_url` - registry_url'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
     DockerLoginRequest:
       type: object
       properties:
@@ -819,6 +2386,50 @@ components:
           type: boolean
       required:
       - success
+    DockerLoginUsernameErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - username
+          type: string
+          description: '* `username` - username'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    DockerLoginValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/DockerLoginError'
+      required:
+      - errors
+      - type
     DockerPortCheckError:
       type: object
       properties:
@@ -997,6 +2608,133 @@ components:
             $ref: '#/components/schemas/DockerImage'
       required:
       - images
+    Error401:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode401Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error404:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode404Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error409:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/Error409CodeEnum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error409CodeEnum:
+      enum:
+      - resource_conflict
+      type: string
+      description: '* `resource_conflict` - Resource Conflict'
+    Error429:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode429Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    ErrorCode401Enum:
+      enum:
+      - authentication_failed
+      - not_authenticated
+      type: string
+      description: |-
+        * `authentication_failed` - Authentication Failed
+        * `not_authenticated` - Not Authenticated
+    ErrorCode404Enum:
+      enum:
+      - not_found
+      type: string
+      description: '* `not_found` - Not Found'
+    ErrorCode429Enum:
+      enum:
+      - throttled
+      type: string
+      description: '* `throttled` - Throttled'
+    ErrorResponse401:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error401'
+      required:
+      - errors
+      - type
+    ErrorResponse404:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error404'
+      required:
+      - errors
+      - type
+    ErrorResponse409:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error409'
+      required:
+      - errors
+      - type
+    ErrorResponse429:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error429'
+      required:
+      - errors
+      - type
     ForbiddenResponse:
       type: object
       properties:
@@ -1004,6 +2742,27 @@ components:
           $ref: '#/components/schemas/BaseError'
       required:
       - errors
+    GetAuthedUserErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetDockerServiceErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetProjectListErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     GetRootDomain:
       type: object
       properties:
@@ -1011,28 +2770,100 @@ components:
           type: string
       required:
       - domain
+    GetRootDomainErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetSingleProjectErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetVolumeSizeErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     LoginError:
+      oneOf:
+      - $ref: '#/components/schemas/LoginNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/LoginUsernameErrorComponent'
+      - $ref: '#/components/schemas/LoginPasswordErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/LoginNonFieldErrorsErrorComponent'
+          username: '#/components/schemas/LoginUsernameErrorComponent'
+          password: '#/components/schemas/LoginPasswordErrorComponent'
+    LoginErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/LoginValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/LoginValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    LoginNonFieldErrorsErrorComponent:
       type: object
       properties:
-        root:
-          type: array
-          items:
-            type: string
-        username:
-          type: array
-          items:
-            type: string
-        password:
-          type: array
-          items:
-            type: string
-    LoginErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/LoginError'
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
       required:
-      - errors
+      - attr
+      - code
+      - detail
+    LoginPasswordErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - password
+          type: string
+          description: '* `password` - password'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - min_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `min_length` - min_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
     LoginRequest:
       type: object
       properties:
@@ -1054,6 +2885,90 @@ components:
           type: boolean
       required:
       - success
+    LoginUsernameErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - username
+          type: string
+          description: '* `username` - username'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - min_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `min_length` - min_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    LoginValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/LoginError'
+      required:
+      - errors
+      - type
+    LogoutErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    ParseError:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ParseErrorCodeEnum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    ParseErrorCodeEnum:
+      enum:
+      - parse_error
+      type: string
+      description: '* `parse_error` - Parse Error'
+    ParseErrorResponse:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParseError'
+      required:
+      - errors
+      - type
     PatchedProjectUpdateRequest:
       type: object
       properties:
@@ -1101,7 +3016,7 @@ components:
           type: string
           maxLength: 255
           pattern: ^[-a-zA-Z0-9_]+$
-    ProjectSuccessResponse:
+    ProjectListResponse:
       type: object
       properties:
         active:
@@ -1111,42 +3026,13 @@ components:
       required:
       - active
       - archived
-    ProjectUpdateErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/ProjetUpdateError'
-      required:
-      - errors
-    ProjetCreateError:
-      type: object
-      properties:
-        root:
-          type: array
-          items:
-            type: string
-        slug:
-          type: array
-          items:
-            type: string
-    ProjetCreateErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/ProjetCreateError'
-      required:
-      - errors
-    ProjetUpdateError:
-      type: object
-      properties:
-        root:
-          type: array
-          items:
-            type: string
-        slug:
-          type: array
-          items:
-            type: string
+    SearchDockerRegistryErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     ServicePortsRequest:
       type: object
       properties:
@@ -1157,7 +3043,7 @@ components:
           type: integer
       required:
       - forwarded
-    SingleProjectSuccessResponse:
+    SingleProjectResponse:
       type: object
       properties:
         project:
@@ -1202,6 +3088,87 @@ components:
           type: array
           items:
             type: string
+    UpdateProjectNameError:
+      oneOf:
+      - $ref: '#/components/schemas/UpdateProjectNameNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/UpdateProjectNameSlugErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/UpdateProjectNameNonFieldErrorsErrorComponent'
+          slug: '#/components/schemas/UpdateProjectNameSlugErrorComponent'
+    UpdateProjectNameErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/UpdateProjectNameValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/UpdateProjectNameValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    UpdateProjectNameNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    UpdateProjectNameSlugErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - slug
+          type: string
+          description: '* `slug` - slug'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    UpdateProjectNameValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/UpdateProjectNameError'
+      required:
+      - errors
+      - type
     User:
       type: object
       properties:
@@ -1223,6 +3190,11 @@ components:
           description: Designates whether the user can log into this admin site.
       required:
       - username
+    ValidationErrorEnum:
+      enum:
+      - validation_error
+      type: string
+      description: '* `validation_error` - Validation Error'
     Volume:
       type: object
       properties:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -2,28 +2,7 @@ openapi: 3.0.3
 info:
   title: ZaneOps API
   version: 1.0.0
-  description: "\n\n## Overview\n\nZaneOps is a self-hosted, open source platform\
-    \ as a service for hosting static sites, web apps, \ndatabases, CRONS, Workers\
-    \ using docker swarm as the engine.\n\n## Errors\n\n### 405 Method Not Allowed\n\
-    \nThis is returned when an endpoint is called with an unexpected http method.\
-    \ For example, if updating a user requires\na POST request and a PATCH is issued\
-    \ instead, this error is returned. Here's how it looks like:\n\n```json\n{\n \
-    \ \"type\": \"client_error\",\n  \"errors\": [\n    {\n      \"code\": \"method_not_allowed\"\
-    ,\n      \"detail\": \"Method “patch” not allowed.\",\n      \"attr\": null\n\
-    \    }\n  ]\n}\n```\n\n### 406 Not Acceptable\n\nThis is returned if the `Accept`\
-    \ header is submitted and contains a value other than `application/json`. Here's\
-    \ how the\nresponse would look:\n\n```json\n{\n  \"type\": \"client_error\",\n\
-    \  \"errors\": [\n    {\n      \"code\": \"not_acceptable\",\n      \"detail\"\
-    : \"Could not satisfy the request Accept header.\",\n      \"attr\": null\n  \
-    \  }\n  ]\n}\n```\n\n### 415 Unsupported Media Type\n\nThis is returned when the\
-    \ request content type is not json. Here's how the response would look:\n\n```json\n\
-    {\n  \"type\": \"client_error\",\n  \"errors\": [\n    {\n      \"code\": \"not_acceptable\"\
-    ,\n      \"detail\": \"Unsupported media type “application/xml” in request.\"\
-    ,\n      \"attr\": null\n    }\n  ]\n}\n```\n\n### 500 Internal Server Error\n\
-    \nThis is returned when the API server encounters an unexpected error. Here's\
-    \ how the response would look:\n\n```json\n{\n  \"type\": \"server_error\",\n\
-    \  \"errors\": [\n    {\n      \"code\": \"error\",\n      \"detail\": \"A server\
-    \ error occurred.\",\n      \"attr\": null\n    }\n  ]\n}\n```\n"
+  description: Your deployment, simplified. Everything handled for you.
 paths:
   /api/auth/login/:
     post:
@@ -46,52 +25,29 @@ paths:
       - cookieAuth: []
       - {}
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoginErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/LoginSuccessResponse'
+          description: ''
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginErrorResponse'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginErrorResponse'
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginErrorResponse'
           description: ''
   /api/auth/logout/:
     delete:
@@ -101,49 +57,14 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LogoutErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '204':
           description: No response body
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+          description: ''
   /api/auth/me/:
     get:
       operationId: getAuthedUser
@@ -152,52 +73,17 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetAuthedUserErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/AuthedSuccessResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
           description: ''
   /api/csrf/:
     get:
@@ -209,47 +95,6 @@ paths:
       - cookieAuth: []
       - {}
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CsrfRetrieveErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
@@ -276,41 +121,6 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
@@ -328,14 +138,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
           description: ''
         '422':
           content:
@@ -358,47 +160,6 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SearchDockerRegistryErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
@@ -410,14 +171,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
           description: ''
         '422':
           content:
@@ -445,52 +198,29 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockerLoginErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DockerLoginSuccessResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+          description: ''
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockerLoginErrorResponse'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockerLoginErrorResponse'
           description: ''
   /api/domain/root/:
     get:
@@ -500,47 +230,6 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetRootDomainErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
@@ -552,14 +241,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
           description: ''
   /api/projects/:
     get:
@@ -609,52 +290,23 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetProjectListErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectListResponse'
+                $ref: '#/components/schemas/ProjectSuccessResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+          description: ''
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjetCreateErrorResponse'
           description: ''
     post:
       operationId: createProject
@@ -674,58 +326,35 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateProjectErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '201':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SingleProjectResponse'
+                $ref: '#/components/schemas/SingleProjectSuccessResponse'
+          description: ''
+        '403':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ForbiddenResponse'
+          description: ''
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjetCreateErrorResponse'
           description: ''
         '409':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse409'
+                $ref: '#/components/schemas/ProjetCreateErrorResponse'
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjetCreateErrorResponse'
           description: ''
   /api/projects/{project_slug}/archive-service/docker/{service_slug}/:
     delete:
@@ -748,47 +377,6 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ArchiveDockerServiceErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '204':
           description: No response body
         '404':
@@ -796,28 +384,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
           description: ''
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
           description: ''
   /api/projects/{project_slug}/create-service/docker/:
     post:
@@ -846,60 +418,11 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CreateDockerServiceErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DockerServiceCreateErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
           description: ''
         '409':
           content:
@@ -918,14 +441,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
           description: ''
   /api/projects/{project_slug}/service-details/docker/{service_slug}/:
     get:
@@ -948,60 +463,11 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetDockerServiceErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
           description: ''
         '200':
           content:
@@ -1014,14 +480,6 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
           description: ''
   /api/projects/{slug}/:
     get:
@@ -1038,66 +496,23 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/GetSingleProjectErrorResponse400'
+                $ref: '#/components/schemas/SingleProjectSuccessResponse'
           description: ''
-        '401':
+        '403':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
+                $ref: '#/components/schemas/ForbiddenResponse'
           description: ''
         '404':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse404'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SingleProjectResponse'
+                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
           description: ''
     patch:
       operationId: updateProjectName
@@ -1124,66 +539,29 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
+        '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UpdateProjectNameErrorResponse400'
+                $ref: '#/components/schemas/SingleProjectSuccessResponse'
           description: ''
-        '401':
+        '403':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
+                $ref: '#/components/schemas/ForbiddenResponse'
+          description: ''
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
           description: ''
         '404':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse404'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
+                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
           description: ''
     delete:
       operationId: archiveSingleProject
@@ -1199,63 +577,26 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
+        '200':
+          description: No response body
+        '403':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ArchiveSingleProjectErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
+                $ref: '#/components/schemas/ForbiddenResponse'
           description: ''
         '404':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse404'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
+                $ref: '#/components/schemas/BaseErrorResponse'
           description: ''
-        '429':
+        '500':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
+                $ref: '#/components/schemas/BaseErrorResponse'
           description: ''
-        '200':
-          description: No response body
   /api/volumes/{volume_id}/size/:
     get:
       operationId: getVolumeSize
@@ -1271,47 +612,6 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/GetVolumeSizeErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
-          description: ''
-        '429':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse429'
-              examples:
-                Throttled:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: throttled
-                      detail: Request was throttled.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
@@ -1323,28 +623,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
           description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
           description: ''
 components:
   schemas:
@@ -1360,20 +644,6 @@ components:
       required:
       - projects
       - total_count
-    ArchiveDockerServiceErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
-    ArchiveSingleProjectErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
     ArchivedProject:
       type: object
       properties:
@@ -1429,761 +699,6 @@ components:
           type: string
       required:
       - details
-    ClientErrorEnum:
-      enum:
-      - client_error
-      type: string
-      description: '* `client_error` - Client Error'
-    CreateDockerServiceCommandErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - command
-          type: string
-          description: '* `command` - command'
-        code:
-          enum:
-          - blank
-          - invalid
-          - 'null'
-          - null_characters_not_allowed
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceCredentialsNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - credentials.non_field_errors
-          type: string
-          description: '* `credentials.non_field_errors` - credentials.non_field_errors'
-        code:
-          enum:
-          - invalid
-          - 'null'
-          type: string
-          description: |-
-            * `invalid` - invalid
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceCredentialsPasswordErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - credentials.password
-          type: string
-          description: '* `credentials.password` - credentials.password'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceCredentialsRegistryUrlErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - credentials.registry_url
-          type: string
-          description: '* `credentials.registry_url` - credentials.registry_url'
-        code:
-          enum:
-          - blank
-          - invalid
-          - 'null'
-          - null_characters_not_allowed
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceCredentialsUsernameErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - credentials.username
-          type: string
-          description: '* `credentials.username` - credentials.username'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceEnvErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - env
-          type: string
-          description: '* `env` - env'
-        code:
-          enum:
-          - not_a_dict
-          - 'null'
-          type: string
-          description: |-
-            * `not_a_dict` - not_a_dict
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceEnvKEYErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - env.KEY
-          type: string
-          description: '* `env.KEY` - env.KEY'
-        code:
-          enum:
-          - blank
-          - invalid
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceError:
-      oneOf:
-      - $ref: '#/components/schemas/CreateDockerServiceNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceSlugErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceImageErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceCommandErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceCredentialsNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceCredentialsUsernameErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceCredentialsPasswordErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceCredentialsRegistryUrlErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceUrlsNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXDomainErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXBasePathErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXStripPrefixErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServicePortsNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXPublicErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXForwardedErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceEnvErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceEnvKEYErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceVolumesNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXNameErrorComponent'
-      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXMountPathErrorComponent'
-      discriminator:
-        propertyName: attr
-        mapping:
-          non_field_errors: '#/components/schemas/CreateDockerServiceNonFieldErrorsErrorComponent'
-          slug: '#/components/schemas/CreateDockerServiceSlugErrorComponent'
-          image: '#/components/schemas/CreateDockerServiceImageErrorComponent'
-          command: '#/components/schemas/CreateDockerServiceCommandErrorComponent'
-          credentials.non_field_errors: '#/components/schemas/CreateDockerServiceCredentialsNonFieldErrorsErrorComponent'
-          credentials.username: '#/components/schemas/CreateDockerServiceCredentialsUsernameErrorComponent'
-          credentials.password: '#/components/schemas/CreateDockerServiceCredentialsPasswordErrorComponent'
-          credentials.registry_url: '#/components/schemas/CreateDockerServiceCredentialsRegistryUrlErrorComponent'
-          urls.non_field_errors: '#/components/schemas/CreateDockerServiceUrlsNonFieldErrorsErrorComponent'
-          urls.INDEX.non_field_errors: '#/components/schemas/CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent'
-          urls.INDEX.domain: '#/components/schemas/CreateDockerServiceUrlsINDEXDomainErrorComponent'
-          urls.INDEX.base_path: '#/components/schemas/CreateDockerServiceUrlsINDEXBasePathErrorComponent'
-          urls.INDEX.strip_prefix: '#/components/schemas/CreateDockerServiceUrlsINDEXStripPrefixErrorComponent'
-          ports.non_field_errors: '#/components/schemas/CreateDockerServicePortsNonFieldErrorsErrorComponent'
-          ports.INDEX.non_field_errors: '#/components/schemas/CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent'
-          ports.INDEX.public: '#/components/schemas/CreateDockerServicePortsINDEXPublicErrorComponent'
-          ports.INDEX.forwarded: '#/components/schemas/CreateDockerServicePortsINDEXForwardedErrorComponent'
-          env: '#/components/schemas/CreateDockerServiceEnvErrorComponent'
-          env.KEY: '#/components/schemas/CreateDockerServiceEnvKEYErrorComponent'
-          volumes.non_field_errors: '#/components/schemas/CreateDockerServiceVolumesNonFieldErrorsErrorComponent'
-          volumes.INDEX.non_field_errors: '#/components/schemas/CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent'
-          volumes.INDEX.name: '#/components/schemas/CreateDockerServiceVolumesINDEXNameErrorComponent'
-          volumes.INDEX.mount_path: '#/components/schemas/CreateDockerServiceVolumesINDEXMountPathErrorComponent'
-    CreateDockerServiceErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/CreateDockerServiceValidationError'
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          validation_error: '#/components/schemas/CreateDockerServiceValidationError'
-          client_error: '#/components/schemas/ParseErrorResponse'
-    CreateDockerServiceImageErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - image
-          type: string
-          description: '* `image` - image'
-        code:
-          enum:
-          - blank
-          - invalid
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - non_field_errors
-          type: string
-          description: '* `non_field_errors` - non_field_errors'
-        code:
-          enum:
-          - invalid
-          type: string
-          description: '* `invalid` - invalid'
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServicePortsINDEXForwardedErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - ports.INDEX.forwarded
-          type: string
-          description: '* `ports.INDEX.forwarded` - ports.INDEX.forwarded'
-        code:
-          enum:
-          - invalid
-          - max_string_length
-          - 'null'
-          - required
-          type: string
-          description: |-
-            * `invalid` - invalid
-            * `max_string_length` - max_string_length
-            * `null` - null
-            * `required` - required
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - ports.INDEX.non_field_errors
-          type: string
-          description: '* `ports.INDEX.non_field_errors` - ports.INDEX.non_field_errors'
-        code:
-          enum:
-          - invalid
-          - 'null'
-          type: string
-          description: |-
-            * `invalid` - invalid
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServicePortsINDEXPublicErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - ports.INDEX.public
-          type: string
-          description: '* `ports.INDEX.public` - ports.INDEX.public'
-        code:
-          enum:
-          - invalid
-          - max_string_length
-          - 'null'
-          type: string
-          description: |-
-            * `invalid` - invalid
-            * `max_string_length` - max_string_length
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServicePortsNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - ports.non_field_errors
-          type: string
-          description: '* `ports.non_field_errors` - ports.non_field_errors'
-        code:
-          enum:
-          - not_a_list
-          - 'null'
-          type: string
-          description: |-
-            * `not_a_list` - not_a_list
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceSlugErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - slug
-          type: string
-          description: '* `slug` - slug'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceUrlsINDEXBasePathErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - urls.INDEX.base_path
-          type: string
-          description: '* `urls.INDEX.base_path` - urls.INDEX.base_path'
-        code:
-          enum:
-          - blank
-          - invalid
-          - 'null'
-          - null_characters_not_allowed
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceUrlsINDEXDomainErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - urls.INDEX.domain
-          type: string
-          description: '* `urls.INDEX.domain` - urls.INDEX.domain'
-        code:
-          enum:
-          - blank
-          - invalid
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - urls.INDEX.non_field_errors
-          type: string
-          description: '* `urls.INDEX.non_field_errors` - urls.INDEX.non_field_errors'
-        code:
-          enum:
-          - invalid
-          - 'null'
-          type: string
-          description: |-
-            * `invalid` - invalid
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceUrlsINDEXStripPrefixErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - urls.INDEX.strip_prefix
-          type: string
-          description: '* `urls.INDEX.strip_prefix` - urls.INDEX.strip_prefix'
-        code:
-          enum:
-          - invalid
-          - 'null'
-          type: string
-          description: |-
-            * `invalid` - invalid
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceUrlsNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - urls.non_field_errors
-          type: string
-          description: '* `urls.non_field_errors` - urls.non_field_errors'
-        code:
-          enum:
-          - not_a_list
-          - 'null'
-          type: string
-          description: |-
-            * `not_a_list` - not_a_list
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceValidationError:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ValidationErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/CreateDockerServiceError'
-      required:
-      - errors
-      - type
-    CreateDockerServiceVolumesINDEXMountPathErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - volumes.INDEX.mount_path
-          type: string
-          description: '* `volumes.INDEX.mount_path` - volumes.INDEX.mount_path'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceVolumesINDEXNameErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - volumes.INDEX.name
-          type: string
-          description: '* `volumes.INDEX.name` - volumes.INDEX.name'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - volumes.INDEX.non_field_errors
-          type: string
-          description: '* `volumes.INDEX.non_field_errors` - volumes.INDEX.non_field_errors'
-        code:
-          enum:
-          - invalid
-          - 'null'
-          type: string
-          description: |-
-            * `invalid` - invalid
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateDockerServiceVolumesNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - volumes.non_field_errors
-          type: string
-          description: '* `volumes.non_field_errors` - volumes.non_field_errors'
-        code:
-          enum:
-          - not_a_list
-          - 'null'
-          type: string
-          description: |-
-            * `not_a_list` - not_a_list
-            * `null` - null
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateProjectError:
-      oneOf:
-      - $ref: '#/components/schemas/CreateProjectNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/CreateProjectSlugErrorComponent'
-      discriminator:
-        propertyName: attr
-        mapping:
-          non_field_errors: '#/components/schemas/CreateProjectNonFieldErrorsErrorComponent'
-          slug: '#/components/schemas/CreateProjectSlugErrorComponent'
-    CreateProjectErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/CreateProjectValidationError'
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          validation_error: '#/components/schemas/CreateProjectValidationError'
-          client_error: '#/components/schemas/ParseErrorResponse'
-    CreateProjectNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - non_field_errors
-          type: string
-          description: '* `non_field_errors` - non_field_errors'
-        code:
-          enum:
-          - invalid
-          type: string
-          description: '* `invalid` - invalid'
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateProjectSlugErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - slug
-          type: string
-          description: '* `slug` - slug'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    CreateProjectValidationError:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ValidationErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/CreateProjectError'
-      required:
-      - errors
-      - type
     CredentialError:
       type: object
       properties:
@@ -2199,13 +714,6 @@ components:
           type: array
           items:
             type: string
-    CsrfRetrieveErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
     DockerCredentialsRequest:
       type: object
       properties:
@@ -2264,106 +772,31 @@ components:
       required:
       - errors
     DockerLoginError:
-      oneOf:
-      - $ref: '#/components/schemas/DockerLoginNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/DockerLoginUsernameErrorComponent'
-      - $ref: '#/components/schemas/DockerLoginPasswordErrorComponent'
-      - $ref: '#/components/schemas/DockerLoginRegistryUrlErrorComponent'
-      discriminator:
-        propertyName: attr
-        mapping:
-          non_field_errors: '#/components/schemas/DockerLoginNonFieldErrorsErrorComponent'
-          username: '#/components/schemas/DockerLoginUsernameErrorComponent'
-          password: '#/components/schemas/DockerLoginPasswordErrorComponent'
-          registry_url: '#/components/schemas/DockerLoginRegistryUrlErrorComponent'
-    DockerLoginErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/DockerLoginValidationError'
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          validation_error: '#/components/schemas/DockerLoginValidationError'
-          client_error: '#/components/schemas/ParseErrorResponse'
-    DockerLoginNonFieldErrorsErrorComponent:
       type: object
       properties:
-        attr:
-          enum:
-          - non_field_errors
-          type: string
-          description: '* `non_field_errors` - non_field_errors'
-        code:
-          enum:
-          - invalid
-          type: string
-          description: '* `invalid` - invalid'
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    DockerLoginPasswordErrorComponent:
+        root:
+          type: array
+          items:
+            type: string
+        username:
+          type: array
+          items:
+            type: string
+        password:
+          type: array
+          items:
+            type: string
+        registry_url:
+          type: array
+          items:
+            type: string
+    DockerLoginErrorResponse:
       type: object
       properties:
-        attr:
-          enum:
-          - password
-          type: string
-          description: '* `password` - password'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
+        errors:
+          $ref: '#/components/schemas/DockerLoginError'
       required:
-      - attr
-      - code
-      - detail
-    DockerLoginRegistryUrlErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - registry_url
-          type: string
-          description: '* `registry_url` - registry_url'
-        code:
-          enum:
-          - blank
-          - invalid
-          - 'null'
-          - null_characters_not_allowed
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
+      - errors
     DockerLoginRequest:
       type: object
       properties:
@@ -2386,50 +819,6 @@ components:
           type: boolean
       required:
       - success
-    DockerLoginUsernameErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - username
-          type: string
-          description: '* `username` - username'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    DockerLoginValidationError:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ValidationErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/DockerLoginError'
-      required:
-      - errors
-      - type
     DockerPortCheckError:
       type: object
       properties:
@@ -2608,133 +997,6 @@ components:
             $ref: '#/components/schemas/DockerImage'
       required:
       - images
-    Error401:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode401Enum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
-    Error404:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode404Enum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
-    Error409:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/Error409CodeEnum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
-    Error409CodeEnum:
-      enum:
-      - resource_conflict
-      type: string
-      description: '* `resource_conflict` - Resource Conflict'
-    Error429:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/ErrorCode429Enum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
-    ErrorCode401Enum:
-      enum:
-      - authentication_failed
-      - not_authenticated
-      type: string
-      description: |-
-        * `authentication_failed` - Authentication Failed
-        * `not_authenticated` - Not Authenticated
-    ErrorCode404Enum:
-      enum:
-      - not_found
-      type: string
-      description: '* `not_found` - Not Found'
-    ErrorCode429Enum:
-      enum:
-      - throttled
-      type: string
-      description: '* `throttled` - Throttled'
-    ErrorResponse401:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ClientErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error401'
-      required:
-      - errors
-      - type
-    ErrorResponse404:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ClientErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error404'
-      required:
-      - errors
-      - type
-    ErrorResponse409:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ClientErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error409'
-      required:
-      - errors
-      - type
-    ErrorResponse429:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ClientErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/Error429'
-      required:
-      - errors
-      - type
     ForbiddenResponse:
       type: object
       properties:
@@ -2742,27 +1004,6 @@ components:
           $ref: '#/components/schemas/BaseError'
       required:
       - errors
-    GetAuthedUserErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
-    GetDockerServiceErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
-    GetProjectListErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
     GetRootDomain:
       type: object
       properties:
@@ -2770,100 +1011,28 @@ components:
           type: string
       required:
       - domain
-    GetRootDomainErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
-    GetSingleProjectErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
-    GetVolumeSizeErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
     LoginError:
-      oneOf:
-      - $ref: '#/components/schemas/LoginNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/LoginUsernameErrorComponent'
-      - $ref: '#/components/schemas/LoginPasswordErrorComponent'
-      discriminator:
-        propertyName: attr
-        mapping:
-          non_field_errors: '#/components/schemas/LoginNonFieldErrorsErrorComponent'
-          username: '#/components/schemas/LoginUsernameErrorComponent'
-          password: '#/components/schemas/LoginPasswordErrorComponent'
-    LoginErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/LoginValidationError'
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          validation_error: '#/components/schemas/LoginValidationError'
-          client_error: '#/components/schemas/ParseErrorResponse'
-    LoginNonFieldErrorsErrorComponent:
       type: object
       properties:
-        attr:
-          enum:
-          - non_field_errors
-          type: string
-          description: '* `non_field_errors` - non_field_errors'
-        code:
-          enum:
-          - invalid
-          type: string
-          description: '* `invalid` - invalid'
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    LoginPasswordErrorComponent:
+        root:
+          type: array
+          items:
+            type: string
+        username:
+          type: array
+          items:
+            type: string
+        password:
+          type: array
+          items:
+            type: string
+    LoginErrorResponse:
       type: object
       properties:
-        attr:
-          enum:
-          - password
-          type: string
-          description: '* `password` - password'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - min_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `min_length` - min_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
+        errors:
+          $ref: '#/components/schemas/LoginError'
       required:
-      - attr
-      - code
-      - detail
+      - errors
     LoginRequest:
       type: object
       properties:
@@ -2885,90 +1054,6 @@ components:
           type: boolean
       required:
       - success
-    LoginUsernameErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - username
-          type: string
-          description: '* `username` - username'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - min_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `min_length` - min_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    LoginValidationError:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ValidationErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/LoginError'
-      required:
-      - errors
-      - type
-    LogoutErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
-    ParseError:
-      type: object
-      properties:
-        code:
-          $ref: '#/components/schemas/ParseErrorCodeEnum'
-        detail:
-          type: string
-        attr:
-          type: string
-          nullable: true
-      required:
-      - attr
-      - code
-      - detail
-    ParseErrorCodeEnum:
-      enum:
-      - parse_error
-      type: string
-      description: '* `parse_error` - Parse Error'
-    ParseErrorResponse:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ClientErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/ParseError'
-      required:
-      - errors
-      - type
     PatchedProjectUpdateRequest:
       type: object
       properties:
@@ -3016,7 +1101,7 @@ components:
           type: string
           maxLength: 255
           pattern: ^[-a-zA-Z0-9_]+$
-    ProjectListResponse:
+    ProjectSuccessResponse:
       type: object
       properties:
         active:
@@ -3026,13 +1111,42 @@ components:
       required:
       - active
       - archived
-    SearchDockerRegistryErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
+    ProjectUpdateErrorResponse:
+      type: object
+      properties:
+        errors:
+          $ref: '#/components/schemas/ProjetUpdateError'
+      required:
+      - errors
+    ProjetCreateError:
+      type: object
+      properties:
+        root:
+          type: array
+          items:
+            type: string
+        slug:
+          type: array
+          items:
+            type: string
+    ProjetCreateErrorResponse:
+      type: object
+      properties:
+        errors:
+          $ref: '#/components/schemas/ProjetCreateError'
+      required:
+      - errors
+    ProjetUpdateError:
+      type: object
+      properties:
+        root:
+          type: array
+          items:
+            type: string
+        slug:
+          type: array
+          items:
+            type: string
     ServicePortsRequest:
       type: object
       properties:
@@ -3043,7 +1157,7 @@ components:
           type: integer
       required:
       - forwarded
-    SingleProjectResponse:
+    SingleProjectSuccessResponse:
       type: object
       properties:
         project:
@@ -3088,87 +1202,6 @@ components:
           type: array
           items:
             type: string
-    UpdateProjectNameError:
-      oneOf:
-      - $ref: '#/components/schemas/UpdateProjectNameNonFieldErrorsErrorComponent'
-      - $ref: '#/components/schemas/UpdateProjectNameSlugErrorComponent'
-      discriminator:
-        propertyName: attr
-        mapping:
-          non_field_errors: '#/components/schemas/UpdateProjectNameNonFieldErrorsErrorComponent'
-          slug: '#/components/schemas/UpdateProjectNameSlugErrorComponent'
-    UpdateProjectNameErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/UpdateProjectNameValidationError'
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          validation_error: '#/components/schemas/UpdateProjectNameValidationError'
-          client_error: '#/components/schemas/ParseErrorResponse'
-    UpdateProjectNameNonFieldErrorsErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - non_field_errors
-          type: string
-          description: '* `non_field_errors` - non_field_errors'
-        code:
-          enum:
-          - invalid
-          type: string
-          description: '* `invalid` - invalid'
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    UpdateProjectNameSlugErrorComponent:
-      type: object
-      properties:
-        attr:
-          enum:
-          - slug
-          type: string
-          description: '* `slug` - slug'
-        code:
-          enum:
-          - blank
-          - invalid
-          - max_length
-          - 'null'
-          - null_characters_not_allowed
-          - required
-          - surrogate_characters_not_allowed
-          type: string
-          description: |-
-            * `blank` - blank
-            * `invalid` - invalid
-            * `max_length` - max_length
-            * `null` - null
-            * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
-            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
-        detail:
-          type: string
-      required:
-      - attr
-      - code
-      - detail
-    UpdateProjectNameValidationError:
-      type: object
-      properties:
-        type:
-          $ref: '#/components/schemas/ValidationErrorEnum'
-        errors:
-          type: array
-          items:
-            $ref: '#/components/schemas/UpdateProjectNameError'
-      required:
-      - errors
-      - type
     User:
       type: object
       properties:
@@ -3190,11 +1223,6 @@ components:
           description: Designates whether the user can log into this admin site.
       required:
       - username
-    ValidationErrorEnum:
-      enum:
-      - validation_error
-      type: string
-      description: '* `validation_error` - Validation Error'
     Volume:
       type: object
       properties:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -276,6 +276,12 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckIfPortIsAvailableErrorResponse400'
+          description: ''
         '401':
           content:
             application/json:
@@ -315,33 +321,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerPortCheckSuccessResponse'
-          description: ''
-        '400':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockerPortCheckSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockerPortCheckErrorResponse'
+                $ref: '#/components/schemas/DockerPortCheckResponse'
           description: ''
   /api/docker/image-search/:
     get:
@@ -403,27 +383,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockerImageSearchErrorResponse'
+                $ref: '#/components/schemas/DockerImageSearchResponse'
           description: ''
   /api/docker/login/:
     post:
@@ -775,6 +735,20 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
         '429':
           content:
             application/json:
@@ -791,34 +765,6 @@ paths:
           description: ''
         '204':
           description: No response body
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
   /api/projects/{project_slug}/create-service/docker/:
     post:
       operationId: createDockerService
@@ -873,6 +819,20 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
         '429':
           content:
             application/json:
@@ -887,45 +847,17 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockerServiceCreateErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
-          description: ''
         '409':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerServiceCreateErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '201':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerServiceCreateSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
+                $ref: '#/components/schemas/DockerServiceResponse'
           description: ''
   /api/projects/{project_slug}/service-details/docker/{service_slug}/:
     get:
@@ -975,6 +907,20 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
         '429':
           content:
             application/json:
@@ -989,39 +935,11 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
-          description: ''
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerServiceCreateSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
+                $ref: '#/components/schemas/DockerServiceResponse'
           description: ''
   /api/projects/{slug}/:
     get:
@@ -1298,6 +1216,20 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
         '429':
           content:
             application/json:
@@ -1316,35 +1248,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/VolumeGetSizeSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
+                $ref: '#/components/schemas/VolumeGetSizeResponse'
           description: ''
 components:
   schemas:
@@ -1415,13 +1319,6 @@ components:
           type: array
           items:
             type: string
-    BaseErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/BaseError'
-      required:
-      - errors
     CSRF:
       type: object
       properties:
@@ -1429,6 +1326,83 @@ components:
           type: string
       required:
       - details
+    CheckIfPortIsAvailableError:
+      oneOf:
+      - $ref: '#/components/schemas/CheckIfPortIsAvailableNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CheckIfPortIsAvailablePortErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/CheckIfPortIsAvailableNonFieldErrorsErrorComponent'
+          port: '#/components/schemas/CheckIfPortIsAvailablePortErrorComponent'
+    CheckIfPortIsAvailableErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/CheckIfPortIsAvailableValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/CheckIfPortIsAvailableValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    CheckIfPortIsAvailableNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CheckIfPortIsAvailablePortErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - port
+          type: string
+          description: '* `port` - port'
+        code:
+          enum:
+          - invalid
+          - max_string_length
+          - min_value
+          - 'null'
+          - required
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `max_string_length` - max_string_length
+            * `min_value` - min_value
+            * `null` - null
+            * `required` - required
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CheckIfPortIsAvailableValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CheckIfPortIsAvailableError'
+      required:
+      - errors
+      - type
     ClientErrorEnum:
       enum:
       - client_error
@@ -2184,21 +2158,6 @@ components:
       required:
       - errors
       - type
-    CredentialError:
-      type: object
-      properties:
-        username:
-          type: array
-          items:
-            type: string
-        password:
-          type: array
-          items:
-            type: string
-        registry_url:
-          type: array
-          items:
-            type: string
     CsrfRetrieveErrorResponse400:
       oneOf:
       - $ref: '#/components/schemas/ParseErrorResponse'
@@ -2245,24 +2204,15 @@ components:
       required:
       - description
       - full_image
-    DockerImageSearchError:
+    DockerImageSearchResponse:
       type: object
       properties:
-        root:
+        images:
           type: array
           items:
-            type: string
-        q:
-          type: array
-          items:
-            type: string
-    DockerImageSearchErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/DockerImageSearchError'
+            $ref: '#/components/schemas/DockerImage'
       required:
-      - errors
+      - images
     DockerLoginError:
       oneOf:
       - $ref: '#/components/schemas/DockerLoginNonFieldErrorsErrorComponent'
@@ -2430,24 +2380,6 @@ components:
       required:
       - errors
       - type
-    DockerPortCheckError:
-      type: object
-      properties:
-        root:
-          type: array
-          items:
-            type: string
-        port:
-          type: array
-          items:
-            type: string
-    DockerPortCheckErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/DockerPortCheckError'
-      required:
-      - errors
     DockerPortCheckRequest:
       type: object
       properties:
@@ -2456,7 +2388,7 @@ components:
           minimum: 0
       required:
       - port
-    DockerPortCheckSuccessResponse:
+    DockerPortCheckResponse:
       type: object
       properties:
         available:
@@ -2512,50 +2444,6 @@ components:
       - updated_at
       - urls
       - volumes
-    DockerServiceCreateError:
-      type: object
-      properties:
-        root:
-          type: array
-          items:
-            type: string
-        slug:
-          type: array
-          items:
-            type: string
-        image:
-          type: array
-          items:
-            type: string
-        command:
-          type: array
-          items:
-            type: string
-        credentials:
-          $ref: '#/components/schemas/CredentialError'
-        urls:
-          type: array
-          items:
-            $ref: '#/components/schemas/URLsError'
-        ports:
-          type: array
-          items:
-            type: string
-        env:
-          type: array
-          items:
-            type: string
-        volumes:
-          type: array
-          items:
-            type: string
-    DockerServiceCreateErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/DockerServiceCreateError'
-      required:
-      - errors
     DockerServiceCreateRequest:
       type: object
       properties:
@@ -2590,7 +2478,7 @@ components:
           default: []
       required:
       - image
-    DockerServiceCreateSuccessResponse:
+    DockerServiceResponse:
       type: object
       properties:
         service:
@@ -2599,15 +2487,6 @@ components:
           readOnly: true
       required:
       - service
-    DockerSuccessResponse:
-      type: object
-      properties:
-        images:
-          type: array
-          items:
-            $ref: '#/components/schemas/DockerImage'
-      required:
-      - images
     Error401:
       type: object
       properties:
@@ -3077,17 +2956,6 @@ components:
           default: true
       required:
       - domain
-    URLsError:
-      type: object
-      properties:
-        domain:
-          type: array
-          items:
-            type: string
-        base_path:
-          type: array
-          items:
-            type: string
     UpdateProjectNameError:
       oneOf:
       - $ref: '#/components/schemas/UpdateProjectNameNonFieldErrorsErrorComponent'
@@ -3220,7 +3088,7 @@ components:
       - created_at
       - name
       - updated_at
-    VolumeGetSizeSuccessResponse:
+    VolumeGetSizeResponse:
       type: object
       properties:
         size:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -25,29 +25,108 @@ paths:
       - cookieAuth: []
       - {}
       responses:
-        '201':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginSuccessResponse'
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/LoginErrorResponse'
+                $ref: '#/components/schemas/LoginErrorResponse400'
           description: ''
         '401':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
           description: ''
         '429':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/LoginErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LoginSuccessResponse'
           description: ''
   /api/auth/logout/:
     delete:
@@ -57,6 +136,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/LogoutErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '204':
           description: No response body
         '403':
@@ -64,6 +240,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/auth/me/:
     get:
@@ -73,6 +257,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetAuthedUserErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -84,6 +365,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/csrf/:
     get:
@@ -95,6 +384,103 @@ paths:
       - cookieAuth: []
       - {}
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CsrfRetrieveErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -121,6 +507,97 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -138,6 +615,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '422':
           content:
@@ -160,6 +645,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SearchDockerRegistryErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -171,6 +753,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '422':
           content:
@@ -198,29 +788,108 @@ paths:
       security:
       - cookieAuth: []
       responses:
-        '200':
+        '400':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerLoginSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/DockerLoginErrorResponse'
+                $ref: '#/components/schemas/DockerLoginErrorResponse400'
           description: ''
         '401':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/DockerLoginErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockerLoginSuccessResponse'
           description: ''
   /api/domain/root/:
     get:
@@ -230,6 +899,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetRootDomainErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -241,6 +1007,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/projects/:
     get:
@@ -290,6 +1064,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetProjectListErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -301,6 +1172,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '422':
           content:
@@ -326,6 +1205,89 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateProjectErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '201':
           content:
             application/json:
@@ -337,6 +1299,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '422':
           content:
@@ -355,6 +1325,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjetCreateErrorResponse'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
           description: ''
   /api/projects/{project_slug}/archive-service/docker/{service_slug}/:
     delete:
@@ -377,6 +1355,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArchiveDockerServiceErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '204':
           description: No response body
         '404':
@@ -384,12 +1459,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
         '403':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/projects/{project_slug}/create-service/docker/:
     post:
@@ -418,11 +1509,116 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateDockerServiceErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DockerServiceCreateErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
         '409':
           content:
@@ -441,6 +1637,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/projects/{project_slug}/service-details/docker/{service_slug}/:
     get:
@@ -463,11 +1667,116 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetDockerServiceErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
         '200':
           content:
@@ -480,6 +1789,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
   /api/projects/{slug}/:
     get:
@@ -496,6 +1813,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetSingleProjectErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -507,12 +1921,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectUpdateErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
     patch:
       operationId: updateProjectName
@@ -539,6 +1969,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateProjectNameErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -550,6 +2077,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '422':
           content:
@@ -562,6 +2097,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ProjectUpdateErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
     delete:
       operationId: archiveSingleProject
@@ -577,6 +2120,89 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ArchiveSingleProjectErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
         '200':
           description: No response body
         '403':
@@ -584,18 +2210,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
         '500':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
           description: ''
   /api/volumes/{volume_id}/size/:
     get:
@@ -612,6 +2262,103 @@ paths:
       security:
       - cookieAuth: []
       responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetVolumeSizeErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '405':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse405'
+              examples:
+                MethodNotAllowed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: method_not_allowed
+                      detail: Method "get" not allowed.
+                      attr: null
+          description: ''
+        '406':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse406'
+              examples:
+                NotAcceptable:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_acceptable
+                      detail: Could not satisfy the request Accept header.
+                      attr: null
+          description: ''
+        '415':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse415'
+              examples:
+                UnsupportedMediaType:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: unsupported_media_type
+                      detail: Unsupported media type "application/json" in request.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '500':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse500'
+              examples:
+                APIException:
+                  value:
+                    type: server_error
+                    errors:
+                    - code: error
+                      detail: A server error occurred.
+                      attr: null
+          description: ''
         '200':
           content:
             application/json:
@@ -623,12 +2370,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ForbiddenResponse'
+              examples:
+                PermissionDenied:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: permission_denied
+                      detail: You do not have permission to perform this action.
+                      attr: null
           description: ''
         '404':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/BaseErrorResponse'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
           description: ''
 components:
   schemas:
@@ -644,6 +2407,20 @@ components:
       required:
       - projects
       - total_count
+    ArchiveDockerServiceErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    ArchiveSingleProjectErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     ArchivedProject:
       type: object
       properties:
@@ -699,6 +2476,761 @@ components:
           type: string
       required:
       - details
+    ClientErrorEnum:
+      enum:
+      - client_error
+      type: string
+      description: '* `client_error` - Client Error'
+    CreateDockerServiceCommandErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - command
+          type: string
+          description: '* `command` - command'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceCredentialsNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - credentials.non_field_errors
+          type: string
+          description: '* `credentials.non_field_errors` - credentials.non_field_errors'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceCredentialsPasswordErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - credentials.password
+          type: string
+          description: '* `credentials.password` - credentials.password'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceCredentialsRegistryUrlErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - credentials.registry_url
+          type: string
+          description: '* `credentials.registry_url` - credentials.registry_url'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceCredentialsUsernameErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - credentials.username
+          type: string
+          description: '* `credentials.username` - credentials.username'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceEnvErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - env
+          type: string
+          description: '* `env` - env'
+        code:
+          enum:
+          - not_a_dict
+          - 'null'
+          type: string
+          description: |-
+            * `not_a_dict` - not_a_dict
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceEnvKEYErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - env.KEY
+          type: string
+          description: '* `env.KEY` - env.KEY'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceError:
+      oneOf:
+      - $ref: '#/components/schemas/CreateDockerServiceNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceSlugErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceImageErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCommandErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCredentialsNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCredentialsUsernameErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCredentialsPasswordErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceCredentialsRegistryUrlErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXDomainErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXBasePathErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceUrlsINDEXStripPrefixErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServicePortsNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXPublicErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServicePortsINDEXForwardedErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceEnvErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceEnvKEYErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceVolumesNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXNameErrorComponent'
+      - $ref: '#/components/schemas/CreateDockerServiceVolumesINDEXMountPathErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/CreateDockerServiceNonFieldErrorsErrorComponent'
+          slug: '#/components/schemas/CreateDockerServiceSlugErrorComponent'
+          image: '#/components/schemas/CreateDockerServiceImageErrorComponent'
+          command: '#/components/schemas/CreateDockerServiceCommandErrorComponent'
+          credentials.non_field_errors: '#/components/schemas/CreateDockerServiceCredentialsNonFieldErrorsErrorComponent'
+          credentials.username: '#/components/schemas/CreateDockerServiceCredentialsUsernameErrorComponent'
+          credentials.password: '#/components/schemas/CreateDockerServiceCredentialsPasswordErrorComponent'
+          credentials.registry_url: '#/components/schemas/CreateDockerServiceCredentialsRegistryUrlErrorComponent'
+          urls.non_field_errors: '#/components/schemas/CreateDockerServiceUrlsNonFieldErrorsErrorComponent'
+          urls.INDEX.non_field_errors: '#/components/schemas/CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent'
+          urls.INDEX.domain: '#/components/schemas/CreateDockerServiceUrlsINDEXDomainErrorComponent'
+          urls.INDEX.base_path: '#/components/schemas/CreateDockerServiceUrlsINDEXBasePathErrorComponent'
+          urls.INDEX.strip_prefix: '#/components/schemas/CreateDockerServiceUrlsINDEXStripPrefixErrorComponent'
+          ports.non_field_errors: '#/components/schemas/CreateDockerServicePortsNonFieldErrorsErrorComponent'
+          ports.INDEX.non_field_errors: '#/components/schemas/CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent'
+          ports.INDEX.public: '#/components/schemas/CreateDockerServicePortsINDEXPublicErrorComponent'
+          ports.INDEX.forwarded: '#/components/schemas/CreateDockerServicePortsINDEXForwardedErrorComponent'
+          env: '#/components/schemas/CreateDockerServiceEnvErrorComponent'
+          env.KEY: '#/components/schemas/CreateDockerServiceEnvKEYErrorComponent'
+          volumes.non_field_errors: '#/components/schemas/CreateDockerServiceVolumesNonFieldErrorsErrorComponent'
+          volumes.INDEX.non_field_errors: '#/components/schemas/CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent'
+          volumes.INDEX.name: '#/components/schemas/CreateDockerServiceVolumesINDEXNameErrorComponent'
+          volumes.INDEX.mount_path: '#/components/schemas/CreateDockerServiceVolumesINDEXMountPathErrorComponent'
+    CreateDockerServiceErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/CreateDockerServiceValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/CreateDockerServiceValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    CreateDockerServiceImageErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - image
+          type: string
+          description: '* `image` - image'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServicePortsINDEXForwardedErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - ports.INDEX.forwarded
+          type: string
+          description: '* `ports.INDEX.forwarded` - ports.INDEX.forwarded'
+        code:
+          enum:
+          - invalid
+          - max_string_length
+          - 'null'
+          - required
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `max_string_length` - max_string_length
+            * `null` - null
+            * `required` - required
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServicePortsINDEXNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - ports.INDEX.non_field_errors
+          type: string
+          description: '* `ports.INDEX.non_field_errors` - ports.INDEX.non_field_errors'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServicePortsINDEXPublicErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - ports.INDEX.public
+          type: string
+          description: '* `ports.INDEX.public` - ports.INDEX.public'
+        code:
+          enum:
+          - invalid
+          - max_string_length
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `max_string_length` - max_string_length
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServicePortsNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - ports.non_field_errors
+          type: string
+          description: '* `ports.non_field_errors` - ports.non_field_errors'
+        code:
+          enum:
+          - not_a_list
+          - 'null'
+          type: string
+          description: |-
+            * `not_a_list` - not_a_list
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceSlugErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - slug
+          type: string
+          description: '* `slug` - slug'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsINDEXBasePathErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.INDEX.base_path
+          type: string
+          description: '* `urls.INDEX.base_path` - urls.INDEX.base_path'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsINDEXDomainErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.INDEX.domain
+          type: string
+          description: '* `urls.INDEX.domain` - urls.INDEX.domain'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsINDEXNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.INDEX.non_field_errors
+          type: string
+          description: '* `urls.INDEX.non_field_errors` - urls.INDEX.non_field_errors'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsINDEXStripPrefixErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.INDEX.strip_prefix
+          type: string
+          description: '* `urls.INDEX.strip_prefix` - urls.INDEX.strip_prefix'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceUrlsNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - urls.non_field_errors
+          type: string
+          description: '* `urls.non_field_errors` - urls.non_field_errors'
+        code:
+          enum:
+          - not_a_list
+          - 'null'
+          type: string
+          description: |-
+            * `not_a_list` - not_a_list
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateDockerServiceError'
+      required:
+      - errors
+      - type
+    CreateDockerServiceVolumesINDEXMountPathErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - volumes.INDEX.mount_path
+          type: string
+          description: '* `volumes.INDEX.mount_path` - volumes.INDEX.mount_path'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceVolumesINDEXNameErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - volumes.INDEX.name
+          type: string
+          description: '* `volumes.INDEX.name` - volumes.INDEX.name'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceVolumesINDEXNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - volumes.INDEX.non_field_errors
+          type: string
+          description: '* `volumes.INDEX.non_field_errors` - volumes.INDEX.non_field_errors'
+        code:
+          enum:
+          - invalid
+          - 'null'
+          type: string
+          description: |-
+            * `invalid` - invalid
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateDockerServiceVolumesNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - volumes.non_field_errors
+          type: string
+          description: '* `volumes.non_field_errors` - volumes.non_field_errors'
+        code:
+          enum:
+          - not_a_list
+          - 'null'
+          type: string
+          description: |-
+            * `not_a_list` - not_a_list
+            * `null` - null
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateProjectError:
+      oneOf:
+      - $ref: '#/components/schemas/CreateProjectNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/CreateProjectSlugErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/CreateProjectNonFieldErrorsErrorComponent'
+          slug: '#/components/schemas/CreateProjectSlugErrorComponent'
+    CreateProjectErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/CreateProjectValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/CreateProjectValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    CreateProjectNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateProjectSlugErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - slug
+          type: string
+          description: '* `slug` - slug'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    CreateProjectValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreateProjectError'
+      required:
+      - errors
+      - type
     CredentialError:
       type: object
       properties:
@@ -714,6 +3246,13 @@ components:
           type: array
           items:
             type: string
+    CsrfRetrieveErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     DockerCredentialsRequest:
       type: object
       properties:
@@ -772,31 +3311,106 @@ components:
       required:
       - errors
     DockerLoginError:
+      oneOf:
+      - $ref: '#/components/schemas/DockerLoginNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/DockerLoginUsernameErrorComponent'
+      - $ref: '#/components/schemas/DockerLoginPasswordErrorComponent'
+      - $ref: '#/components/schemas/DockerLoginRegistryUrlErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/DockerLoginNonFieldErrorsErrorComponent'
+          username: '#/components/schemas/DockerLoginUsernameErrorComponent'
+          password: '#/components/schemas/DockerLoginPasswordErrorComponent'
+          registry_url: '#/components/schemas/DockerLoginRegistryUrlErrorComponent'
+    DockerLoginErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/DockerLoginValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/DockerLoginValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    DockerLoginNonFieldErrorsErrorComponent:
       type: object
       properties:
-        root:
-          type: array
-          items:
-            type: string
-        username:
-          type: array
-          items:
-            type: string
-        password:
-          type: array
-          items:
-            type: string
-        registry_url:
-          type: array
-          items:
-            type: string
-    DockerLoginErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/DockerLoginError'
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
       required:
-      - errors
+      - attr
+      - code
+      - detail
+    DockerLoginPasswordErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - password
+          type: string
+          description: '* `password` - password'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    DockerLoginRegistryUrlErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - registry_url
+          type: string
+          description: '* `registry_url` - registry_url'
+        code:
+          enum:
+          - blank
+          - invalid
+          - 'null'
+          - null_characters_not_allowed
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
     DockerLoginRequest:
       type: object
       properties:
@@ -819,6 +3433,50 @@ components:
           type: boolean
       required:
       - success
+    DockerLoginUsernameErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - username
+          type: string
+          description: '* `username` - username'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    DockerLoginValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/DockerLoginError'
+      required:
+      - errors
+      - type
     DockerPortCheckError:
       type: object
       properties:
@@ -997,6 +3655,195 @@ components:
             $ref: '#/components/schemas/DockerImage'
       required:
       - images
+    Error401:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode401Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error405:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode405Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error406:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode406Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error415:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode415Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error429:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode429Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error500:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode500Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    ErrorCode401Enum:
+      enum:
+      - authentication_failed
+      - not_authenticated
+      type: string
+      description: |-
+        * `authentication_failed` - Authentication Failed
+        * `not_authenticated` - Not Authenticated
+    ErrorCode405Enum:
+      enum:
+      - method_not_allowed
+      type: string
+      description: '* `method_not_allowed` - Method Not Allowed'
+    ErrorCode406Enum:
+      enum:
+      - not_acceptable
+      type: string
+      description: '* `not_acceptable` - Not Acceptable'
+    ErrorCode415Enum:
+      enum:
+      - unsupported_media_type
+      type: string
+      description: '* `unsupported_media_type` - Unsupported Media Type'
+    ErrorCode429Enum:
+      enum:
+      - throttled
+      type: string
+      description: '* `throttled` - Throttled'
+    ErrorCode500Enum:
+      enum:
+      - error
+      type: string
+      description: '* `error` - Error'
+    ErrorResponse401:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error401'
+      required:
+      - errors
+      - type
+    ErrorResponse405:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error405'
+      required:
+      - errors
+      - type
+    ErrorResponse406:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error406'
+      required:
+      - errors
+      - type
+    ErrorResponse415:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error415'
+      required:
+      - errors
+      - type
+    ErrorResponse429:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error429'
+      required:
+      - errors
+      - type
+    ErrorResponse500:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ServerErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error500'
+      required:
+      - errors
+      - type
     ForbiddenResponse:
       type: object
       properties:
@@ -1004,6 +3851,27 @@ components:
           $ref: '#/components/schemas/BaseError'
       required:
       - errors
+    GetAuthedUserErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetDockerServiceErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetProjectListErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     GetRootDomain:
       type: object
       properties:
@@ -1011,28 +3879,100 @@ components:
           type: string
       required:
       - domain
+    GetRootDomainErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetSingleProjectErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetVolumeSizeErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     LoginError:
+      oneOf:
+      - $ref: '#/components/schemas/LoginNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/LoginUsernameErrorComponent'
+      - $ref: '#/components/schemas/LoginPasswordErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/LoginNonFieldErrorsErrorComponent'
+          username: '#/components/schemas/LoginUsernameErrorComponent'
+          password: '#/components/schemas/LoginPasswordErrorComponent'
+    LoginErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/LoginValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/LoginValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    LoginNonFieldErrorsErrorComponent:
       type: object
       properties:
-        root:
-          type: array
-          items:
-            type: string
-        username:
-          type: array
-          items:
-            type: string
-        password:
-          type: array
-          items:
-            type: string
-    LoginErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/LoginError'
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
       required:
-      - errors
+      - attr
+      - code
+      - detail
+    LoginPasswordErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - password
+          type: string
+          description: '* `password` - password'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - min_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `min_length` - min_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
     LoginRequest:
       type: object
       properties:
@@ -1054,6 +3994,90 @@ components:
           type: boolean
       required:
       - success
+    LoginUsernameErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - username
+          type: string
+          description: '* `username` - username'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - min_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `min_length` - min_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    LoginValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/LoginError'
+      required:
+      - errors
+      - type
+    LogoutErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    ParseError:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ParseErrorCodeEnum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    ParseErrorCodeEnum:
+      enum:
+      - parse_error
+      type: string
+      description: '* `parse_error` - Parse Error'
+    ParseErrorResponse:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ParseError'
+      required:
+      - errors
+      - type
     PatchedProjectUpdateRequest:
       type: object
       properties:
@@ -1147,6 +4171,18 @@ components:
           type: array
           items:
             type: string
+    SearchDockerRegistryErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    ServerErrorEnum:
+      enum:
+      - server_error
+      type: string
+      description: '* `server_error` - Server Error'
     ServicePortsRequest:
       type: object
       properties:
@@ -1202,6 +4238,87 @@ components:
           type: array
           items:
             type: string
+    UpdateProjectNameError:
+      oneOf:
+      - $ref: '#/components/schemas/UpdateProjectNameNonFieldErrorsErrorComponent'
+      - $ref: '#/components/schemas/UpdateProjectNameSlugErrorComponent'
+      discriminator:
+        propertyName: attr
+        mapping:
+          non_field_errors: '#/components/schemas/UpdateProjectNameNonFieldErrorsErrorComponent'
+          slug: '#/components/schemas/UpdateProjectNameSlugErrorComponent'
+    UpdateProjectNameErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/UpdateProjectNameValidationError'
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          validation_error: '#/components/schemas/UpdateProjectNameValidationError'
+          client_error: '#/components/schemas/ParseErrorResponse'
+    UpdateProjectNameNonFieldErrorsErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - non_field_errors
+          type: string
+          description: '* `non_field_errors` - non_field_errors'
+        code:
+          enum:
+          - invalid
+          type: string
+          description: '* `invalid` - invalid'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    UpdateProjectNameSlugErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - slug
+          type: string
+          description: '* `slug` - slug'
+        code:
+          enum:
+          - blank
+          - invalid
+          - max_length
+          - 'null'
+          - null_characters_not_allowed
+          - required
+          - surrogate_characters_not_allowed
+          type: string
+          description: |-
+            * `blank` - blank
+            * `invalid` - invalid
+            * `max_length` - max_length
+            * `null` - null
+            * `null_characters_not_allowed` - null_characters_not_allowed
+            * `required` - required
+            * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    UpdateProjectNameValidationError:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ValidationErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/UpdateProjectNameError'
+      required:
+      - errors
+      - type
     User:
       type: object
       properties:
@@ -1223,6 +4340,11 @@ components:
           description: Designates whether the user can log into this admin site.
       required:
       - username
+    ValidationErrorEnum:
+      enum:
+      - validation_error
+      type: string
+      description: '* `validation_error` - Validation Error'
     Volume:
       type: object
       properties:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -87,12 +87,6 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '201':
           content:
             application/json:
@@ -148,12 +142,6 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '204':
           description: No response body
   /api/auth/me/:
@@ -204,12 +192,6 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
-          description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -267,12 +249,6 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
-          description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -334,12 +310,6 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
-          description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -429,12 +399,6 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '200':
           content:
             application/json:
@@ -522,12 +486,6 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '200':
           content:
             application/json:
@@ -582,12 +540,6 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
-          description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -698,12 +650,6 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '200':
           content:
             application/json:
@@ -769,17 +715,17 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SingleProjectResponse'
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
   /api/projects/{project_slug}/archive-service/docker/{service_slug}/:
     delete:
@@ -842,12 +788,6 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
-          description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '204':
           description: No response body
@@ -1049,12 +989,6 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '404':
           content:
             application/json:
@@ -1159,12 +1093,6 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '200':
           content:
             application/json:
@@ -1257,12 +1185,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ErrorResponse409'
           description: ''
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SingleProjectResponse'
-          description: ''
     delete:
       operationId: archiveSingleProject
       parameters:
@@ -1332,12 +1254,6 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
-          description: ''
         '200':
           description: No response body
   /api/volumes/{volume_id}/size/:
@@ -1395,12 +1311,6 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
-          description: ''
-        '409':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -2730,7 +2640,7 @@ components:
       type: object
       properties:
         code:
-          $ref: '#/components/schemas/ErrorCode409Enum'
+          $ref: '#/components/schemas/Error409CodeEnum'
         detail:
           type: string
         attr:
@@ -2740,6 +2650,11 @@ components:
       - attr
       - code
       - detail
+    Error409CodeEnum:
+      enum:
+      - resource_conflict
+      type: string
+      description: '* `resource_conflict` - Resource Conflict'
     Error429:
       type: object
       properties:
@@ -2767,11 +2682,6 @@ components:
       - not_found
       type: string
       description: '* `not_found` - Not Found'
-    ErrorCode409Enum:
-      enum:
-      - resource_conflict
-      type: string
-      description: '* `resource_conflict` - Resource Conflict'
     ErrorCode429Enum:
       enum:
       - throttled
@@ -2805,7 +2715,7 @@ components:
       type: object
       properties:
         type:
-          $ref: '#/components/schemas/ServerErrorEnum'
+          $ref: '#/components/schemas/ClientErrorEnum'
         errors:
           type: array
           items:
@@ -3123,11 +3033,6 @@ components:
         propertyName: type
         mapping:
           client_error: '#/components/schemas/ParseErrorResponse'
-    ServerErrorEnum:
-      enum:
-      - server_error
-      type: string
-      description: '* `server_error` - Server Error'
     ServicePortsRequest:
       type: object
       properties:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -201,7 +201,7 @@ paths:
           description: ''
   /api/csrf/:
     get:
-      operationId: csrf_retrieve
+      operationId: getCSRF
       description: CSRF cookie view for retrieving CSRF before doing requests
       tags:
       - csrf
@@ -213,28 +213,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CsrfRetrieveErrorResponse400'
-          description: ''
-        '401':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ErrorResponse401'
-              examples:
-                AuthenticationFailed:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: authentication_failed
-                      detail: Incorrect authentication credentials.
-                      attr: null
-                NotAuthenticated:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_authenticated
-                      detail: Authentication credentials were not provided.
-                      attr: null
+                $ref: '#/components/schemas/GetCSRFErrorResponse400'
           description: ''
         '429':
           content:
@@ -250,12 +229,8 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '200':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/CSRF'
-          description: ''
+        '401':
+          description: No response body
   /api/docker/check-port/:
     post:
       operationId: checkIfPortIsAvailable
@@ -1319,13 +1294,6 @@ components:
           type: array
           items:
             type: string
-    CSRF:
-      type: object
-      properties:
-        details:
-          type: string
-      required:
-      - details
     CheckIfPortIsAvailableError:
       oneOf:
       - $ref: '#/components/schemas/CheckIfPortIsAvailableNonFieldErrorsErrorComponent'
@@ -2158,13 +2126,6 @@ components:
       required:
       - errors
       - type
-    CsrfRetrieveErrorResponse400:
-      oneOf:
-      - $ref: '#/components/schemas/ParseErrorResponse'
-      discriminator:
-        propertyName: type
-        mapping:
-          client_error: '#/components/schemas/ParseErrorResponse'
     DockerCredentialsRequest:
       type: object
       properties:
@@ -2622,6 +2583,13 @@ components:
       required:
       - errors
     GetAuthedUserErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    GetCSRFErrorResponse400:
       oneOf:
       - $ref: '#/components/schemas/ParseErrorResponse'
       discriminator:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -87,6 +87,12 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '201':
           content:
             application/json:
@@ -142,6 +148,12 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '204':
           description: No response body
   /api/auth/me/:
@@ -192,6 +204,12 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -249,6 +267,12 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -310,6 +334,12 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -399,6 +429,12 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '200':
           content:
             application/json:
@@ -486,6 +522,12 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '200':
           content:
             application/json:
@@ -540,6 +582,12 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -650,31 +698,17 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjectSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjetCreateErrorResponse'
+                $ref: '#/components/schemas/ProjectListResponse'
           description: ''
     post:
       operationId: createProject
@@ -735,51 +769,17 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
-        '201':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SingleProjectSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjetCreateErrorResponse'
-          description: ''
         '409':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjetCreateErrorResponse'
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
-        '500':
+        '201':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProjetCreateErrorResponse'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
-                      attr: null
+                $ref: '#/components/schemas/SingleProjectResponse'
           description: ''
   /api/projects/{project_slug}/archive-service/docker/{service_slug}/:
     delete:
@@ -842,6 +842,12 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '204':
           description: No response body
@@ -1043,6 +1049,12 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '404':
           content:
             application/json:
@@ -1119,6 +1131,20 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
         '429':
           content:
             application/json:
@@ -1133,39 +1159,17 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SingleProjectSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
+                $ref: '#/components/schemas/SingleProjectResponse'
           description: ''
     patch:
       operationId: updateProjectName
@@ -1219,6 +1223,20 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
         '429':
           content:
             application/json:
@@ -1233,45 +1251,17 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '200':
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/SingleProjectSuccessResponse'
-          description: ''
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
-        '422':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
-          description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ProjectUpdateErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
+                $ref: '#/components/schemas/SingleProjectResponse'
           description: ''
     delete:
       operationId: archiveSingleProject
@@ -1314,6 +1304,20 @@ paths:
                       detail: Authentication credentials were not provided.
                       attr: null
           description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
         '429':
           content:
             application/json:
@@ -1328,50 +1332,14 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '200':
           description: No response body
-        '403':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ForbiddenResponse'
-              examples:
-                PermissionDenied:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: permission_denied
-                      detail: You do not have permission to perform this action.
-                      attr: null
-          description: ''
-        '404':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseErrorResponse'
-              examples:
-                NotFound:
-                  value:
-                    type: client_error
-                    errors:
-                    - code: not_found
-                      detail: Not found.
-                      attr: null
-          description: ''
-        '500':
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BaseErrorResponse'
-              examples:
-                APIException:
-                  value:
-                    type: server_error
-                    errors:
-                    - code: error
-                      detail: A server error occurred.
-                      attr: null
-          description: ''
   /api/volumes/{volume_id}/size/:
     get:
       operationId: getVolumeSize
@@ -1427,6 +1395,12 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '200':
           content:
@@ -2738,6 +2712,34 @@ components:
       - attr
       - code
       - detail
+    Error404:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode404Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error409:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/ErrorCode409Enum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
     Error429:
       type: object
       properties:
@@ -2760,6 +2762,16 @@ components:
       description: |-
         * `authentication_failed` - Authentication Failed
         * `not_authenticated` - Not Authenticated
+    ErrorCode404Enum:
+      enum:
+      - not_found
+      type: string
+      description: '* `not_found` - Not Found'
+    ErrorCode409Enum:
+      enum:
+      - resource_conflict
+      type: string
+      description: '* `resource_conflict` - Resource Conflict'
     ErrorCode429Enum:
       enum:
       - throttled
@@ -2774,6 +2786,30 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Error401'
+      required:
+      - errors
+      - type
+    ErrorResponse404:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error404'
+      required:
+      - errors
+      - type
+    ErrorResponse409:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ServerErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error409'
       required:
       - errors
       - type
@@ -3070,7 +3106,7 @@ components:
           type: string
           maxLength: 255
           pattern: ^[-a-zA-Z0-9_]+$
-    ProjectSuccessResponse:
+    ProjectListResponse:
       type: object
       properties:
         active:
@@ -3080,42 +3116,6 @@ components:
       required:
       - active
       - archived
-    ProjectUpdateErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/ProjetUpdateError'
-      required:
-      - errors
-    ProjetCreateError:
-      type: object
-      properties:
-        root:
-          type: array
-          items:
-            type: string
-        slug:
-          type: array
-          items:
-            type: string
-    ProjetCreateErrorResponse:
-      type: object
-      properties:
-        errors:
-          $ref: '#/components/schemas/ProjetCreateError'
-      required:
-      - errors
-    ProjetUpdateError:
-      type: object
-      properties:
-        root:
-          type: array
-          items:
-            type: string
-        slug:
-          type: array
-          items:
-            type: string
     SearchDockerRegistryErrorResponse400:
       oneOf:
       - $ref: '#/components/schemas/ParseErrorResponse'
@@ -3123,6 +3123,11 @@ components:
         propertyName: type
         mapping:
           client_error: '#/components/schemas/ParseErrorResponse'
+    ServerErrorEnum:
+      enum:
+      - server_error
+      type: string
+      description: '* `server_error` - Server Error'
     ServicePortsRequest:
       type: object
       properties:
@@ -3133,7 +3138,7 @@ components:
           type: integer
       required:
       - forwarded
-    SingleProjectSuccessResponse:
+    SingleProjectResponse:
       type: object
       properties:
         project:


### PR DESCRIPTION
## Description

This PR involves replacing our custom serializers for error responses and instead this will allow us to instead send a standard error form that supports nested children

closes #73

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
