### PR TITLE
:passport_control: Extend session if less than 2 days left and still logged-in

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -62,6 +62,7 @@ CACHES = {
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
 SESSION_EXPIRE_THRESHOLD = 2
+SESSION_EXTEND_PERIOD = 7
 # Application definition
 
 INSTALLED_APPS = [

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -61,7 +61,8 @@ CACHES = {
 }
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-
+# Only extend the session if the current expiry_date is less than 7 days from now
+SESSION_EXPIRE_THRESHOLD = 7
 # Application definition
 
 INSTALLED_APPS = [

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -61,8 +61,7 @@ CACHES = {
 }
 
 SESSION_ENGINE = "django.contrib.sessions.backends.cache"
-# Only extend the session if the current expiry_date is less than 7 days from now
-SESSION_EXPIRE_THRESHOLD = 7
+SESSION_EXPIRE_THRESHOLD = 2
 # Application definition
 
 INSTALLED_APPS = [

--- a/backend/zane_api/tests/auth.py
+++ b/backend/zane_api/tests/auth.py
@@ -101,7 +101,7 @@ class AuthMeViewTests(AuthAPITestCase):
     def test_authed_renew_session(self, mock_timezone: Mock):
         self.loginUser()
 
-        fixed_time = timezone.now() + timedelta(days=10)
+        fixed_time = timezone.now() + timedelta(days=13)
         mock_timezone.now.return_value = fixed_time
         response = self.client.get(reverse("zane_api:auth.me"))
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/backend/zane_api/tests/auth.py
+++ b/backend/zane_api/tests/auth.py
@@ -1,6 +1,10 @@
+from datetime import timedelta
+from unittest.mock import patch, Mock
+
 from django.contrib.auth.models import User
 from django.http import QueryDict
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.authtoken.models import Token
 
@@ -92,6 +96,16 @@ class AuthMeViewTests(AuthAPITestCase):
         self.assertIsNotNone(response.json().get("user"))
         user = response.json().get("user")
         self.assertEqual("Fredkiss3", user["username"])
+
+    @patch("zane_api.views.auth.timezone")
+    def test_authed_renew_session(self, mock_timezone: Mock):
+        self.loginUser()
+
+        fixed_time = timezone.now() + timedelta(days=10)
+        mock_timezone.now.return_value = fixed_time
+        response = self.client.get(reverse("zane_api:auth.me"))
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertIsNotNone(response.cookies.get("sessionid"))
 
     def test_authed_without_token_but_session(self):
         self.loginUser()

--- a/backend/zane_api/views/auth.py
+++ b/backend/zane_api/views/auth.py
@@ -1,7 +1,6 @@
 from datetime import timedelta
 
 from django.conf import settings
-from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import AnonymousUser
 from django.http import QueryDict
@@ -88,7 +87,7 @@ class AuthedView(APIView):
             now + timedelta(days=settings.SESSION_EXPIRE_THRESHOLD)
         ):
             request.session.set_expiry(
-                now + timedelta(seconds=settings.SESSION_COOKIE_AGE)
+                now + timedelta(seconds=settings.SESSION_EXTEND_PERIOD)
             )
 
         response = AuthedSuccessResponseSerializer({"user": request.user})

--- a/backend/zane_api/views/auth.py
+++ b/backend/zane_api/views/auth.py
@@ -1,9 +1,13 @@
+from datetime import timedelta
+
+from django.conf import settings
 from django.conf import settings
 from django.contrib.auth import authenticate, login, logout
 from django.contrib.auth.models import AnonymousUser
 from django.http import QueryDict
 from django.shortcuts import redirect
 from django.urls import reverse
+from django.utils import timezone
 from django.utils.decorators import method_decorator
 from django.utils.encoding import iri_to_uri
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -78,6 +82,15 @@ class AuthedView(APIView):
         operation_id="getAuthedUser",
     )
     def get(self, request: Request):
+        now = timezone.now()
+
+        if request.session.get_expiry_date() < (
+            now + timedelta(days=settings.SESSION_EXPIRE_THRESHOLD)
+        ):
+            request.session.set_expiry(
+                now + timedelta(seconds=settings.SESSION_COOKIE_AGE)
+            )
+
         response = AuthedSuccessResponseSerializer({"user": request.user})
         return Response(
             response.data,

--- a/frontend/src/components/helper/use-auth-user.tsx
+++ b/frontend/src/components/helper/use-auth-user.tsx
@@ -1,11 +1,19 @@
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "~/api/client";
 
+const THIRTY_MINUTES = 30 * 60 * 1000; // in milliseconds
+
 export function useAuthUser() {
   return useQuery({
     queryKey: ["AUTHED_USER"],
     queryFn: ({ signal }) => {
       return apiClient.GET("/api/auth/me/", { signal });
+    },
+    refetchInterval: (query) => {
+      if (query.state.data?.data?.user) {
+        return THIRTY_MINUTES;
+      }
+      return false;
     }
   });
 }

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -2878,7 +2878,6 @@ components:
         deployment_status_reason:
           type: string
           nullable: true
-          maxLength: 255
         url:
           type: string
           format: uri
@@ -3112,7 +3111,7 @@ components:
         timeout_seconds:
           type: integer
           minimum: 5
-          default: 300
+          default: 60
         interval_seconds:
           type: string
           default: '30'
@@ -3231,7 +3230,6 @@ components:
           type: string
       required:
       - success
-      - token
     LoginUsernameErrorComponent:
       type: object
       properties:


### PR DESCRIPTION
## Description

By default Django keep the session for 2 weeks without renewing it,  in this PR  we add the ability to extend the session for connected users when they request the user data from the client, if there is only less than 2 days left, the app will try to keep them connected for 7 more days.

I also added the code to keep refreshing the session on the client each 30 minutes to not loose the connection state.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
