### PR TITLE
Chore: Updated setup scripts and contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,18 @@ You can open a new issue with this [issue form](https://github.com/zane-ops/zane
 
 3. **Start the project**
 
+   Start the DEV server for docker and the frontend :
     ```shell
     make dev
     # or
-    pnpm -r --parallel run dev
+    pnpm run  --filter='!backend' --recursive --parallel dev
+    ```
+
+   You need to wait for the text `Server launched at http://app.zaneops.local` then, Start the DEV server for the API :
+    ```shell
+    make dev-api
+    # or
+	pnpm run  --filter='backend' --recursive dev
     ```
 
 4. **Run DB migrations :**
@@ -119,18 +127,20 @@ You can open a new issue with this [issue form](https://github.com/zane-ops/zane
 
    The app should be available at https://app.zaneops.local.
 
+## 🛠️ Debugging
 
-##  🛠️ Debugging 
-   You may end up having issues where the project is not working, the app is not reachable on the browser, or the API seems to be down, this section is to help debugging this case, if the app is working fine on your end, you don't need to read this section.
+You may end up having issues where the project is not working, the app is not reachable on the browser, or the API seems
+to be down, this section is to help debugging this case, if the app is working fine on your end, you don't need to read
+this section.
 
-   1. make sure you ran `make dev` and it didn't exit unexpectedly 
-   2. make sure that all the containers are up, you can check it in your docker tool of choice, orbstack or docker desktop 
+1. make sure you ran `make dev` and it didn't exit unexpectedly
+2. make sure that all the containers are up, you can check it in your docker tool of choice, orbstack or docker desktop
    ![illustration](./images/illustration.webp)
-   3. make sure that the API is launched, and that no error is in thrown in the terminal where `make dev` is running
-   4. make sure to run `nslookup` as stated in the previous section detailling how to setup the local domain
-   5. make sure to setup the project and install the packages with `make setup`
-   6. If the app is still unresponsive, run `make reset-db` However, it's crucial to note that this action will completely erase all data in the database and reset the project to its initial state.
-
+3. make sure that the API is launched, and that no error is in thrown in the terminal where `make dev` is running
+4. make sure to run `nslookup` as stated in the previous section detailling how to setup the local domain
+5. make sure to setup the project and install the packages with `make setup`
+6. If the app is still unresponsive, run `make reset-db` However, it's crucial to note that this action will completely
+   erase all data in the database and reset the project to its initial state.
 
 ## 🧐 Project structure
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ help: ### Show this help
 
 setup: ### Initial setup of the project
 	echo 'Creating a virtual env...'
+	docker network create --driver overlay zane || true
 	python3 -m venv ./backend/venv
 	echo 'activating the virtualenv...'
 	chmod a+x ./backend/venv/bin/activate
@@ -20,7 +21,10 @@ migrate: ### Run db migration
 	python ./backend/manage.py migrate
 
 dev: ### Start the DEV server
-	pnpm --recursive --parallel run dev
+	pnpm run  --filter='!backend' --recursive --parallel dev
+
+dev-api: ### Start the API server
+	pnpm run  --filter='backend' --recursive dev
 
 reset-db: ### Wipe out the database and reset the application to its initial state
 	chmod a+x reset-db.sh

--- a/docker/attach-proxy-networks.sh
+++ b/docker/attach-proxy-networks.sh
@@ -1,22 +1,11 @@
 #!/bin/bash
 
 echo "Attaching saved networks to the proxy..."
-# Service name or ID
-service_name="zane_zane-proxy"
-
-# File containing the new network IDs
-file=".proxy_attached_networks"
-
-if [ ! -f $file ]; then
-    echo "No saved network found."
-    exit 0
-fi
-
-# Read and prepare network IDs from the file
-while read p; do
-  net_id=$(echo $p | sed 's/"//g')
-  if [ -n "$net_id" ]; then
-   docker service update --network-add $net_id $service_name
+network_ids=$(docker network ls --filter "label=zane-managed=true" -q)
+for network_id in $network_ids;
+do
+  if [ -n "$network_id" ]; then
+    docker service update --network-add "$network_id" zane_zane-proxy
   fi
-done <$file
+done
 

--- a/docker/docker-stack.yaml
+++ b/docker/docker-stack.yaml
@@ -47,5 +47,3 @@ volumes:
 networks:
   zane:
     external: true
-    # This network is created like this :
-    # `docker network create --driver overlay --attachable --subnet=10.5.0.0/16 zane`

--- a/docker/stop-docker-stack.sh
+++ b/docker/stop-docker-stack.sh
@@ -1,21 +1,13 @@
 #!/bin/bash
-
-echo "Saving networks attached to the proxy..."
-network_id=$(docker network inspect zane_default -f '{{.ID}}')
-docker service inspect zane_zane-proxy  | jq --arg network_id "$network_id" '.[].Spec.TaskTemplate.Networks[] | select(.Target != $network_id) | .Target'  > .proxy_attached_networks
-
 echo "Removing the proxy and the docker-compose stack..."
 docker stack rm zane && docker-compose down --remove-orphans
 
 echo "Scaling down all zane-ops services..."
-services=$(docker service ls  --filter "mode=replicated" --filter "label=zane-managed=true" --format '{{.Name}} {{.Replicas}}' | awk '$2!="0/0" {print $1}')
+services=$(docker service ls --filter "label=zane-managed=true" --format "{{.ID}}")
 echo "$services" | while IFS= read -r service; do
   if [[ -n "$service" ]]; then
     echo "Scaling down service: $service"
     docker service scale --detach $service=0
-    # Add your commands for each service here
   fi
 done
-echo "$services" > .alive_services
-
 echo "Done undeploying the stack"


### PR DESCRIPTION
## Description

In this PR, I made some modifications about how we start and setup the dev server, as it made starting the DEV server flaky, with the new changes, the dev server should start without any issue now, I also updated the contribution docs to reflect the changes. 

Now to start the dev server, you need to run 2 commands instead of one : 
 
```shell
# Start the DEV server for docker and the frontend
make dev
# Wait for the text `Server launched at http://app.zaneops.local` 
# then, Start the DEV server for the API :
make dev-api
```

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
