### PR TITLE
:recycle: Use a local DNS server for resolving domain names & replace default domain with `app.zaneops.local`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,7 +100,7 @@ You can open a new issue with this [issue form](https://github.com/zane-ops/zane
        # list all the dns servers
        sudo networksetup -getdnsservers Wi-Fi
        # Now add localhost as one dns server
-       sudo networksetup -setdnsservers Wi-Fi 127.0.0.1  # 1.1.1.1 8.8.8.8 8.8.4.4 # (optional) these 3 are cloudflare and google dns servers
+       sudo networksetup -setdnsservers Wi-Fi 127.0.0.1  1.1.1.1 8.8.8.8 8.8.4.4 # the last 3 servers are cloudflare and google dns servers
        ```
        The app should be available at https://app.zaneops.local.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,27 @@ You can open a new issue with this [issue form](https://github.com/zane-ops/zane
     python manage.py migrate
     ```
 
-6. Go to `/etc/hosts` and append this entry to that file :
+6. **Setting up the local domain for development :**
+   This step is for allowing you to access the app and generated domains locally
+   (for example when you create an app in the GUI), the generated domains will be
+   available at `<service-name-project-name>.zaneops.local`.
 
-    ```
-    127.0.0.1       zane.local 
-    ```
+    1. On a Mac, list all your network services :
 
-   The API will be available at [https://zane.local](https://zane.local).
+        ```shell
+        sudo networksetup -listallnetworkservices
+        ```
+
+    2. You will probably see `Wi-Fi` appear in the list of services,
+       if you are connected to it, you can add `127.0.0.1` the list of dns servers :
+
+       ```shell
+       # list all the dns servers
+       sudo networksetup -getdnsservers Wi-Fi
+       # Now add localhost as one dns server
+       sudo networksetup -setdnsservers Wi-Fi 127.0.0.1  # 1.1.1.1 8.8.8.8 8.8.4.4 # (optional) these 3 are cloudflare and google dns servers
+       ```
+       The app should be available at https://app.zaneops.local.
 
 7. **Open the source code and start rocking ! 😎**
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -35,21 +35,21 @@ CSRF_COOKIE_SECURE = env == PRODUCTION_ENV
 SESSION_COOKIE_SECURE = env == PRODUCTION_ENV
 REDIS_URL = os.environ.get("REDIS_URL", "redis://127.0.0.1:6381/0")
 
-## We will only support one root domain on production
-## And it will be in the format domain.com (without `http://` or `https://`)
-root_domain = os.environ.get("ROOT_DOMAIN")
-zane_app_domain = os.environ.get("ZANE_APP_DOMAIN")
-ROOT_DOMAIN = "zane.local" if root_domain is None else root_domain
-ZANE_APP_DOMAIN = ROOT_DOMAIN if zane_app_domain is None else zane_app_domain
+# We will only support one root domain on production
+# And it will be in the format domain.com (without `http://` or `https://`)
+ROOT_DOMAIN = os.environ.get("ROOT_DOMAIN", "zaneops.local")
+ZANE_APP_DOMAIN = os.environ.get("ZANE_APP_DOMAIN", "app.zaneops.local")
 ALLOWED_HOSTS = (
-    ["zane.local", "localhost", "127.0.0.1"] if root_domain is None else [root_domain]
+    [ZANE_APP_DOMAIN, "localhost", "127.0.0.1"]
+    if env != PRODUCTION_ENV
+    else [ZANE_APP_DOMAIN]
 )
 
-## This is necessary for making sure that CSRF protections work on production
+# This is necessary for making sure that CSRF protections work on production
 CSRF_TRUSTED_ORIGINS = (
-    ["http://zane.local", "https://zane.local"]
-    if root_domain is None
-    else [f"https://{root_domain}"]
+    [f"https://{ZANE_APP_DOMAIN}", f"http://{ZANE_APP_DOMAIN}"]
+    if env != PRODUCTION_ENV
+    else [f"https://{ZANE_APP_DOMAIN}"]
 )
 
 CACHES = {

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -335,10 +335,20 @@ class CreateDockerServiceAPIView(APIView):
 
                 if can_create_urls:
                     if len(service_urls_from_request) == 0:
-                        default_url = URL.objects.create(
+                        existing_urls = URL.objects.filter(
                             domain=f"{project.slug}-{service_slug}.{settings.ROOT_DOMAIN}",
                             base_path="/",
-                        )
+                        ).first()
+                        if existing_urls is None:
+                            default_url = URL.objects.create(
+                                domain=f"{project.slug}-{service_slug}.{settings.ROOT_DOMAIN}",
+                                base_path="/",
+                            )
+                        else:
+                            default_url = URL.objects.create(
+                                domain=f"{project.slug}-{service_slug}-{fake.slug()}.{settings.ROOT_DOMAIN}",
+                                base_path="/",
+                            )
                         service.urls.add(default_url)
                     else:
                         urls_to_create: list[URL] = []

--- a/docker/build-push-caddy-image.sh
+++ b/docker/build-push-caddy-image.sh
@@ -4,6 +4,10 @@ echo "Building zane-proxy..."
 docker buildx install
 docker buildx create --name zane_builder --config ./buildkit/buildkitd.toml --driver=docker-container
 echo password | docker login  --username=zane --password-stdin localhost:9989
-docker buildx build  --load -t localhost:9989/caddy:2.7.6-with-sablier -t fredkiss3/caddy-with-sablier ./proxy
-docker push localhost:9989/caddy:2.7.6-with-sablier
-docker push fredkiss3/caddy-with-sablier
+docker buildx build --push  \
+    -t fredkiss3/caddy-with-sablier:latest \
+    -t fredkiss3/caddy-with-sablier:v0.1.3 \
+    ./proxy
+#docker push localhost:9989/caddy:2.7.6-with-sablier
+#docker push fredkiss3/caddy-with-sablier:latest
+#docker push fredkiss3/caddy-with-sablier:v0.1.0

--- a/docker/dnsmasq/dnsmasq.conf
+++ b/docker/dnsmasq/dnsmasq.conf
@@ -1,0 +1,15 @@
+#listen on container interface
+listen-address=0.0.0.0
+interface=eth0
+user=root
+log-queries
+expand-hosts
+
+#only use these namesservers
+no-resolv
+server=1.1.1.1
+server=8.8.8.8
+server=8.8.4.4
+
+#static entries
+address=/zaneops.local/127.0.0.1

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,6 +1,14 @@
 version: "3.4"
 
 services:
+  dnsmasq:
+    image: andyshinn/dnsmasq
+    cap_add:
+      - NET_ADMIN
+    command: --log-facility=-
+    volumes:
+      - ./dnsmasq/dnsmasq.conf:/etc/dnsmasq.conf
+    network_mode: 'host'
   celery-worker:
     build:
       context: ../backend

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -8,7 +8,7 @@ RUN xcaddy build \
 
 FROM caddy:${CADDY_VERSION}
 
-ARG ZANE_HOST=zane.local
+ARG ZANE_HOST=app.zaneops.local
 ENV ZANE_HOST=$ZANE_HOST
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy

--- a/docker/start-docker-stack.sh
+++ b/docker/start-docker-stack.sh
@@ -28,7 +28,7 @@ for service in $services; do
 done
 
 # Wait until Ctrl+C is pressed
-echo "Server launched at http://zane.local"
+echo "Server launched at http://app.zaneops.local"
 echo "Press Ctrl+C to stop everything..."
 while true; do
   sleep 1

--- a/reset-db.sh
+++ b/reset-db.sh
@@ -46,7 +46,7 @@ echo "Deleting networks..."
 docker network rm $(docker network ls -q --filter label=zane-managed=true) 2>/dev/null
 
 echo "Resetting caddy config..."
-sed -i'.bak' "s#{{ZANE_HOST}}#zane.local#g" ./docker/proxy/default-caddy-config.json
+sed -i'.bak' "s#{{ZANE_HOST}}#app.zaneops.local#g" ./docker/proxy/default-caddy-config.json
 
 curl "http://localhost:2019/load" \
 	-H "Content-Type: application/json" \


### PR DESCRIPTION
## Description

This Pull Request adds a local DNS server for resolving zaneops domains, the benefit of this approach is the so that all  `*.zaneops.local` domains will points to `localhost` and we won't need to manually add entries to our localhost for them to work, It also allows us to better replicate the production behavior.  

This PR also changes the domain where the app is served from from `zane.local` to `app.zaneops.local`. 

> [!IMPORTANT]
> This is a pretty big change in how the DEV server is setup, so please follow the instructions [here](https://github.com/zane-ops/zane-ops/pull/85/files#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055R90-R105) to update your local setup, I only included instructions for MacOs only, if you don't use macOS, please reach out to us to update the contributions docs.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
