### PR TITLE
🐛 fix bug with service not created throwing an error due to `image` being `None`

### DIFF
--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -351,7 +351,12 @@ class ProjectServiceListView(APIView):
                 DockerDeployment.DeploymentStatus.CANCELLED: "NOT_DEPLOYED_YET",
             }
 
-            parts = service.image.split(":")
+            service_image = service.image
+            if service_image is None:
+                image_change = service.unapplied_changes.filter(field="image").first()
+                service_image = image_change.new_value
+
+            parts = service_image.split(":")
             if len(parts) == 1:
                 tag = "latest"
                 image = service.image
@@ -373,7 +378,7 @@ class ProjectServiceListView(APIView):
                         status=(
                             status_map[service.latest_production_deployment_status]
                             if service.latest_production_deployment_status is not None
-                            else None
+                            else "NOT_DEPLOYED_YET"
                         ),
                     )
                 ).data


### PR DESCRIPTION
## Description

There was a bug in the dashboard, when we create a service but do not deploy it yet, it would have the `image` field to `None` or we use it to display the image in the frontend, we need to instead get the image from the `change` created.


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
