### PR TITLE
♻️ change API to not return images with `latest` tag and remove `library` prefix

### DIFF
--- a/backend/zane_api/docker_operations.py
+++ b/backend/zane_api/docker_operations.py
@@ -80,13 +80,12 @@ def search_images_docker_hub(term: str) -> List[DockerImageResult]:
     images_to_return: List[DockerImageResult] = []
 
     for image in result:
-        api_image_result = {}
-        if image["is_official"]:
-            api_image_result["full_image"] = f'library/{image["name"]}:latest'
-        else:
-            api_image_result["full_image"] = f'{image["name"]}:latest'
-        api_image_result["description"] = image["description"]
-        images_to_return.append(api_image_result)
+        images_to_return.append(
+            dict(
+                full_image=image["name"],
+                description=image["description"],
+            )
+        )
     return images_to_return
 
 

--- a/backend/zane_api/tests/docker.py
+++ b/backend/zane_api/tests/docker.py
@@ -17,8 +17,8 @@ class DockerViewTests(AuthAPITestCase):
 
         self.assertIsNotNone(response.json().get("images"))
         images = response.json().get("images")
-        self.assertEqual(images[0]["full_image"], "library/caddy:latest")
-        self.assertEqual(images[1]["full_image"], "siwecos/caddy:latest")
+        self.assertEqual(images[0]["full_image"], "caddy")
+        self.assertEqual(images[1]["full_image"], "siwecos/caddy")
 
     def test_search_query_empty(self):
         response = self.client.get(reverse("zane_api:docker.image_search"))


### PR DESCRIPTION
## Description

Since we can't search images by tags, we don't need to add a tag suffix, I also removed the `library/` prefix from official repositories to reflect more what the docker hub API returns.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
