### PR TITLE
Fix: delete old url entries when modifying an URL

### DIFF
--- a/backend/zane_api/tasks.py
+++ b/backend/zane_api/tasks.py
@@ -248,8 +248,12 @@ def cleanup_docker_resources_for_deployment(
         map(
             lambda change: URLDto.from_dict(change.old_value),
             new_deployment.changes.filter(
-                field=DockerDeploymentChange.ChangeField.URLS,
-                type=DockerDeploymentChange.ChangeType.DELETE,
+                Q(field=DockerDeploymentChange.ChangeField.URLS)
+                & Q(old_value__isnull=False)
+                & (
+                    Q(type=DockerDeploymentChange.ChangeType.DELETE)
+                    | Q(type=DockerDeploymentChange.ChangeType.UPDATE)
+                ),
             ),
         )
     )

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -25,6 +25,7 @@ from ..models import (
     HealthCheck,
     DockerEnvVariable,
 )
+from ..serializers import DockerServiceSerializer
 from ..views.helpers import URLDto
 
 
@@ -2937,6 +2938,7 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
                 "base_path": "/config",
                 "strip_prefix": False,
             },
+            old_value=DockerServiceSerializer(service).data.get("urls")[0],
             service=service,
         )
 
@@ -2959,7 +2961,7 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
             other_changes=[
                 DockerDeploymentChange(
                     field=DockerDeploymentChange.ChangeField.URLS,
-                    type=DockerDeploymentChange.ChangeType.UPDATE,
+                    type=DockerDeploymentChange.ChangeType.ADD,
                     new_value={
                         "domain": "proxy.fredkiss.dev",
                         "base_path": "/",
@@ -2971,15 +2973,16 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
 
         url: URL = service.urls.first()
 
-        change = DockerDeploymentChange.objects.create(
+        DockerDeploymentChange.objects.create(
             field=DockerDeploymentChange.ChangeField.URLS,
             type=DockerDeploymentChange.ChangeType.UPDATE,
             item_id=url.id,
             new_value={
                 "domain": "proxy.fredkiss.dev",
-                "base_path": "/config",
+                "base_path": "/",
                 "strip_prefix": True,
             },
+            old_value=DockerServiceSerializer(service).data.get("urls")[0],
             service=service,
         )
 

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -2953,6 +2953,49 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
         mock.assert_called()
         mock.assert_called_with([URLDto.from_dict(change.old_value)])
 
+    @patch("zane_api.tasks.apply_deleted_urls_changes")
+    def test_update_url_do_not_delete_old_url_if_still_used(self, mock: Mock):
+        p, service = self.create_and_deploy_caddy_docker_service(
+            other_changes=[
+                DockerDeploymentChange(
+                    field=DockerDeploymentChange.ChangeField.URLS,
+                    type=DockerDeploymentChange.ChangeType.UPDATE,
+                    new_value={
+                        "domain": "proxy.fredkiss.dev",
+                        "base_path": "/",
+                        "strip_prefix": False,
+                    },
+                )
+            ]
+        )
+
+        url: URL = service.urls.first()
+
+        change = DockerDeploymentChange.objects.create(
+            field=DockerDeploymentChange.ChangeField.URLS,
+            type=DockerDeploymentChange.ChangeType.UPDATE,
+            item_id=url.id,
+            new_value={
+                "domain": "proxy.fredkiss.dev",
+                "base_path": "/config",
+                "strip_prefix": True,
+            },
+            service=service,
+        )
+
+        response = self.client.put(
+            reverse(
+                "zane_api:services.docker.deploy_service",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": service.slug,
+                },
+            ),
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        mock.assert_called()
+        mock.assert_called_with([])
+
     @patch("zane_api.docker_operations.sleep")
     @patch("zane_api.docker_operations.monotonic")
     def test_update_service_do_not_set_different_deployment_slot_if_first_deployment_fails(

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -25,6 +25,7 @@ from ..models import (
     HealthCheck,
     DockerEnvVariable,
 )
+from ..views.helpers import URLDto
 
 
 class DockerServiceDeploymentViewTests(AuthAPITestCase):
@@ -2920,6 +2921,37 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
         self.assertNotEqual(
             DockerDeployment.DeploymentStatus.QUEUED, third_deployment.status
         )
+
+    @patch("zane_api.tasks.apply_deleted_urls_changes")
+    def test_update_url_delete_old_url_from_caddy(self, mock: Mock):
+        p, service = self.create_and_deploy_caddy_docker_service()
+
+        url: URL = service.urls.first()
+
+        change = DockerDeploymentChange.objects.create(
+            field=DockerDeploymentChange.ChangeField.URLS,
+            type=DockerDeploymentChange.ChangeType.UPDATE,
+            item_id=url.id,
+            new_value={
+                "domain": "proxy.fredkiss.dev",
+                "base_path": "/config",
+                "strip_prefix": False,
+            },
+            service=service,
+        )
+
+        response = self.client.put(
+            reverse(
+                "zane_api:services.docker.deploy_service",
+                kwargs={
+                    "project_slug": p.slug,
+                    "service_slug": service.slug,
+                },
+            ),
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        mock.assert_called()
+        mock.assert_called_with([URLDto.from_dict(change.old_value)])
 
     @patch("zane_api.docker_operations.sleep")
     @patch("zane_api.docker_operations.monotonic")


### PR DESCRIPTION
## Description

In this PR I fixed a bug where when we update an URL for a service, the entry for the old url value is still kept in the proxy configuration. I found this bug in production 🤦🏾 .

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
