### PR TITLE
♻️ use 5 seconds as the refetch interval for queries instead of 10

### DIFF
--- a/frontend/src/lib/hooks/use-project-details.tsx
+++ b/frontend/src/lib/hooks/use-project-details.tsx
@@ -2,7 +2,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { apiClient } from "~/api/client";
 import { type ProjectDetailsSearch, projectKeys } from "~/key-factories";
 
-const TEN_SECONDS = 10 * 1000;
+const FIVE_SECONDS = 5 * 1000;
 
 export function useProjectDetails(slug: string, filters: ProjectDetailsSearch) {
   return useQuery({
@@ -23,7 +23,7 @@ export function useProjectDetails(slug: string, filters: ProjectDetailsSearch) {
     placeholderData: keepPreviousData,
     refetchInterval: (query) => {
       if (query.state.data?.data) {
-        return TEN_SECONDS;
+        return FIVE_SECONDS;
       }
       return false;
     }

--- a/frontend/src/lib/hooks/use-project-list.tsx
+++ b/frontend/src/lib/hooks/use-project-list.tsx
@@ -2,7 +2,7 @@ import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { apiClient } from "~/api/client";
 import { type ProjectSearch, projectKeys } from "~/key-factories";
 
-const TEN_SECONDS = 10 * 1000;
+const FIVE_SECONDS = 5 * 1000;
 
 export function useProjectList(filters: ProjectSearch) {
   return useQuery({
@@ -25,7 +25,7 @@ export function useProjectList(filters: ProjectSearch) {
     enabled: filters.status !== "archived",
     refetchInterval: (query) => {
       if (query.state.data?.data?.results) {
-        return TEN_SECONDS;
+        return FIVE_SECONDS;
       }
       return false;
     }


### PR DESCRIPTION
## Description

10 seconds is too long and it takes a lot of time before the user can see if their service has deployed for ex, same for the statuses in the project list. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
