### PR TITLE
Feat: cancel pending deployment changes

### DIFF
--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -431,7 +431,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "new_value": "ghcr.io/zane-ops/app",
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -468,7 +468,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             },
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -506,7 +506,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "password": "bad",
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -545,7 +545,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "UPDATE",
             "new_value": self.fake_docker_client.NONEXISTANT_PRIVATE_IMAGE,
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -580,7 +580,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             },
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -608,7 +608,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "container_path": "/etc/logs/zane",
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -653,7 +653,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "item_id": v.id,
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -687,7 +687,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "host_path": "/etc/localtime",
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -713,7 +713,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "host_path": "/etc/localtime",
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -741,7 +741,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "host_path": "/etc/localtime",
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -768,7 +768,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "container_path": "/etc/logs/zane",
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -794,7 +794,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "host_path": "/etc/logs/zane",
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -826,7 +826,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             },
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -858,7 +858,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             },
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -883,7 +883,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             },
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -918,7 +918,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             },
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -950,7 +950,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             },
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -984,7 +984,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             },
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1018,7 +1018,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "DELETE",
             "item_id": port.id,
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1066,7 +1066,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "DELETE",
             "item_id": port.id,
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1105,7 +1105,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "ADD",
             "new_value": {"domain": "dcr.fredkiss.dev", "base_path": "/portainer"},
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1124,7 +1124,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "ADD",
             "new_value": {"domain": settings.ZANE_APP_DOMAIN},
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1147,7 +1147,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "ADD",
             "new_value": {"domain": "abc.gh.fredkiss.dev"},
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1166,7 +1166,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "ADD",
             "new_value": {"domain": f"*.{settings.ZANE_APP_DOMAIN}"},
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1196,7 +1196,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "ADD",
             "new_value": {"domain": "labs.idx.co"},
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1230,7 +1230,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "DELETE",
             "item_id": url.id,
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1276,7 +1276,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "type": "DELETE",
             "item_id": url.id,
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1300,7 +1300,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "item_id": url.id,
             "new_value": {"domain": "labs.idx.co"},
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1325,7 +1325,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "item_id": url.id,
             "new_value": {"domain": "labs.idx.co"},
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1369,7 +1369,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "forwarded": 3000,
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1395,7 +1395,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "interval_seconds": 5,
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1423,7 +1423,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "interval_seconds": 5,
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1459,7 +1459,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "interval_seconds": 5,
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1499,7 +1499,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
                 "interval_seconds": 5,
             },
         }
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
@@ -1519,7 +1519,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "new_value": "ghcr.io/zane-ops/app",
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": "project", "service_slug": "app"},
@@ -1538,7 +1538,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
             "new_value": "ghcr.io/zane-ops/app",
         }
 
-        response = self.client.post(
+        response = self.client.put(
             reverse(
                 "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -433,7 +433,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -470,7 +470,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -508,7 +508,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -547,7 +547,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -582,7 +582,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -610,7 +610,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -655,7 +655,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -689,7 +689,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -715,7 +715,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -743,7 +743,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -770,7 +770,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -796,7 +796,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -828,7 +828,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -860,7 +860,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -885,7 +885,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -920,7 +920,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -952,7 +952,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -986,7 +986,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1020,7 +1020,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1068,7 +1068,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1107,7 +1107,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1126,7 +1126,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1149,7 +1149,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1168,7 +1168,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1198,7 +1198,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1232,7 +1232,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1278,7 +1278,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1302,7 +1302,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1327,7 +1327,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1371,7 +1371,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1397,7 +1397,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1425,7 +1425,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1461,7 +1461,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1501,7 +1501,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
         }
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1521,7 +1521,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": "project", "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1540,7 +1540,7 @@ class DockerServiceDeploymentAddChangesViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse(
-                "zane_api:services.docker.deployment_changes",
+                "zane_api:services.docker.request_deployment_changes",
                 kwargs={"project_slug": p.slug, "service_slug": "app"},
             ),
             data=changes_payload,
@@ -1573,10 +1573,13 @@ class DockerServiceDeploymentCancelChangesViewTests(AuthAPITestCase):
 
         response = self.client.delete(
             reverse(
-                "zane_api:services.docker.deployment_changes",
-                kwargs={"project_slug": p.slug, "service_slug": "app"},
+                "zane_api:services.docker.cancel_deployment_changes",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": "app",
+                    "change_id": changes[0].id,
+                },
             ),
-            data={"change_id": changes[0].id},
         )
         self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
         change_count = DockerDeploymentChange.objects.filter(
@@ -1591,12 +1594,15 @@ class DockerServiceDeploymentCancelChangesViewTests(AuthAPITestCase):
 
         response = self.client.delete(
             reverse(
-                "zane_api:services.docker.deployment_changes",
-                kwargs={"project_slug": p.slug, "service_slug": "app"},
+                "zane_api:services.docker.cancel_deployment_changes",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": "app",
+                    "change_id": "val_123",
+                },
             ),
-            data={"change_id": "val_123"},
         )
-        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_404_NOT_FOUND, response.status_code)
 
     def test_cannot_cancel_a_change_that_sets_image_null(self):
         owner = self.loginUser()
@@ -1611,9 +1617,185 @@ class DockerServiceDeploymentCancelChangesViewTests(AuthAPITestCase):
 
         response = self.client.delete(
             reverse(
-                "zane_api:services.docker.deployment_changes",
-                kwargs={"project_slug": p.slug, "service_slug": "app"},
+                "zane_api:services.docker.cancel_deployment_changes",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": "app",
+                    "change_id": change.id,
+                },
             ),
-            data={"change_id": change.id},
         )
-        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual(status.HTTP_409_CONFLICT, response.status_code)
+
+    def test_cannot_cancel_port_change_if_healthcheck_path(
+        self,
+    ):
+        owner = self.loginUser()
+        p = Project.objects.create(slug="zaneops", owner=owner)
+        service = DockerRegistryService.objects.create(slug="app", project=p)
+        port_change, _, _ = DockerDeploymentChange.objects.bulk_create(
+            [
+                DockerDeploymentChange(
+                    field="ports",
+                    type=DockerDeploymentChange.ChangeType.ADD,
+                    new_value={"forwarded": 80},
+                    service=service,
+                ),
+                DockerDeploymentChange(
+                    field="healthcheck",
+                    type=DockerDeploymentChange.ChangeType.UPDATE,
+                    new_value={
+                        "type": "PATH",
+                        "value": "/",
+                        "timeout_seconds": 30,
+                        "interval_seconds": 5,
+                    },
+                    service=service,
+                ),
+                DockerDeploymentChange(
+                    field="image",
+                    type=DockerDeploymentChange.ChangeType.UPDATE,
+                    new_value="caddy:2.8-alpine",
+                    service=service,
+                ),
+            ]
+        )
+
+        response = self.client.delete(
+            reverse(
+                "zane_api:services.docker.cancel_deployment_changes",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": "app",
+                    "change_id": port_change.id,
+                },
+            ),
+        )
+        self.assertEqual(status.HTTP_409_CONFLICT, response.status_code)
+
+    def test_cannot_cancel_url_change_if_healthcheck_path(
+        self,
+    ):
+        owner = self.loginUser()
+        p = Project.objects.create(slug="zaneops", owner=owner)
+        service = DockerRegistryService.objects.create(slug="app", project=p)
+        url_change, _, _ = DockerDeploymentChange.objects.bulk_create(
+            [
+                DockerDeploymentChange(
+                    field="urls",
+                    type=DockerDeploymentChange.ChangeType.ADD,
+                    new_value={
+                        "domain": "portainer.com",
+                        "base_path": "/",
+                        "strip_prefix": True,
+                    },
+                    service=service,
+                ),
+                DockerDeploymentChange(
+                    field="healthcheck",
+                    type=DockerDeploymentChange.ChangeType.UPDATE,
+                    new_value={
+                        "type": "PATH",
+                        "value": "/",
+                        "timeout_seconds": 30,
+                        "interval_seconds": 5,
+                    },
+                    service=service,
+                ),
+                DockerDeploymentChange(
+                    field="image",
+                    type=DockerDeploymentChange.ChangeType.UPDATE,
+                    new_value="caddy:2.8-alpine",
+                    service=service,
+                ),
+            ]
+        )
+
+        changes_payload = {
+            "change_id": url_change.id,
+        }
+        response = self.client.delete(
+            reverse(
+                "zane_api:services.docker.cancel_deployment_changes",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": "app",
+                    "change_id": url_change.id,
+                },
+            ),
+        )
+        self.assertEqual(status.HTTP_409_CONFLICT, response.status_code)
+
+    def test_can_cancel_port_change_if_no_healthcheck_path_in_service(
+        self,
+    ):
+        owner = self.loginUser()
+        p = Project.objects.create(slug="zaneops", owner=owner)
+        service = DockerRegistryService.objects.create(slug="app", project=p)
+        port_change, _ = DockerDeploymentChange.objects.bulk_create(
+            [
+                DockerDeploymentChange(
+                    field="ports",
+                    type=DockerDeploymentChange.ChangeType.ADD,
+                    new_value={"forwarded": 80},
+                    service=service,
+                ),
+                DockerDeploymentChange(
+                    field="image",
+                    type=DockerDeploymentChange.ChangeType.UPDATE,
+                    new_value="caddy:2.8-alpine",
+                    service=service,
+                ),
+            ]
+        )
+
+        response = self.client.delete(
+            reverse(
+                "zane_api:services.docker.cancel_deployment_changes",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": "app",
+                    "change_id": port_change.id,
+                },
+            ),
+        )
+        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+
+    def test_can_cancel_url_change_if_no_healthcheck_path_in_service(
+        self,
+    ):
+        owner = self.loginUser()
+        p = Project.objects.create(slug="zaneops", owner=owner)
+        service = DockerRegistryService.objects.create(slug="app", project=p)
+        url_change, _ = DockerDeploymentChange.objects.bulk_create(
+            [
+                DockerDeploymentChange(
+                    field="urls",
+                    type=DockerDeploymentChange.ChangeType.ADD,
+                    new_value={
+                        "domain": "portainer.com",
+                        "base_path": "/",
+                        "strip_prefix": True,
+                    },
+                    service=service,
+                ),
+                DockerDeploymentChange(
+                    field="image",
+                    type=DockerDeploymentChange.ChangeType.UPDATE,
+                    new_value="caddy:2.8-alpine",
+                    service=service,
+                ),
+            ]
+        )
+
+        response = self.client.delete(
+            reverse(
+                "zane_api:services.docker.cancel_deployment_changes",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": "app",
+                    "change_id": url_change.id,
+                },
+            ),
+        )
+        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)

--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -54,10 +54,16 @@ urlpatterns = [
         name="services.docker.create",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/service-changes/docker"
+        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/request-service-changes/docker"
         r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/?$",
-        views.DockerServiceDeploymentChangesAPIView.as_view(),
-        name="services.docker.deployment_changes",
+        views.RequestDockerServiceDeploymentChangesAPIView.as_view(),
+        name="services.docker.request_deployment_changes",
+    ),
+    re_path(
+        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/cancel-service-changes/docker"
+        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/(?P<change_id>[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*)/?$",
+        views.CancelDockerServiceDeploymentChangesAPIView.as_view(),
+        name="services.docker.cancel_deployment_changes",
     ),
     re_path(
         r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/archive-service/docker"

--- a/backend/zane_api/views/base.py
+++ b/backend/zane_api/views/base.py
@@ -10,12 +10,12 @@ EMPTY_PAGINATED_RESPONSE = OrderedDict(
 )
 
 
-class CustomThrottledException(exceptions.Throttled):
+class ThrottledExceptionWithWaitTime(exceptions.Throttled):
     default_detail = "You made too Many requests in a short amount of time,"
-    extra_detail_plural = "Please wait for {wait} seconds before retrying your action."
     extra_detail_singular = (
         "Please wait for {wait} seconds before retrying your action."
     )
+    extra_detail_plural = extra_detail_singular
 
 
 class ResourceConflict(exceptions.APIException):
@@ -30,7 +30,7 @@ class ResourceConflict(exceptions.APIException):
 class CustomExceptionHandler(ExceptionHandler):
     def convert_known_exceptions(self, exc: Exception) -> Exception:
         if isinstance(exc, exceptions.Throttled):
-            return CustomThrottledException(wait=exc.wait)
+            return ThrottledExceptionWithWaitTime(wait=exc.wait)
         if isinstance(exc, exceptions.AuthenticationFailed):
             exc.status_code = status.HTTP_401_UNAUTHORIZED
         if (

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -33,7 +33,6 @@ from .serializers import (
     DockerCredentialsFieldChangeSerializer,
     HealthcheckFieldChangeSerializer,
     DockerDeploymentFieldChangeRequestSerializer,
-    CancelDockerDeploymentChangesResponseSerializer,
 )
 from ..models import (
     Project,
@@ -399,12 +398,12 @@ class RequestDockerServiceDeploymentChangesAPIView(APIView):
 
 
 class CancelDockerServiceDeploymentChangesAPIView(APIView):
-    serializer_class = CancelDockerDeploymentChangesResponseSerializer
-
     @extend_schema(
         responses={
             409: ErrorResponse409Serializer,
-            204: CancelDockerDeploymentChangesResponseSerializer,
+            204: inline_serializer(
+                name="CancelDockerServiveDeploymentChangesResponseSerializer", fields={}
+            ),
         },
         operation_id="cancelDeploymentChanges",
     )

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -302,7 +302,7 @@ class RequestDockerServiceDeploymentChangesAPIView(APIView):
         },
         operation_id="requestDeploymentChanges",
     )
-    def post(self, request: Request, project_slug: str, service_slug: str):
+    def put(self, request: Request, project_slug: str, service_slug: str):
         try:
             project = Project.objects.get(slug=project_slug.lower(), owner=request.user)
         except Project.DoesNotExist:

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -404,9 +404,7 @@ class CancelDockerServiceDeploymentChangesAPIView(APIView):
     @extend_schema(
         responses={
             409: ErrorResponse409Serializer,
-            204: inline_serializer(
-                name="CancelDockerServiveDeploymentChangesResponseSerializer", fields={}
-            ),
+            204: CancelDockerDeploymentChangesResponseSerializer,
         },
         operation_id="cancelDeploymentChanges",
     )

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -31,7 +31,11 @@ from ..models import (
     DockerDeployment,
     GitDeployment,
 )
-from ..serializers import ProjectSerializer, ArchivedProjectSerializer
+from ..serializers import (
+    ProjectSerializer,
+    ArchivedProjectSerializer,
+    ErrorResponse409Serializer,
+)
 from ..tasks import (
     delete_docker_resources_for_project,
     create_docker_resources_for_project,
@@ -117,6 +121,7 @@ class ProjectsListAPIView(ListCreateAPIView):
     @extend_schema(
         request=ProjectCreateRequestSerializer,
         responses={
+            409: ErrorResponse409Serializer,
             201: ProjectSerializer,
         },
         operation_id="createProject",

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -194,7 +194,7 @@ class DockerServiceCreateRequestSerializer(serializers.Serializer):
                     {
                         "healthcheck": {
                             "path": [
-                                f"healthcheck requires that at least one `url` or one `port` is provided"
+                                f"healthcheck requires that at least one `url` or one `port` is set in the service."
                             ]
                         }
                     }

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -823,7 +823,7 @@ class DockerCredentialsFieldChangeSerializer(BaseFieldChangeSerializer):
             if not do_image_exists:
                 raise serializers.ValidationError(
                     {
-                        "new_value": f"The credentials are invalid for the image `{snapshot.image}` is set for the service."
+                        "new_value": f"The credentials are invalid for the image `{snapshot.image}` set in the service."
                     }
                 )
         return attrs

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -823,7 +823,7 @@ class DockerCredentialsFieldChangeSerializer(BaseFieldChangeSerializer):
             if not do_image_exists:
                 raise serializers.ValidationError(
                     {
-                        "new_value": f"The credentials are invalid for the image `{snapshot.image}` provided for the service."
+                        "new_value": f"The credentials are invalid for the image `{snapshot.image}` is set for the service."
                     }
                 )
         return attrs
@@ -875,7 +875,7 @@ class HealthcheckFieldChangeSerializer(BaseFieldChangeSerializer):
             if len(snapshot.urls) == 0 and len(ports_exposed_to_http) == 0:
                 raise serializers.ValidationError(
                     {
-                        "new_value": f"healthcheck requires that at least one `url` or one `port` is provided"
+                        "new_value": f"healthcheck requires that at least one `url` or one `port` is set in the service."
                     }
                 )
         return attrs

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -895,12 +895,3 @@ class DockerDeploymentFieldChangeRequestSerializer(serializers.Serializer):
             "healthcheck",
         ],
     )
-
-
-# ====================================
-#   cancel Docker services changes   #
-# ====================================
-
-
-class CancelDockerDeploymentChangesResponseSerializer(serializers.Serializer):
-    pass

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -826,6 +826,12 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '201':
           content:
             application/json:
@@ -907,6 +913,96 @@ paths:
                     - code: throttled
                       detail: Request was throttled.
                       attr: null
+          description: ''
+        '204':
+          description: No response body
+  /api/projects/{project_slug}/cancel-service-changes/docker/{service_slug}/{change_id}/:
+    delete:
+      operationId: cancelDeploymentChanges
+      parameters:
+      - in: path
+        name: change_id
+        schema:
+          type: string
+          pattern: ^[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*$
+        required: true
+      - in: path
+        name: project_slug
+        schema:
+          type: string
+          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+        required: true
+      - in: path
+        name: service_slug
+        schema:
+          type: string
+          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+        required: true
+      tags:
+      - projects
+      security:
+      - cookieAuth: []
+      responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelDeploymentChangesErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
           description: ''
         '204':
           description: No response body
@@ -992,13 +1088,19 @@ paths:
                       detail: Request was throttled.
                       attr: null
           description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
         '201':
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/DockerService'
           description: ''
-  /api/projects/{project_slug}/service-changes/docker/{service_slug}/:
+  /api/projects/{project_slug}/request-service-changes/docker/{service_slug}/:
     post:
       operationId: requestDeploymentChanges
       parameters:
@@ -1802,6 +1904,13 @@ components:
           readOnly: true
       required:
       - user
+    CancelDeploymentChangesErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     CheckIfPortIsAvailableError:
       oneOf:
       - $ref: '#/components/schemas/CheckIfPortIsAvailableNonFieldErrorsErrorComponent'
@@ -3404,6 +3513,25 @@ components:
       - attr
       - code
       - detail
+    Error409:
+      type: object
+      properties:
+        code:
+          $ref: '#/components/schemas/Error409CodeEnum'
+        detail:
+          type: string
+        attr:
+          type: string
+          nullable: true
+      required:
+      - attr
+      - code
+      - detail
+    Error409CodeEnum:
+      enum:
+      - resource_conflict
+      type: string
+      description: '* `resource_conflict` - Resource Conflict'
     Error429:
       type: object
       properties:
@@ -3457,6 +3585,18 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Error404'
+      required:
+      - errors
+      - type
+    ErrorResponse409:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/ClientErrorEnum'
+        errors:
+          type: array
+          items:
+            $ref: '#/components/schemas/Error409'
       required:
       - errors
       - type
@@ -4346,6 +4486,7 @@ components:
           enum:
           - blank
           - invalid
+          - min_length
           - 'null'
           - null_characters_not_allowed
           - required
@@ -4354,6 +4495,7 @@ components:
           description: |-
             * `blank` - blank
             * `invalid` - invalid
+            * `min_length` - min_length
             * `null` - null
             * `null_characters_not_allowed` - null_characters_not_allowed
             * `required` - required

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -1101,7 +1101,7 @@ paths:
                 $ref: '#/components/schemas/DockerService'
           description: ''
   /api/projects/{project_slug}/request-service-changes/docker/{service_slug}/:
-    post:
+    put:
       operationId: requestDeploymentChanges
       parameters:
       - in: path


### PR DESCRIPTION
## Description

This PR builds on top of #106, this adds the ability to cancel pending changes.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
