### PR TITLE
Fix: URLs path matchers should not end with a `/` matcher

### DIFF
--- a/.github/workflows/build-push-images-canary.yaml
+++ b/.github/workflows/build-push-images-canary.yaml
@@ -98,8 +98,10 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/zane-ops/docs:canary,ghcr.io/zane-ops/docs:${{ github.sha }}
-          cache-from: type=registry,ref=ghcr.io/zane-ops/docs:canary
-          cache-to: type=inline
+          cache-from: |
+            type=registry,ref=ghcr.io/zane-ops/docs-build-cache:canary
+            type=registry,ref=ghcr.io/zane-ops/docs:canary
+          cache-to: type=registry,ref=ghcr.io/zane-ops/docs-build-cache:canary,mode=max
   build-push-backend:
     name: Build and Push Zane Backend
     runs-on: ubuntu-latest

--- a/.github/workflows/build-push-images-dev.yaml
+++ b/.github/workflows/build-push-images-dev.yaml
@@ -99,9 +99,10 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/zane-ops/docs:pr-${{ github.event.pull_request.number }},ghcr.io/zane-ops/docs:${{ github.sha }}
           cache-from: |
+            type=registry,ref=ghcr.io/zane-ops/docs-build-cache:pr-${{ github.event.pull_request.number }}
             type=registry,ref=ghcr.io/zane-ops/docs:pr-${{ github.event.pull_request.number }}
             type=registry,ref=ghcr.io/zane-ops/docs:canary
-          cache-to: type=inline
+          cache-to: type=registry,ref=ghcr.io/zane-ops/docs-build-cache:pr-${{ github.event.pull_request.number }},mode=max
   build-push-backend:
     name: Build and Push Zane Backend
     runs-on: ubuntu-latest

--- a/backend/zane_api/docker_operations.py
+++ b/backend/zane_api/docker_operations.py
@@ -722,7 +722,11 @@ def get_caddy_request_for_url(
         "match": [
             {
                 "path": [
-                    f"{strip_slash_if_exists(url.base_path, strip_end=True, strip_start=False)}/*"
+                    (
+                        "/*"
+                        if url.base_path == "/"
+                        else f"{strip_slash_if_exists(url.base_path, strip_end=True, strip_start=False)}*"
+                    )
                 ],
             }
         ],


### PR DESCRIPTION
## Description

I also found this bug in producton, when you deploy an app with a base_path like `/docs`, in the proxy it would match urls starting with `/docs/*` to your service, excluding `/docs` itself, this PR fixes that.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
