### PR TITLE
💄 use `Link` components instead of `a` tag in 404 pages

### DIFF
--- a/frontend/src/routes/__root.tsx
+++ b/frontend/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { Outlet, createRootRoute } from "@tanstack/react-router";
+import { Link, Outlet, createRootRoute } from "@tanstack/react-router";
 import { TanStackRouterDevtools } from "@tanstack/router-devtools";
 import { Logo } from "~/components/logo";
 import { MetaTitle } from "~/components/meta-title";
@@ -32,9 +32,9 @@ function NotFound() {
           <h1 className="text-3xl font-bold">Error 404</h1>
           <p className="text-lg">Looks like you're lost 😛</p>
         </div>
-        <a href="/">
+        <Link to="/">
           <Button>Go home</Button>
-        </a>
+        </Link>
       </div>
     </>
   );

--- a/frontend/src/routes/_dashboard/project.$slug.tsx
+++ b/frontend/src/routes/_dashboard/project.$slug.tsx
@@ -88,9 +88,9 @@ function ProjectDetail() {
                 <h1 className="text-3xl font-bold">Error 404</h1>
                 <p className="text-lg">This project does not exist</p>
               </div>
-              <a href="/">
+              <Link to="/">
                 <Button>Go home</Button>
-              </a>
+              </Link>
             </div>
           </section>
         </>


### PR DESCRIPTION
## Description

Use `Link` components instead of `a` tag in 404 pages.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
