### PR TITLE
:recycle: Use a label for getting the `zane_proxy` service instead of calling the service by name

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -280,4 +280,3 @@ CELERY_RESULT_SERIALIZER = "json"
 CADDY_PROXY_ADMIN_HOST = os.environ.get(
     "CADDY_PROXY_ADMIN_HOST", "http://localhost:2019"
 )
-CADDY_PROXY_SERVICE = "zane_zane-proxy"

--- a/docker/docker-stack.yaml
+++ b/docker/docker-stack.yaml
@@ -19,6 +19,8 @@ services:
       placement:
         constraints:
           - node.role==manager
+      labels:
+        zane.role: "proxy"
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
## Description

This small PR makes calling the proxy service more reliable by using labels instead of calling the proxy service by name, this is so that we can call the service another name or since we will use docker-stack in production, the service name is not guaranteed to be the same.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
