### PR TITLE
🐛 do not return 500 error on non existing image

### DIFF
--- a/backend/zane_api/docker_operations.py
+++ b/backend/zane_api/docker_operations.py
@@ -74,9 +74,11 @@ def search_images_docker_hub(term: str) -> List[DockerImageResult]:
     List all images in registry starting with a certain term.
     """
     client = get_docker_client()
-    result: List[DockerImageResultFromRegistry] = client.images.search(
-        term=term, limit=30
-    )
+    result: List[DockerImageResultFromRegistry] = []
+    try:
+        result = client.images.search(term=term, limit=30)
+    except docker.errors.APIError:
+        pass
     images_to_return: List[DockerImageResult] = []
 
     for image in result:


### PR DESCRIPTION
## Description

When searching for image `ghcr.io/zane-ops/docs`, zaneOps throw a 500 error, we catch it to not throw an error.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
