### PR TITLE
🔨 fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,4 +28,4 @@ dev-api: ### Start the API server
 
 reset-db: ### Wipe out the database and reset the application to its initial state
 	chmod a+x reset-db.sh
-	. ./reset-db.sh
+	./reset-db.sh

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ setup: ### Initial setup of the project
 	python3 -m venv ./backend/venv
 	echo 'activating the virtualenv...'
 	chmod a+x ./backend/venv/bin/activate
-	./backend/venv/bin/activate
+	. ./backend/venv/bin/activate
 	echo 'installing dependencies...'
 	pip install uv
 	uv pip install -r ./backend/requirements.txt
@@ -17,7 +17,7 @@ setup: ### Initial setup of the project
 	docker swarm init || true
 
 migrate: ### Run db migration
-	./backend/venv/bin/activate
+	. ./backend/venv/bin/activate
 	python ./backend/manage.py migrate
 
 dev: ### Start the DEV server
@@ -28,4 +28,4 @@ dev-api: ### Start the API server
 
 reset-db: ### Wipe out the database and reset the application to its initial state
 	chmod a+x reset-db.sh
-	./reset-db.sh
+	. ./reset-db.sh


### PR DESCRIPTION
## Description

This is a small fix for the Makefile, the `venv`s should be activated with either `.` or `source`, we can't just call the script directly. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
