### PR TITLE
Fix: Delete all service logs after archiving a service

### DIFF
--- a/backend/zane_api/tasks.py
+++ b/backend/zane_api/tasks.py
@@ -32,6 +32,7 @@ from .models import (
     ArchivedProject,
     ArchivedDockerService,
     DockerDeploymentChange,
+    SimpleLog,
 )
 from .utils import cache_lock, LockAcquisitionError, find_item_in_list
 from .views.helpers import URLDto
@@ -312,7 +313,7 @@ def delete_docker_resources_for_project(archived_project_id: int):
     retry_kwargs={"max_retries": 3, "countdown": 5},
 )
 def delete_resources_for_docker_service(archived_service_id: id):
-    archived_service = (
+    archived_service: ArchivedDockerService = (
         ArchivedDockerService.objects.filter(id=archived_service_id)
         .select_related("project")
         .prefetch_related("volumes", "urls")
@@ -323,6 +324,7 @@ def delete_resources_for_docker_service(archived_service_id: id):
         )
     unexpose_docker_service_from_http(archived_service)
     cleanup_docker_service_resources(archived_service)
+    SimpleLog.objects.filter(service_id=archived_service.original_id).delete()
 
 
 @shared_task

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -149,7 +149,7 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
         self.assertIsNotNone(log.service_id)
 
 
-class LogStreamViewTests(AuthAPITestCase):
+class SimpleLogViewTests(AuthAPITestCase):
     sample_log_contents = [
         (
             datetime.datetime(2024, 6, 30, 21, 52, 43, tzinfo=datetime.timezone.utc),

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from rest_framework import status
 
 from .base import AuthAPITestCase
-from ..models import SimpleLog, DockerDeployment
+from ..models import SimpleLog, DockerDeployment, DockerRegistryService
 
 
 class SimpleLogCollectViewTests(AuthAPITestCase):
@@ -197,7 +197,7 @@ class LogStreamViewTests(AuthAPITestCase):
         p, service = self.create_and_deploy_redis_docker_service()
         deployment: DockerDeployment = service.deployments.first()
 
-        simple_logs = SimpleLog.objects.bulk_create(
+        SimpleLog.objects.bulk_create(
             [
                 SimpleLog(
                     time=time,
@@ -232,7 +232,7 @@ class LogStreamViewTests(AuthAPITestCase):
         p, service = self.create_and_deploy_redis_docker_service()
         deployment: DockerDeployment = service.deployments.first()
 
-        simple_logs = SimpleLog.objects.bulk_create(
+        SimpleLog.objects.bulk_create(
             [
                 SimpleLog(
                     time=time,
@@ -270,7 +270,7 @@ class LogStreamViewTests(AuthAPITestCase):
         p, service = self.create_and_deploy_redis_docker_service()
         deployment: DockerDeployment = service.deployments.first()
 
-        simple_logs = SimpleLog.objects.bulk_create(
+        SimpleLog.objects.bulk_create(
             [
                 SimpleLog(
                     time=time,
@@ -307,3 +307,36 @@ class LogStreamViewTests(AuthAPITestCase):
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(2, len(response.json()["results"]))
+
+    def test_delete_logs_after_archiving_a_service(self):
+        p, service = self.create_and_deploy_redis_docker_service()
+        deployment: DockerDeployment = service.deployments.first()
+
+        SimpleLog.objects.bulk_create(
+            [
+                SimpleLog(
+                    time=time,
+                    content=content,
+                    service_id=service.id,
+                    deployment_id=deployment.hash,
+                    source=SimpleLog.LogSource.SERVICE,
+                    level=SimpleLog.LogLevel.INFO,
+                )
+                for (time, content) in enumerate(self.sample_log_contents)
+            ]
+        )
+
+        response = self.client.delete(
+            reverse(
+                "zane_api:services.docker.archive",
+                kwargs={"project_slug": p.slug, "service_slug": service.slug},
+            ),
+        )
+        self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
+        deleted_service = DockerRegistryService.objects.filter(
+            slug=service.slug
+        ).first()
+        self.assertIsNone(deleted_service)
+
+        logs_for_service = SimpleLog.objects.filter(service_id=service.id).count()
+        self.assertEqual(0, len(logs_for_service))

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -201,7 +201,7 @@ class LogStreamViewTests(AuthAPITestCase):
         p, service = self.create_and_deploy_redis_docker_service()
         deployment: DockerDeployment = service.deployments.first()
 
-        SimpleLog.objects.bulk_create(
+        simple_logs = SimpleLog.objects.bulk_create(
             [
                 SimpleLog(
                     time=time,

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -322,7 +322,7 @@ class LogStreamViewTests(AuthAPITestCase):
                     source=SimpleLog.LogSource.SERVICE,
                     level=SimpleLog.LogLevel.INFO,
                 )
-                for (time, content) in enumerate(self.sample_log_contents)
+                for (time, content) in self.sample_log_contents
             ]
         )
 

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -339,4 +339,4 @@ class LogStreamViewTests(AuthAPITestCase):
         self.assertIsNone(deleted_service)
 
         logs_for_service = SimpleLog.objects.filter(service_id=service.id).count()
-        self.assertEqual(0, len(logs_for_service))
+        self.assertEqual(0, logs_for_service)


### PR DESCRIPTION
## Description

In this PR, we make it so that logs are deleted after archiving a service, as we don't need them anymore.  However to delete logs, we don't do it in the `archive` endpoint directly, but after deleting the service in docker within the worker, this is because the service might still be up and send logs if we delete it directly, we will need to make sure the service is down before deleting all the logs it could produce. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
