### PR TITLE
Refactor/resource list and pagination

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd backend
-          pip install uv
+          pip install uv==0.1.0
           uv venv
           uv pip install -r requirements.txt
 

--- a/backend/zane_api/tests/project.py
+++ b/backend/zane_api/tests/project.py
@@ -45,6 +45,23 @@ class ProjectListViewTests(AuthAPITestCase):
         project_list = response.json().get("results", [])
         self.assertEqual(2, len(project_list))
 
+    def test_list_filter_slug(self):
+        owner = self.loginUser()
+
+        Project.objects.bulk_create(
+            [
+                Project(owner=owner, slug="gh-clone"),
+                Project(owner=owner, slug="gh-next"),
+                Project(owner=owner, slug="zaneops"),
+            ]
+        )
+        response = self.client.get(
+            reverse("zane_api:projects.list"), QUERY_STRING="slug=gh"
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        project_list = response.json().get("results", [])
+        self.assertEqual(2, len(project_list))
+
     def test_unauthed(self):
         response = self.client.get(reverse("zane_api:projects.list"))
         self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)

--- a/backend/zane_api/tests/project.py
+++ b/backend/zane_api/tests/project.py
@@ -480,7 +480,7 @@ class ProjectStatusViewTests(AuthAPITestCase):
         self.assertIsNotNone(statuses.get(thullo.id))
         thullo_status = statuses.get(thullo.id)
         self.assertEqual(0, thullo_status.get("healthy_services"))
-        self.assertEqual(0, thullo_status.get("unhealthy_services"))
+        self.assertEqual(0, thullo_status.get("total_services"))
 
     def test_with_succesful_deploy(self):
         owner = self.loginUser()
@@ -511,7 +511,7 @@ class ProjectStatusViewTests(AuthAPITestCase):
         self.assertIsNotNone(statuses.get(sandbox.id))
         project_status = statuses.get(sandbox.id)
         self.assertEqual(1, project_status.get("healthy_services"))
-        self.assertEqual(0, project_status.get("unhealthy_services"))
+        self.assertEqual(1, project_status.get("total_services"))
 
     def test_with_multiple_projects(self):
         owner = self.loginUser()
@@ -541,8 +541,8 @@ class ProjectStatusViewTests(AuthAPITestCase):
         statuses = response.json().get("projects", {})
         self.assertEqual(
             {
-                sandbox.id: {"healthy_services": 1, "unhealthy_services": 0},
-                sandbox2.id: {"healthy_services": 0, "unhealthy_services": 0},
+                sandbox.id: {"healthy_services": 1, "total_services": 1},
+                sandbox2.id: {"healthy_services": 0, "total_services": 0},
             },
             statuses,
         )
@@ -582,7 +582,7 @@ class ProjectStatusViewTests(AuthAPITestCase):
         project_status = statuses.get(sandbox.id)
 
         self.assertEqual(0, project_status.get("healthy_services"))
-        self.assertEqual(1, project_status.get("unhealthy_services"))
+        self.assertEqual(1, project_status.get("total_services"))
 
     def test_with_unhealthy_deployment(self):
         owner = self.loginUser()
@@ -621,4 +621,4 @@ class ProjectStatusViewTests(AuthAPITestCase):
         project_status = statuses.get(sandbox.id)
 
         self.assertEqual(0, project_status.get("healthy_services"))
-        self.assertEqual(1, project_status.get("unhealthy_services"))
+        self.assertEqual(1, project_status.get("total_services"))

--- a/backend/zane_api/views/base.py
+++ b/backend/zane_api/views/base.py
@@ -1,7 +1,12 @@
+from collections import OrderedDict
+
 from drf_standardized_errors.handler import ExceptionHandler
 from rest_framework import exceptions, status
 
 EMPTY_RESPONSE = {}
+EMPTY_PAGINATED_RESPONSE = OrderedDict(
+    [("count", 0), ("next", None), ("previous", None), ("results", [])]
+)
 
 
 class CustomThrottledException(exceptions.Throttled):

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -200,7 +200,7 @@ class ProjectStatusView(APIView):
 
                 project_statuses[project.id] = {
                     "healthy_services": healthy_services,
-                    "unhealthy_services": unhealthy_services,
+                    "total_services": healthy_services + unhealthy_services,
                 }
 
             serializer = ProjectStatusResponseSerializer({"projects": project_statuses})

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -12,7 +12,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from .base import EMPTY_RESPONSE, ResourceConflict
+from .base import EMPTY_RESPONSE, EMPTY_PAGINATED_RESPONSE, ResourceConflict
 from .serializers import (
     ProjectListPagination,
     ProjectListFilterSet,
@@ -46,6 +46,12 @@ class ProjectsListAPIView(ListCreateAPIView):
     filter_backends = [DjangoFilterBackend]
     filterset_class = ProjectListFilterSet
     queryset = Project.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        try:
+            return super().get(request, *args, **kwargs)
+        except exceptions.NotFound:
+            return Response(EMPTY_PAGINATED_RESPONSE)
 
     @extend_schema(
         request=ProjectCreateRequestSerializer,
@@ -207,6 +213,12 @@ class ArchivedProjectsListAPIView(ListAPIView):
     filter_backends = [DjangoFilterBackend]
     filterset_class = ArchivedProjectListFilterSet
     queryset = ArchivedProject.objects.all()
+
+    def get(self, request, *args, **kwargs):
+        try:
+            return super().get(request, *args, **kwargs)
+        except exceptions.NotFound:
+            return Response(EMPTY_PAGINATED_RESPONSE)
 
 
 class ProjectDetailsView(APIView):

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -297,6 +297,7 @@ class ProjectListFilterSet(django_filters.FilterSet):
             "slug": "name",
         },
     )
+    slug = django_filters.CharFilter(lookup_expr="icontains")
 
     class Meta:
         model = Project
@@ -310,6 +311,7 @@ class ArchivedProjectListFilterSet(django_filters.FilterSet):
             "slug": "name",
         },
     )
+    slug = django_filters.CharFilter(lookup_expr="icontains")
 
     class Meta:
         model = ArchivedProject

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -297,7 +297,7 @@ class ProjectListFilterSet(django_filters.FilterSet):
             "slug": "name",
         },
     )
-    slug = django_filters.CharFilter(lookup_expr="icontains")
+    slug = django_filters.CharFilter(lookup_expr="istartswith")
 
     class Meta:
         model = Project
@@ -311,7 +311,7 @@ class ArchivedProjectListFilterSet(django_filters.FilterSet):
             "slug": "name",
         },
     )
-    slug = django_filters.CharFilter(lookup_expr="icontains")
+    slug = django_filters.CharFilter(lookup_expr="istartswith")
 
     class Meta:
         model = ArchivedProject

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -331,7 +331,7 @@ class ProjectListPagination(pagination.PageNumberPagination):
 
 class ProjectStatusSerializer(serializers.Serializer):
     healthy_services = serializers.IntegerField(min_value=0)
-    unhealthy_services = serializers.IntegerField(min_value=0)
+    total_services = serializers.IntegerField(min_value=0)
 
 
 class ProjectStatusResponseSerializer(serializers.Serializer):

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -3788,12 +3788,12 @@ components:
         healthy_services:
           type: integer
           minimum: 0
-        unhealthy_services:
+        total_services:
           type: integer
           minimum: 0
       required:
       - healthy_services
-      - unhealthy_services
+      - total_services
     ProjectStatusResponse:
       type: object
       properties:


### PR DESCRIPTION
## Description

In this PR : 
- I fixed the `slug` filter in `/api/projects` & `/api/archived-projects` so that it returns the results if they starts with the slug provided
- I made it so that if an invalid page is sent to the paginated list of items in `/api/projects` & `/api/archived-projects` it returns an empty page instead of 404
- I also made the status endpoint (`/api/project/status-list`) returns the total number of services directly instead of the number of unhealthy services.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
