### PR TITLE
:bug: replace `"` with `\"` character when searching for content in logs

### DIFF
--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -191,6 +191,10 @@ class LogStreamViewTests(AuthAPITestCase):
             datetime.datetime(2024, 6, 30, 21, 52, 22, tzinfo=datetime.timezone.utc),
             '10.0.8.103 - - [30/Jun/2024:21:52:22 +0000] "GET / HTTP/1.1" 200 12127 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0" "10.0.0.2"',
         ),
+        (
+            datetime.datetime(2024, 6, 30, 21, 52, 22, tzinfo=datetime.timezone.utc),
+            '10.0.8.103 - - [30/Jun/2024:21:52:22 +0000] "POST / HTTP/1.1" 200 12127 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:127.0) Gecko/20100101 Firefox/127.0" "10.0.0.2"',
+        ),
     ]
 
     def test_view_logs(self):
@@ -226,7 +230,7 @@ class LogStreamViewTests(AuthAPITestCase):
             ),
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        self.assertEqual(10, len(response.json()["results"]))
+        self.assertEqual(len(simple_logs), len(response.json()["results"]))
 
     def test_paginate(self):
         p, service = self.create_and_deploy_redis_docker_service()
@@ -307,3 +311,35 @@ class LogStreamViewTests(AuthAPITestCase):
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(2, len(response.json()["results"]))
+
+    def test_quote_in_query(self):
+        p, service = self.create_and_deploy_redis_docker_service()
+        deployment: DockerDeployment = service.deployments.first()
+
+        SimpleLog.objects.bulk_create(
+            [
+                SimpleLog(
+                    time=time,
+                    content=content,
+                    service_id=service.id,
+                    deployment_id=deployment.hash,
+                    source=SimpleLog.LogSource.SERVICE,
+                    level=SimpleLog.LogLevel.INFO,
+                )
+                for (time, content) in self.sample_log_contents
+            ]
+        )
+
+        response = self.client.get(
+            reverse(
+                "zane_api:services.docker.deployment_logs",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": service.slug,
+                    "deployment_hash": deployment.hash,
+                },
+            ),
+            QUERY_STRING=f"content=%2B0000%5D%20%22POST",  # searching for `+0000] "POST`
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(1, len(response.json()["results"]))

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -894,9 +894,7 @@ class DockerContainerLogsResponseSerializer(serializers.Serializer):
 
 class DeploymentLogsFilterSet(django_filters.FilterSet):
     time = django_filters.DateTimeFromToRangeFilter()
-    content = django_filters.CharFilter(
-        lookup_expr="icontains", method="filter_content"
-    )
+    content = django_filters.CharFilter(method="filter_content")
 
     def filter_content(self, queryset: QuerySet, name: str, value: str):
         # construct the full lookup expression.

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -5,7 +5,7 @@ from typing import Any
 import django_filters
 from django.conf import settings
 from django.core.exceptions import ValidationError
-from django.db.models import Q
+from django.db.models import Q, QuerySet
 from django.utils.translation import gettext_lazy as _
 from django_filters import OrderingFilter
 from rest_framework import pagination
@@ -894,7 +894,14 @@ class DockerContainerLogsResponseSerializer(serializers.Serializer):
 
 class DeploymentLogsFilterSet(django_filters.FilterSet):
     time = django_filters.DateTimeFromToRangeFilter()
-    content = django_filters.CharFilter(lookup_expr="icontains")
+    content = django_filters.CharFilter(
+        lookup_expr="icontains", method="filter_content"
+    )
+
+    def filter_content(self, queryset: QuerySet, name: str, value: str):
+        # construct the full lookup expression.
+        lookup = f"{name}__icontains"
+        return queryset.filter(**{lookup: value.replace('"', '\\"')})
 
     class Meta:
         model = SimpleLog


### PR DESCRIPTION
## Description

Since logs are saved as JSON values, `"` is escaped, so we need to do the same when searching for logs containing it.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
