### PR TITLE
Feat: Redeployments of previous deployments

### DIFF
--- a/backend/zane_api/docker_operations.py
+++ b/backend/zane_api/docker_operations.py
@@ -459,7 +459,7 @@ def create_resources_for_docker_service_deployment(deployment: DockerDeployment)
                 f"ZANE_SERVICE_ID={service.id}",
                 f"ZANE_SERVICE_NAME={service.slug}",
                 f"ZANE_PROJECT_ID={service.project.id}",
-                f'ZANE_DEPLOYMENT_URL="{deployment.url or ""}"',
+                f"""ZANE_DEPLOYMENT_URL={deployment.url or '""'}""",
             ]
         )
 

--- a/backend/zane_api/docker_operations.py
+++ b/backend/zane_api/docker_operations.py
@@ -451,9 +451,15 @@ def create_resources_for_docker_service_deployment(deployment: DockerDeployment)
         # zane-specific-envs
         envs.extend(
             [
+                f"ZANE=1",
                 f"ZANE_DEPLOYMENT_SLOT={deployment.slot}",
                 f"ZANE_DEPLOYMENT_HASH={deployment.unprefixed_hash}",
                 f"ZANE_DEPLOYMENT_TYPE=docker",
+                f"ZANE_PRIVATE_DOMAIN={service.network_alias}",
+                f"ZANE_SERVICE_ID={service.id}",
+                f"ZANE_SERVICE_NAME={service.slug}",
+                f"ZANE_PROJECT_ID={service.project.id}",
+                f'ZANE_DEPLOYMENT_URL="{deployment.url or ""}"',
             ]
         )
 

--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -421,6 +421,7 @@ class DockerRegistryService(BaseService):
         self.refresh_from_db()
 
     def add_change(self, change: "DockerDeploymentChange"):
+        change.service = self
         match change.field:
             case "image" | "command" | "credentials" | "healthcheck":
                 change_for_field: "DockerDeploymentChange" = (

--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -306,11 +306,20 @@ class DockerRegistryService(BaseService):
                 ):
                     setattr(self, change.field, change.new_value)
                 case DockerDeploymentChange.ChangeField.CREDENTIALS:
+                    if change.new_value is None:
+                        self.credentials = None
+                        continue
                     self.credentials = {
                         "username": change.new_value.get("username"),
                         "password": change.new_value.get("password"),
                     }
                 case DockerDeploymentChange.ChangeField.HEALTHCHECK:
+                    if change.new_value is None:
+                        if self.healthcheck is not None:
+                            self.healthcheck.delete()
+                            self.healthcheck = None
+                        continue
+
                     if self.healthcheck is None:
                         self.healthcheck = HealthCheck()
 

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -2,6 +2,8 @@ import os
 
 from django.contrib.auth.models import User
 from django.db.models import TextChoices
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from drf_standardized_errors.openapi_serializers import ClientErrorEnum
 from rest_framework import serializers
 from rest_framework.serializers import *
@@ -158,7 +160,11 @@ class DockerServiceDeploymentSerializer(ModelSerializer):
         child=serializers.CharField(), read_only=True
     )
     service_snapshot = DockerServiceSerializer(allow_null=True)
-    is_redeploy_of = serializers.CharField(allow_null=True, read_only=True)
+    redeploy_hash = serializers.SerializerMethodField(allow_null=True)
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_redeploy_hash(self, obj: models.DockerDeployment):
+        return obj.is_redeploy_of.hash if obj.is_redeploy_of else None
 
     class Meta:
         model = models.DockerDeployment
@@ -166,7 +172,7 @@ class DockerServiceDeploymentSerializer(ModelSerializer):
             "is_current_production",
             "slot",
             "created_at",
-            "is_redeploy_of",
+            "redeploy_hash",
             "hash",
             "status",
             "status_reason",

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -161,6 +161,7 @@ class DockerServiceDeploymentSerializer(ModelSerializer):
     )
     service_snapshot = DockerServiceSerializer(allow_null=True)
     redeploy_hash = serializers.SerializerMethodField(allow_null=True)
+    changes = DockerDeploymentChangeSerializer(many=True, read_only=True)
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_redeploy_hash(self, obj: models.DockerDeployment):
@@ -179,4 +180,5 @@ class DockerServiceDeploymentSerializer(ModelSerializer):
             "url",
             "network_aliases",
             "service_snapshot",
+            "changes",
         ]

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -164,7 +164,7 @@ class DockerServiceDeploymentSerializer(ModelSerializer):
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_redeploy_hash(self, obj: models.DockerDeployment):
-        return obj.is_redeploy_of.hash if obj.is_redeploy_of else None
+        return obj.is_redeploy_of.hash if obj.is_redeploy_of is not None else None
 
     class Meta:
         model = models.DockerDeployment

--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -77,6 +77,12 @@ urlpatterns = [
         name="services.docker.deploy_service",
     ),
     re_path(
+        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/deploy-service/docker"
+        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
+        views.RedeployDockerServiceAPIView.as_view(),
+        name="services.docker.redeploy_service",
+    ),
+    re_path(
         r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/archive-service/docker"
         r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/?$",
         views.ArchiveDockerServiceAPIView.as_view(),

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -547,6 +547,9 @@ class RedeployDockerServiceAPIView(APIView):
         else:
             new_deployment.slot = DockerDeployment.DeploymentSlot.BLUE
 
+        if len(service.urls.all()) > 0:
+            new_deployment.url = f"{project.slug}-{service_slug}-docker-{new_deployment.unprefixed_hash}.{settings.ROOT_DOMAIN}"
+
         new_deployment.service_snapshot = DockerServiceSerializer(service).data
         new_deployment.save()
 

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -21,7 +21,10 @@ from rest_framework.views import APIView
 
 from . import EMPTY_PAGINATED_RESPONSE
 from .base import EMPTY_RESPONSE, ResourceConflict
-from .helpers import compute_docker_service_snapshot_without_changes
+from .helpers import (
+    compute_docker_service_snapshot_without_changes,
+    compute_docker_changes_from_snapshots,
+)
 from .serializers import (
     DockerServiceCreateRequestSerializer,
     DockerServiceDeploymentFilterSet,
@@ -445,6 +448,94 @@ class ApplyDockerServiceDeploymentChangesAPIView(APIView):
             new_deployment.url = f"{project.slug}-{service_slug}-docker-{new_deployment.unprefixed_hash}.{settings.ROOT_DOMAIN}"
 
         latest_deployment = service.latest_production_deployment
+        if (
+            latest_deployment is not None
+            and latest_deployment.slot == DockerDeployment.DeploymentSlot.BLUE
+            and latest_deployment.status != DockerDeployment.DeploymentStatus.FAILED
+            # 👆🏽 technically this can only be true for the initial deployment
+            # for the next deployments, when they fail, they will not be promoted to production
+        ):
+            new_deployment.slot = DockerDeployment.DeploymentSlot.GREEN
+        else:
+            new_deployment.slot = DockerDeployment.DeploymentSlot.BLUE
+
+        new_deployment.service_snapshot = DockerServiceSerializer(service).data
+        new_deployment.save()
+
+        token = Token.objects.get(user=request.user)
+        # Run celery deployment task
+        transaction.on_commit(
+            lambda: deploy_docker_service_with_changes.apply_async(
+                kwargs=dict(
+                    deployment_hash=new_deployment.hash,
+                    service_id=service.id,
+                    auth_token=token.key,
+                ),
+                task_id=new_deployment.task_id,
+            )
+        )
+
+        response = DockerServiceDeploymentSerializer(new_deployment)
+        return Response(response.data, status=status.HTTP_200_OK)
+
+
+class RedeployDockerServiceAPIView(APIView):
+    serializer_class = DockerServiceDeploymentSerializer
+
+    @transaction.atomic()
+    @extend_schema(
+        request=None,
+        operation_id="redeployDockerService",
+    )
+    def put(
+        self,
+        request: Request,
+        project_slug: str,
+        service_slug: str,
+        deployment_hash: str,
+    ):
+        try:
+            project = Project.objects.get(slug=project_slug.lower(), owner=request.user)
+        except Project.DoesNotExist:
+            raise exceptions.NotFound(
+                detail=f"A project with the slug `{project_slug}` does not exist"
+            )
+
+        service: DockerRegistryService = (
+            DockerRegistryService.objects.filter(
+                Q(slug=service_slug) & Q(project=project)
+            )
+            .select_related("project")
+            .prefetch_related("volumes", "ports", "urls", "env_variables", "changes")
+        ).first()
+
+        if service is None:
+            raise exceptions.NotFound(
+                detail=f"A service with the slug `{service_slug}`"
+                f" does not exist within the project `{project_slug}`"
+            )
+
+        try:
+            deployment = service.deployments.get(hash=deployment_hash)
+        except DockerDeployment.DoesNotExist:
+            raise exceptions.NotFound(
+                detail=f"A deployment with the hash `{deployment_hash}` does not exist for this service."
+            )
+
+        latest_deployment = service.latest_production_deployment
+
+        changes = compute_docker_changes_from_snapshots(
+            latest_deployment.service_snapshot, deployment.service_snapshot
+        )
+
+        for change in changes:
+            service.add_change(change)
+
+        new_deployment = DockerDeployment.objects.create(
+            service=service, is_redeploy_of=deployment
+        )
+        service.apply_pending_changes(deployment=new_deployment)
+
         if (
             latest_deployment is not None
             and latest_deployment.slot == DockerDeployment.DeploymentSlot.BLUE

--- a/backend/zane_api/views/helpers.py
+++ b/backend/zane_api/views/helpers.py
@@ -195,7 +195,7 @@ def compute_docker_changes_from_snapshots(current: dict, target: dict):
                             )
                         )
 
-                    # Check for additions
+                # Check for additions
                 for item_id in target_items:
                     if item_id not in current_items:
                         element = target_items[item_id]

--- a/backend/zane_api/views/helpers.py
+++ b/backend/zane_api/views/helpers.py
@@ -146,12 +146,24 @@ def compute_docker_changes_from_snapshots(current: dict, target: dict):
                     )
             case "healthcheck" | "credentials":
                 if current_value != target_value:
+                    if target_value is not None and isinstance(
+                        target_value, HealthCheckDto
+                    ):
+                        target_value.id = None
                     changes.append(
                         DockerDeploymentChange(
                             type=DockerDeploymentChange.ChangeType.UPDATE,
                             field=service_field.name,
-                            new_value=dataclasses.asdict(target_value),
-                            old_value=dataclasses.asdict(current_value),
+                            new_value=(
+                                dataclasses.asdict(target_value)
+                                if target_value is not None
+                                else None
+                            ),
+                            old_value=(
+                                dataclasses.asdict(current_value)
+                                if current_value is not None
+                                else None
+                            ),
                         )
                     )
             case _:
@@ -169,7 +181,7 @@ def compute_docker_changes_from_snapshots(current: dict, target: dict):
                                 type=DockerDeploymentChange.ChangeType.DELETE,
                                 field=service_field.name,
                                 item_id=item_id,
-                                old_value=dataclasses.asdict(current_value),
+                                old_value=dataclasses.asdict(current_items[item_id]),
                             )
                         )
                     elif current_items[item_id] != target_items[item_id]:

--- a/backend/zane_api/views/helpers.py
+++ b/backend/zane_api/views/helpers.py
@@ -1,9 +1,10 @@
-from dataclasses import dataclass, field
+import dataclasses
+from dataclasses import dataclass, field, fields
 from typing import Literal, Any, Optional, List, Dict
 
 from django.db.models import Q
 
-from ..models import DockerRegistryService, BaseDeploymentChange
+from ..models import DockerRegistryService, BaseDeploymentChange, DockerDeploymentChange
 from ..serializers import DockerServiceSerializer
 
 
@@ -27,7 +28,7 @@ def compute_docker_service_snapshot_with_changes(
 ):
     deployment_changes = compute_all_deployment_changes(service, change)
 
-    service_snapshot = DockerServiceSnapshot.from_serialized_data(
+    service_snapshot = DockerServiceSnapshot.from_dict(
         DockerServiceSerializer(service).data
     )
 
@@ -79,7 +80,7 @@ def compute_docker_service_snapshot_without_changes(
         service.unapplied_changes.filter(~Q(id=change_id)),
     )
 
-    service_snapshot = DockerServiceSnapshot.from_serialized_data(
+    service_snapshot = DockerServiceSnapshot.from_dict(
         DockerServiceSerializer(service).data
     )
 
@@ -121,6 +122,80 @@ def compute_docker_service_snapshot_without_changes(
                             )
 
     return service_snapshot
+
+
+def compute_docker_changes_from_snapshots(current: dict, target: dict):
+    current_snapshot = DockerServiceSnapshot.from_dict(current)
+    target_snapshot = DockerServiceSnapshot.from_dict(target)
+
+    changes: list[DockerDeploymentChange] = []
+
+    for service_field in fields(current_snapshot):
+        current_value = getattr(current_snapshot, service_field.name)
+        target_value = getattr(target_snapshot, service_field.name)
+        match service_field.name:
+            case "image" | "command":
+                if current_value != target_value:
+                    changes.append(
+                        DockerDeploymentChange(
+                            type=DockerDeploymentChange.ChangeType.UPDATE,
+                            field=service_field.name,
+                            new_value=target_value,
+                            old_value=current_value,
+                        )
+                    )
+            case "healthcheck" | "credentials":
+                if current_value != target_value:
+                    changes.append(
+                        DockerDeploymentChange(
+                            type=DockerDeploymentChange.ChangeType.UPDATE,
+                            field=service_field.name,
+                            new_value=dataclasses.asdict(target_value),
+                            old_value=dataclasses.asdict(current_value),
+                        )
+                    )
+            case _:
+                current_items: dict[
+                    str, VolumeDto | URLDto | EnvVariableDto | PortConfigurationDto
+                ] = {item.id: item for item in current_value}
+                target_items: dict[
+                    str, VolumeDto | URLDto | EnvVariableDto | PortConfigurationDto
+                ] = {item.id: item for item in target_value}
+
+                for item_id in current_items:
+                    if item_id not in target_items:
+                        changes.append(
+                            DockerDeploymentChange(
+                                type=DockerDeploymentChange.ChangeType.DELETE,
+                                field=service_field.name,
+                                item_id=item_id,
+                                old_value=dataclasses.asdict(current_value),
+                            )
+                        )
+                    elif current_items[item_id] != target_items[item_id]:
+                        changes.append(
+                            DockerDeploymentChange(
+                                type=DockerDeploymentChange.ChangeType.UPDATE,
+                                field=service_field.name,
+                                item_id=item_id,
+                                new_value=dataclasses.asdict(target_items[item_id]),
+                                old_value=dataclasses.asdict(current_items[item_id]),
+                            )
+                        )
+
+                    # Check for additions
+                for item_id in target_items:
+                    if item_id not in current_items:
+                        element = target_items[item_id]
+                        element.id = None
+                        changes.append(
+                            DockerDeploymentChange(
+                                type=DockerDeploymentChange.ChangeType.ADD,
+                                field=service_field.name,
+                                new_value=dataclasses.asdict(element),
+                            )
+                        )
+    return changes
 
 
 @dataclass
@@ -237,7 +312,7 @@ class DockerServiceSnapshot:
         )
 
     @classmethod
-    def from_serialized_data(cls, data: Dict[str, Any]) -> "DockerServiceSnapshot":
+    def from_dict(cls, data: Dict[str, Any]) -> "DockerServiceSnapshot":
         volumes = [VolumeDto.from_dict(item) for item in data.get("volumes", [])]
         urls = [URLDto.from_dict(item) for item in data.get("urls", [])]
         ports = [PortConfigurationDto.from_dict(item) for item in data.get("ports", [])]

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -2998,7 +2998,13 @@ components:
           allOf:
           - $ref: '#/components/schemas/DockerService'
           nullable: true
+        changes:
+          type: array
+          items:
+            $ref: '#/components/schemas/DockerDeploymentChange'
+          readOnly: true
       required:
+      - changes
       - created_at
       - hash
       - is_current_production

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -1182,6 +1182,94 @@ paths:
               schema:
                 $ref: '#/components/schemas/DockerServiceDeployment'
           description: ''
+  /api/projects/{project_slug}/deploy-service/docker/{service_slug}/{deployment_hash}/:
+    put:
+      operationId: redeployDockerService
+      parameters:
+      - in: path
+        name: deployment_hash
+        schema:
+          type: string
+          pattern: ^[a-zA-Z0-9-_]+$
+        required: true
+      - in: path
+        name: project_slug
+        schema:
+          type: string
+          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+        required: true
+      - in: path
+        name: service_slug
+        schema:
+          type: string
+          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+        required: true
+      tags:
+      - projects
+      security:
+      - cookieAuth: []
+      responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RedeployDockerServiceErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DockerServiceDeployment'
+          description: ''
   /api/projects/{project_slug}/request-service-changes/docker/{service_slug}/:
     put:
       operationId: requestDeploymentChanges
@@ -2878,11 +2966,13 @@ components:
       properties:
         is_current_production:
           type: boolean
+        slot:
+          $ref: '#/components/schemas/SlotEnum'
         created_at:
           type: string
           format: date-time
           readOnly: true
-        is_redeploy_of:
+        redeploy_hash:
           type: string
           readOnly: true
           nullable: true
@@ -2912,9 +3002,10 @@ components:
       - created_at
       - hash
       - is_current_production
-      - is_redeploy_of
       - network_aliases
+      - redeploy_hash
       - service_snapshot
+      - slot
       - status
       - status_reason
       - url
@@ -3739,6 +3830,13 @@ components:
         propertyName: type
         mapping:
           client_error: '#/components/schemas/ParseErrorResponse'
+    RedeployDockerServiceErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
     RequestDeploymentChangesError:
       oneOf:
       - $ref: '#/components/schemas/RequestDeploymentChangesNonFieldErrorsErrorComponent'
@@ -4427,6 +4525,14 @@ components:
           type: integer
       required:
       - forwarded
+    SlotEnum:
+      enum:
+      - BLUE
+      - GREEN
+      type: string
+      description: |-
+        * `BLUE` - Blue
+        * `GREEN` - Green
     StatusEnum:
       enum:
       - QUEUED


### PR DESCRIPTION
## Description

This is the last PR to finish #44, in this PR, we implement the ability to redeploy old deployments and bring state of the service to the one at the point of the chosen deployment.

closes #44

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
