### PR TITLE
Refactor/show latest deployment status in api

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -313,6 +313,7 @@ SPECTACULAR_SETTINGS = {
             ("SLEEPING", "Sleeping"),
             ("NOT_DEPLOYED_YET", "Not deployed yet"),
             ("DEPLOYING", "Deploying"),
+            ("CANCELLED", "Cancelled"),
         ),
     },
     "POSTPROCESSING_HOOKS": [

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -304,14 +304,6 @@ class ProjectServiceListView(APIView):
                 detail=f"A project with the slug `{slug}` does not exist"
             )
 
-        latest_production_deployment_subquery = (
-            DockerDeployment.objects.filter(
-                service_id=OuterRef("pk"), is_current_production=True
-            )
-            .order_by("-created_at")
-            .values("status")[:1]
-        )
-
         # Prefetch related fields and use annotate to count volumes
         filters = Q(project=project)
         query = request.query_params.get("query", "")
@@ -329,8 +321,10 @@ class ProjectServiceListView(APIView):
             )
             .annotate(
                 volume_number=Count("volumes"),
-                latest_production_deployment_status=Subquery(
-                    latest_production_deployment_subquery
+                latest_deployment_status=Subquery(
+                    DockerDeployment.objects.filter(service_id=OuterRef("pk"))
+                    .order_by("-created_at")
+                    .values("status")[:1]
                 ),
             )
         )
@@ -380,8 +374,8 @@ class ProjectServiceListView(APIView):
                         volume_number=service.volume_number,
                         url=str(url) if url is not None else None,
                         status=(
-                            status_map[service.latest_production_deployment_status]
-                            if service.latest_production_deployment_status is not None
+                            status_map[service.latest_deployment_status]
+                            if service.latest_deployment_status is not None
                             else "NOT_DEPLOYED_YET"
                         ),
                     )

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -342,7 +342,7 @@ class ProjectServiceListView(APIView):
                 DockerDeployment.DeploymentStatus.PREPARING: "DEPLOYING",
                 DockerDeployment.DeploymentStatus.STARTING: "DEPLOYING",
                 DockerDeployment.DeploymentStatus.RESTARTING: "UNHEALTHY",
-                DockerDeployment.DeploymentStatus.CANCELLED: "UNHEALTHY",
+                DockerDeployment.DeploymentStatus.CANCELLED: "CANCELLED",
             }
 
             service_image = service.image

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -342,11 +342,7 @@ class ProjectServiceListView(APIView):
                 DockerDeployment.DeploymentStatus.PREPARING: "DEPLOYING",
                 DockerDeployment.DeploymentStatus.STARTING: "DEPLOYING",
                 DockerDeployment.DeploymentStatus.RESTARTING: "UNHEALTHY",
-                # This will only be set for the initial deployment,
-                # for the rest of the deployments, if a deployment is cancelled,
-                # it will not be added as production, so the state returned to the user
-                # is the state of the last production deployment
-                DockerDeployment.DeploymentStatus.CANCELLED: "NOT_DEPLOYED_YET",
+                DockerDeployment.DeploymentStatus.CANCELLED: "UNHEALTHY",
             }
 
             service_image = service.image

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -958,6 +958,7 @@ class BaseServiceCardSerializer(serializers.Serializer):
         ("SLEEPING", _("Sleeping")),
         ("NOT_DEPLOYED_YET", _("Not deployed yet")),
         ("DEPLOYING", _("Deploying")),
+        ("CANCELLED", _("Cancelled")),
     )
     status = serializers.ChoiceField(choices=STATUS_CHOICES)
     id = serializers.CharField(required=True)

--- a/frontend/src/api/v1.ts
+++ b/frontend/src/api/v1.ts
@@ -1541,9 +1541,10 @@ export interface components {
      * * `SLEEPING` - Sleeping
      * * `NOT_DEPLOYED_YET` - Not deployed yet
      * * `DEPLOYING` - Deploying
+     * * `CANCELLED` - Cancelled
      * @enum {string}
      */
-    ServiceStatusEnum: "HEALTHY" | "UNHEALTHY" | "SLEEPING" | "NOT_DEPLOYED_YET" | "DEPLOYING";
+    ServiceStatusEnum: "HEALTHY" | "UNHEALTHY" | "SLEEPING" | "NOT_DEPLOYED_YET" | "DEPLOYING" | "CANCELLED";
     SimpleLog: {
       /** Format: uuid */
       id: string;

--- a/frontend/src/components/service-cards.tsx
+++ b/frontend/src/components/service-cards.tsx
@@ -30,7 +30,8 @@ type CommonServiceCardProps = {
     | "UNHEALTHY"
     | "SLEEPING"
     | "NOT_DEPLOYED_YET"
-    | "DEPLOYING";
+    | "DEPLOYING"
+    | "CANCELLED";
   volumeNumber?: number;
   url?: string | null;
   updatedAt: string;
@@ -56,7 +57,7 @@ export function DockerServiceCard({
         <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
             <span className="absolute cursor-pointer flex h-4 w-4 -top-1 -right-1 z-10">
-              {status !== "NOT_DEPLOYED_YET" && (
+              {status !== "NOT_DEPLOYED_YET" && status !== "CANCELLED" && (
                 <span
                   className={cn(
                     "animate-ping absolute inline-flex h-full w-full rounded-full  opacity-75",
@@ -77,7 +78,8 @@ export function DockerServiceCard({
                     "bg-green-500": status === "HEALTHY",
                     "bg-red-500": status === "UNHEALTHY",
                     "bg-yellow-500": status === "SLEEPING",
-                    "bg-gray-400": status === "NOT_DEPLOYED_YET",
+                    "bg-gray-400":
+                      status === "NOT_DEPLOYED_YET" || status === "CANCELLED",
                     "bg-secondary": status === "DEPLOYING"
                   }
                 )}
@@ -90,6 +92,7 @@ export function DockerServiceCard({
               {status === "SLEEPING" && "🌙 Sleeping"}
               {status === "UNHEALTHY" && "❌ Unhealthy"}
               {status === "DEPLOYING" && "⏳ Deploying..."}
+              {status === "CANCELLED" && "🚫 Cancelled"}
               {status === "NOT_DEPLOYED_YET" && "🚧 Not deployed yet"}
             </div>
           </TooltipContent>
@@ -165,7 +168,7 @@ export function GitServiceCard({
         <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
             <span className="absolute cursor-pointer flex h-4 w-4 -top-1 -right-1 z-10">
-              {status !== "NOT_DEPLOYED_YET" && (
+              {status !== "NOT_DEPLOYED_YET" && status !== "CANCELLED" && (
                 <span
                   className={cn(
                     "animate-ping absolute inline-flex h-full w-full rounded-full  opacity-75",
@@ -186,7 +189,8 @@ export function GitServiceCard({
                     "bg-green-500": status === "HEALTHY",
                     "bg-red-500": status === "UNHEALTHY",
                     "bg-yellow-500": status === "SLEEPING",
-                    "bg-gray-400": status === "NOT_DEPLOYED_YET",
+                    "bg-gray-400":
+                      status === "NOT_DEPLOYED_YET" || status === "CANCELLED",
                     "bg-secondary": status === "DEPLOYING"
                   }
                 )}
@@ -195,10 +199,12 @@ export function GitServiceCard({
           </TooltipTrigger>
           <TooltipContent>
             <div>
-              {status === "HEALTHY" && "✅ "}
-              {status === "SLEEPING" && "💤 "}
-              {status === "UNHEALTHY" && "❌ "}
-              {status === "NOT_DEPLOYED_YET" ? "⏳ Not deployed yet" : status}
+              {status === "HEALTHY" && "✅ Healthy"}
+              {status === "SLEEPING" && "🌙 Sleeping"}
+              {status === "UNHEALTHY" && "❌ Unhealthy"}
+              {status === "DEPLOYING" && "⏳ Deploying..."}
+              {status === "CANCELLED" && "🚫 Cancelled"}
+              {status === "NOT_DEPLOYED_YET" && "🚧 Not deployed yet"}
             </div>
           </TooltipContent>
         </Tooltip>

--- a/frontend/src/components/service-cards.tsx
+++ b/frontend/src/components/service-cards.tsx
@@ -51,11 +51,11 @@ export function DockerServiceCard({
   status
 }: DockerServiceCardProps) {
   return (
-    <Card className="rounded-2xl flex flex-col h-[220px] bg-toggle relative">
+    <Card className="rounded-2xl flex flex-col h-[220px] bg-toggle relative ring-1 ring-transparent hover:ring-primary focus-within:ring-primary transition-colors duration-300">
       <TooltipProvider>
         <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
-            <span className="absolute cursor-pointer flex h-4 w-4 -top-1 -right-1">
+            <span className="absolute cursor-pointer flex h-4 w-4 -top-1 -right-1 z-10">
               {status !== "NOT_DEPLOYED_YET" && (
                 <span
                   className={cn(
@@ -101,11 +101,14 @@ export function DockerServiceCard({
           <Container className="flex-none" size={30} />
           <div className="w-[calc(100%-38px)]">
             <h2 className="text-lg leading-tight">
-              <Link to={`services/docker/${slug}`} className="hover:underline">
+              <Link
+                to={`services/docker/${slug}`}
+                className="hover:underline after:inset-0 after:absolute"
+              >
                 {slug}
               </Link>
             </h2>
-            <p className="text-sm font-normal overflow-x-hidden text-ellipsis whitespace-nowrap text-gray-400 leading-tight">
+            <p className="text-sm font-normal overflow-x-hidden text-ellipsis whitespace-nowrap text-gray-400 leading-tight relative z-10">
               {image}
             </p>
           </div>
@@ -116,7 +119,7 @@ export function DockerServiceCard({
           <a
             href={`//${url}`}
             target="_blank"
-            className="text-sm flex items-center gap-2 text-link"
+            className="text-sm flex items-center gap-2 text-link z-10 relative hover:underline"
           >
             <LinkIcon className="flex-none" size={15} />
             <div className="whitespace-nowrap overflow-x-hidden  text-ellipsis ">
@@ -125,10 +128,10 @@ export function DockerServiceCard({
           </a>
         )}
 
-        <p className="flex items-center gap-2">
+        <p className="flex items-center gap-2 z-10 relative">
           <Tag size={15} /> {tag}
         </p>
-        <p className="flex gap-2 items-center">{updatedAt}</p>
+        <p className="flex gap-2 items-center z-10 relative">{updatedAt}</p>
       </CardContent>
 
       <Separator />
@@ -157,11 +160,11 @@ export function GitServiceCard({
   status
 }: GitServiceCardProps) {
   return (
-    <Card className="rounded-2xl bg-toggle relative">
+    <Card className="rounded-2xl bg-toggle relative ring-1 ring-transparent hover:ring-primary focus-within:ring-primary transition-colors duration-300">
       <TooltipProvider>
         <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
-            <span className="absolute cursor-pointer flex h-4 w-4 -top-1 -right-1">
+            <span className="absolute cursor-pointer flex h-4 w-4 -top-1 -right-1 z-10">
               {status !== "NOT_DEPLOYED_YET" && (
                 <span
                   className={cn(
@@ -206,11 +209,14 @@ export function GitServiceCard({
           <Github className="flex-none" size={30} />
           <div className="w-[calc(100%-38px)]">
             <h2 className="text-lg leading-tight">
-              <Link to={`services/git/${slug}`} className="hover:underline">
+              <Link
+                to={`services/git/${slug}`}
+                className="hover:underline after:inset-0 after:absolute"
+              >
                 {slug}
               </Link>
             </h2>
-            <p className="text-sm font-medium overflow-x-hidden text-ellipsis whitespace-nowrap text-gray-400 leading-tight">
+            <p className="text-sm font-medium overflow-x-hidden text-ellipsis whitespace-nowrap text-gray-400 leading-tight hover:underline">
               {repository}
             </p>
           </div>
@@ -221,7 +227,7 @@ export function GitServiceCard({
           <a
             href={`//${url}`}
             target="_blank"
-            className="text-sm flex items-center gap-2 text-link"
+            className="text-sm flex items-center gap-2 text-link relative z-10 hover:underline"
           >
             <LinkIcon className="flex-none" size={15} />
             <div className="whitespace-nowrap overflow-x-hidden  text-ellipsis ">
@@ -230,10 +236,10 @@ export function GitServiceCard({
           </a>
         )}
 
-        <p className="text-ellipsis overflow-x-hidden whitespace-nowrap">
+        <p className="text-ellipsis overflow-x-hidden whitespace-nowrap relative z-10">
           {lastCommitMessage}
         </p>
-        <p className="flex gap-2 items-center">
+        <p className="flex gap-2 items-center relative z-10">
           {updatedAt} on <GitBranchIcon size={15} /> {branchName}
         </p>
       </CardContent>

--- a/frontend/src/components/service-cards.tsx
+++ b/frontend/src/components/service-cards.tsx
@@ -1,3 +1,4 @@
+import { Link } from "@tanstack/react-router";
 import {
   Container,
   GitBranchIcon,
@@ -99,7 +100,11 @@ export function DockerServiceCard({
         <CardTitle className="flex gap-2 items-center">
           <Container className="flex-none" size={30} />
           <div className="w-[calc(100%-38px)]">
-            <h1 className="text-lg leading-tight">{slug}</h1>
+            <h2 className="text-lg leading-tight">
+              <Link to={`services/docker/${slug}`} className="hover:underline">
+                {slug}
+              </Link>
+            </h2>
             <p className="text-sm font-normal overflow-x-hidden text-ellipsis whitespace-nowrap text-gray-400 leading-tight">
               {image}
             </p>
@@ -200,7 +205,11 @@ export function GitServiceCard({
         <CardTitle className="flex gap-2 items-center">
           <Github className="flex-none" size={30} />
           <div className="w-[calc(100%-38px)]">
-            <h1 className="text-lg leading-tight">{slug}</h1>
+            <h2 className="text-lg leading-tight">
+              <Link to={`services/git/${slug}`} className="hover:underline">
+                {slug}
+              </Link>
+            </h2>
             <p className="text-sm font-medium overflow-x-hidden text-ellipsis whitespace-nowrap text-gray-400 leading-tight">
               {repository}
             </p>

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -5230,6 +5230,7 @@ components:
       - SLEEPING
       - NOT_DEPLOYED_YET
       - DEPLOYING
+      - CANCELLED
       type: string
       description: |-
         * `HEALTHY` - Healthy
@@ -5237,6 +5238,7 @@ components:
         * `SLEEPING` - Sleeping
         * `NOT_DEPLOYED_YET` - Not deployed yet
         * `DEPLOYING` - Deploying
+        * `CANCELLED` - Cancelled
     SimpleLog:
       type: object
       properties:


### PR DESCRIPTION
## Description

In this PR, we modifed the API endpoint for `service-list` to show the status of the latest deployment instead of the production deloyment. I also added a hover effect and a underline on the service card link.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
