### PR TITLE
:bug: Check for non existing service & project

### DIFF
--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -1507,3 +1507,42 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             data=changes_payload,
         )
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+    def test_cannot_add_changes_on_nonexistant_projet(self):
+        owner = self.loginUser()
+        p = Project.objects.create(slug="zaneops", owner=owner)
+        service = DockerRegistryService.objects.create(slug="app", project=p)
+
+        changes_payload = {
+            "field": "image",
+            "type": "UPDATE",
+            "new_value": "ghcr.io/zane-ops/app",
+        }
+
+        response = self.client.post(
+            reverse(
+                "zane_api:services.docker.deployment_changes",
+                kwargs={"project_slug": "project", "service_slug": "app"},
+            ),
+            data=changes_payload,
+        )
+        self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
+
+    def test_cannot_add_changes_on_nonexistant_service(self):
+        owner = self.loginUser()
+        p = Project.objects.create(slug="zaneops", owner=owner)
+
+        changes_payload = {
+            "field": "image",
+            "type": "UPDATE",
+            "new_value": "ghcr.io/zane-ops/app",
+        }
+
+        response = self.client.post(
+            reverse(
+                "zane_api:services.docker.deployment_changes",
+                kwargs={"project_slug": p.slug, "service_slug": "app"},
+            ),
+            data=changes_payload,
+        )
+        self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)


### PR DESCRIPTION
## Description

This PR fixes a bug with the previous one, we forgot to check for existing project & service

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
