### PR TITLE
Fix/nested errors

### DIFF
--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -41,8 +41,8 @@ from ..validators import validate_url_path, validate_env_name
 
 
 class DockerCredentialsRequestSerializer(serializers.Serializer):
-    username = serializers.CharField(max_length=100)
-    password = serializers.CharField(max_length=100)
+    username = serializers.CharField(max_length=100, allow_blank=True, required=False)
+    password = serializers.CharField(max_length=100, allow_blank=True, required=False)
 
 
 class ServicePortsRequestSerializer(serializers.Serializer):

--- a/frontend/src/api/v1.ts
+++ b/frontend/src/api/v1.ts
@@ -240,16 +240,14 @@ export interface components {
        */
       attr: "credentials.password";
       /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
+       * @description * `invalid` - invalid
        * * `max_length` - max_length
        * * `null` - null
        * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
        * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
        * @enum {string}
        */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      code: "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
       detail: string;
     };
     CreateDockerServiceCredentialsUsernameErrorComponent: {
@@ -259,16 +257,14 @@ export interface components {
        */
       attr: "credentials.username";
       /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
+       * @description * `invalid` - invalid
        * * `max_length` - max_length
        * * `null` - null
        * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
        * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
        * @enum {string}
        */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      code: "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
       detail: string;
     };
     CreateDockerServiceError: components["schemas"]["CreateDockerServiceNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceSlugErrorComponent"] | components["schemas"]["CreateDockerServiceImageErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsNonFieldErrorsErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsUsernameErrorComponent"] | components["schemas"]["CreateDockerServiceCredentialsPasswordErrorComponent"];
@@ -408,8 +404,8 @@ export interface components {
       field: components["schemas"]["DockerCredentialsFieldChangeFieldEnum"];
     };
     DockerCredentialsRequestRequest: {
-      username: string;
-      password: string;
+      username?: string;
+      password?: string;
     };
     DockerDeploymentChange: {
       id: string;
@@ -1390,16 +1386,14 @@ export interface components {
        */
       attr: "new_value.password";
       /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
+       * @description * `invalid` - invalid
        * * `max_length` - max_length
        * * `null` - null
        * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
        * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
        * @enum {string}
        */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      code: "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
       detail: string;
     };
     RequestDeploymentChangesNewValueStripPrefixErrorComponent: {
@@ -1454,16 +1448,14 @@ export interface components {
        */
       attr: "new_value.username";
       /**
-       * @description * `blank` - blank
-       * * `invalid` - invalid
+       * @description * `invalid` - invalid
        * * `max_length` - max_length
        * * `null` - null
        * * `null_characters_not_allowed` - null_characters_not_allowed
-       * * `required` - required
        * * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
        * @enum {string}
        */
-      code: "blank" | "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "required" | "surrogate_characters_not_allowed";
+      code: "invalid" | "max_length" | "null" | "null_characters_not_allowed" | "surrogate_characters_not_allowed";
       detail: string;
     };
     RequestDeploymentChangesNewValueValueErrorComponent: {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -47,7 +47,7 @@ export function getFormErrorsFromResponseData<T extends Input>(
       const key = error.attr;
       if (key) {
         const keys = key.split(".");
-        if (keys.length === 0) {
+        if (keys.length === 1) {
           if (!errors[key]) {
             errors[key] = [];
           }
@@ -59,7 +59,7 @@ export function getFormErrorsFromResponseData<T extends Input>(
               [suffix]: []
             };
           }
-          errors[prefix][suffix] = {
+          errors[prefix] = {
             ...errors[prefix],
             [suffix]: [...(errors[prefix][suffix] ?? []), error.detail]
           };

--- a/frontend/src/routes/_dashboard/project_/$slug_.create-service.docker.lazy.tsx
+++ b/frontend/src/routes/_dashboard/project_/$slug_.create-service.docker.lazy.tsx
@@ -166,21 +166,13 @@ function StepServiceForm({ slug, onSuccess }: StepServiceFormProps) {
   return (
     <Form.Root
       action={(formData) => {
-        let credentials = undefined;
-        if (
-          formData.get("credentials.username") ||
-          formData.get("credentials.password")
-        ) {
-          credentials = {
-            password: formData.get("credentials.password")!.toString(),
-            username: formData.get("credentials.username")!.toString().trim()
-          };
-        }
-
         mutate({
           slug: formData.get("slug")?.toString().trim() ?? "",
           image: formData.get("image")?.toString() ?? "",
-          credentials
+          credentials: {
+            password: formData.get("credentials.password")?.toString(),
+            username: formData.get("credentials.username")?.toString().trim()
+          }
         });
       }}
       className="flex my-10 flex-grow justify-center items-center"

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -2488,21 +2488,17 @@ components:
           description: '* `credentials.password` - credentials.password'
         code:
           enum:
-          - blank
           - invalid
           - max_length
           - 'null'
           - null_characters_not_allowed
-          - required
           - surrogate_characters_not_allowed
           type: string
           description: |-
-            * `blank` - blank
             * `invalid` - invalid
             * `max_length` - max_length
             * `null` - null
             * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
             * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
         detail:
           type: string
@@ -2520,21 +2516,17 @@ components:
           description: '* `credentials.username` - credentials.username'
         code:
           enum:
-          - blank
           - invalid
           - max_length
           - 'null'
           - null_characters_not_allowed
-          - required
           - surrogate_characters_not_allowed
           type: string
           description: |-
-            * `blank` - blank
             * `invalid` - invalid
             * `max_length` - max_length
             * `null` - null
             * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
             * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
         detail:
           type: string
@@ -2839,15 +2831,10 @@ components:
       properties:
         username:
           type: string
-          minLength: 1
           maxLength: 100
         password:
           type: string
-          minLength: 1
           maxLength: 100
-      required:
-      - password
-      - username
     DockerDeploymentChange:
       type: object
       properties:
@@ -4976,21 +4963,17 @@ components:
           description: '* `new_value.password` - new_value.password'
         code:
           enum:
-          - blank
           - invalid
           - max_length
           - 'null'
           - null_characters_not_allowed
-          - required
           - surrogate_characters_not_allowed
           type: string
           description: |-
-            * `blank` - blank
             * `invalid` - invalid
             * `max_length` - max_length
             * `null` - null
             * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
             * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
         detail:
           type: string
@@ -5080,21 +5063,17 @@ components:
           description: '* `new_value.username` - new_value.username'
         code:
           enum:
-          - blank
           - invalid
           - max_length
           - 'null'
           - null_characters_not_allowed
-          - required
           - surrogate_characters_not_allowed
           type: string
           description: |-
-            * `blank` - blank
             * `invalid` - invalid
             * `max_length` - max_length
             * `null` - null
             * `null_characters_not_allowed` - null_characters_not_allowed
-            * `required` - required
             * `surrogate_characters_not_allowed` - surrogate_characters_not_allowed
         detail:
           type: string


### PR DESCRIPTION
## Description

In this PR, I fixed an issue I introduced with #178, the nested error function would throw an error for any error we'd have

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
