### PR TITLE
🔧 use cache-control headers for assets and not for HTML for docs

### DIFF
--- a/docs/Caddyfile
+++ b/docs/Caddyfile
@@ -1,11 +1,14 @@
 :80 {
 	# Set the root directory for static files
-	handle {
-		root * /var/www/html
-		file_server
-		header Cache-Control "public, max-age=604800, immutable"
+	root * /var/www/html
+	file_server
+	
+	@assets {
+		path_regexp assets \.(css|js|png|jpg|jpeg|gif|svg|woff|woff2|eot|ttf|otf)$
 	}
 
+	header @assets Cache-Control "public, max-age=31536000, immutable"
+	
 	# Specific handling for robots.txt
 	@robots {
 		path /robots.txt
@@ -15,10 +18,10 @@
 		file_server
 	}
 	handle_errors {
-        @404 {
-            expression {http.error.status_code} == 404
-        }
-        rewrite @404 ./docs/404.html
-        file_server
-    }
+		@404 {
+			expression {http.error.status_code} == 404
+		}
+		rewrite @404 ./docs/404.html
+		file_server
+	}
 }

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -1,8 +1,6 @@
 ---
 import { Icon } from "@astrojs/starlight/components";
 import type { Props } from "@astrojs/starlight/props";
-const { lang, lastUpdated } = Astro.props;
-
 const editUrl = Astro.props.editUrl;
 ---
 


### PR DESCRIPTION
## Description

same as the title

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
