### PR TITLE
:sparkles: Added blue-green deployments on caddy to allow for zero-downtime deployments

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -298,7 +298,7 @@ ZANE_APP_SERVICE_HOST_FROM_PROXY = (
     if ENVIRONMENT != PRODUCTION_ENV
     else "zane-api.zaneops.internal:8000"
 )
-ZANE_PRIVATE_DOMAIN = "zaneops.internal"
+ZANE_INTERNAL_DOMAIN = "zaneops.internal"
 
 DEFAULT_HEALTHCHECK_TIMEOUT = 30  # seconds
 DEFAULT_HEALTHCHECK_INTERVAL = 30  # seconds

--- a/backend/zane_api/docker_operations.py
+++ b/backend/zane_api/docker_operations.py
@@ -652,11 +652,26 @@ def get_caddy_request_for_url(
             }
         )
 
+    thirty_seconds_in_nano_seconds = 30_000_000_000
     proxy_handlers.append(
         {
             "flush_interval": -1,
             "handler": "reverse_proxy",
-            "upstreams": [{"dial": f"{service.network_alias}:{http_port.forwarded}"}],
+            "health_checks": {
+                "passive": {"fail_duration": thirty_seconds_in_nano_seconds}
+            },
+            "load_balancing": {
+                "retries": 3,
+                "selection_policy": {"policy": "first"},
+            },
+            "upstreams": [
+                {
+                    "dial": f"{service.network_alias}.blue.{settings.ZANE_INTERNAL_DOMAIN}:{http_port.forwarded}"
+                },
+                {
+                    "dial": f"{service.network_alias}.green.{settings.ZANE_INTERNAL_DOMAIN}:{http_port.forwarded}"
+                },
+            ],
         }
     )
     return {

--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -384,6 +384,9 @@ class DockerRegistryService(BaseService):
                                 forwarded=change.new_value.get("forwarded"),
                             )
                         )
+                        if is_http_port:
+                            added_new_http_port = True
+
                     if change.type == DockerDeploymentChange.ChangeType.DELETE:
                         self.ports.get(id=change.item_id).delete()
                     if change.type == DockerDeploymentChange.ChangeType.UPDATE:
@@ -398,9 +401,11 @@ class DockerRegistryService(BaseService):
                         port.forwarded = change.new_value.get("forwarded")
                         port.save()
 
+                        if is_http_port:
+                            added_new_http_port = True
+
         # Always recreate an URL if there is an http port
-        self.refresh_from_db()
-        if self.http_port is not None and self.urls.count() == 0:
+        if added_new_http_port and self.urls.count() == 0:
             self.urls.add(URL.create_default_url(service=self))
 
         self.unapplied_changes.update(applied=True, deployment=deployment)

--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -131,6 +131,14 @@ class BaseService(TimestampedModel):
     )
     network_alias = models.CharField(max_length=300, null=True, unique=True)
 
+    @property
+    def host_volumes(self):
+        return self.volumes.filter(host_path__isnull=False)
+
+    @property
+    def docker_volumes(self):
+        return self.volumes.filter(host_path__isnull=True)
+
     class Meta:
         abstract = True
         unique_together = (

--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -220,7 +220,7 @@ class DockerRegistryService(BaseService):
     def network_aliases(self):
         return (
             [
-                f"{self.network_alias}.{settings.ZANE_PRIVATE_DOMAIN}",
+                f"{self.network_alias}.{settings.ZANE_INTERNAL_DOMAIN}",
                 self.network_alias,
             ]
             if self.network_alias is not None
@@ -384,10 +384,6 @@ class DockerRegistryService(BaseService):
                                 forwarded=change.new_value.get("forwarded"),
                             )
                         )
-
-                        if is_http_port:
-                            added_new_http_port = True
-
                     if change.type == DockerDeploymentChange.ChangeType.DELETE:
                         self.ports.get(id=change.item_id).delete()
                     if change.type == DockerDeploymentChange.ChangeType.UPDATE:
@@ -402,10 +398,9 @@ class DockerRegistryService(BaseService):
                         port.forwarded = change.new_value.get("forwarded")
                         port.save()
 
-                        if is_http_port:
-                            added_new_http_port = True
-
-        if added_new_http_port and self.urls.count() == 0:
+        # Always recreate an URL if there is an http port
+        self.refresh_from_db()
+        if self.http_port is not None and self.urls.count() == 0:
             self.urls.add(URL.create_default_url(service=self))
 
         self.unapplied_changes.update(applied=True, deployment=deployment)
@@ -569,7 +564,7 @@ class DockerDeployment(BaseDeployment):
         aliases = []
         if self.service is not None and len(self.service.network_aliases) > 0:
             aliases = self.service.network_aliases + [
-                f"{self.service.network_alias}.{self.slot.lower()}.{settings.ZANE_PRIVATE_DOMAIN}",
+                f"{self.service.network_alias}.{self.slot.lower()}.{settings.ZANE_INTERNAL_DOMAIN}",
             ]
         return aliases
 

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -164,6 +164,7 @@ class DockerServiceDeploymentSerializer(ModelSerializer):
         model = models.DockerDeployment
         fields = [
             "is_current_production",
+            "slot",
             "created_at",
             "is_redeploy_of",
             "hash",

--- a/backend/zane_api/tasks.py
+++ b/backend/zane_api/tasks.py
@@ -132,7 +132,8 @@ def deploy_docker_service_with_changes(
                     create_docker_volume(corresponding_volume, service=service)
 
             if (
-                service.volumes.count() > 0 or service.ports.count() > 0
+                service.volumes.count() > 0
+                or service.ports.filter(host__isnull=False).count() > 0
             ) and latest_production_deploy is not None:
                 scale_down_service_deployment(latest_production_deploy)
 

--- a/healthcheck-strategy.md
+++ b/healthcheck-strategy.md
@@ -37,7 +37,7 @@ Should we ?
                 lb_policy first # always choose the first available service before the next
                 fail_duration 30s # How long to hold that a proxy is down
 
-                health_path /<healthcheck-path>
+                health_uri /<healthcheck-path>
                 health_status 2xx
                 health_interval <healthcheck-interval>s
                 health_timeout <healthcheck-timeout>s
@@ -56,7 +56,7 @@ Should we ?
   ?redirect_to=`<uri>`
 - [x] modify the `/api/login` to take into account the search param and redirect accordingly
 - [ ] add lock on monitor, to skip a monitor if it hasn't run yet
-- [ ] Remove all deployments url configs when archiving a service
+- [x] Remove all deployments url configs when archiving a service
 - [x] Pass user context in monitor task
 
 ### Other important things (in another PR)

--- a/healthcheck-strategy.md
+++ b/healthcheck-strategy.md
@@ -36,16 +36,10 @@ Should we ?
              reverse_proxy service-alias.blue.zaneops.internal service-alias.green.zaneops.internal {
                 lb_policy first # always choose the first available service before the next
                 fail_duration 30s # How long to hold that a proxy is down
-
-                health_uri /<healthcheck-path>
-                health_status 2xx
-                health_interval <healthcheck-interval>s
-                health_timeout <healthcheck-timeout>s
              }
           }
         }
        ```
-    3. If healthcheck has changed, we will modify the caddy proxy after we are sure that the new service is up.
     4. Caddy will always redirect to the first available upstream
 
 - [x] We also need to expose temporarily the deployment to an url that is reachable from the outside
@@ -55,7 +49,7 @@ Should we ?
 - [x] modify `/api/auth/me` to redirect to login page if `headers['accept']` contain `text/html`, with a search param
   ?redirect_to=`<uri>`
 - [x] modify the `/api/login` to take into account the search param and redirect accordingly
-- [ ] add lock on monitor, to skip a monitor if it hasn't run yet
+- [x] add lock on monitor, to skip a monitor if it hasn't run yet
 - [x] Remove all deployments url configs when archiving a service
 - [x] Pass user context in monitor task
 


### PR DESCRIPTION
## Description

This adds the zero-downtime deployment story on caddy, we do this by reverse proxying to the blue & green deployments on caddy, each request is retried 3 times to assure that they are really dead.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
