### PR TITLE
📝 add ROADMAP to beta, v1 & v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,12 @@
   - [ ] settings page 
 - [ ] CLI
   - [ ] install & setup zaneops
+  - [ ] shutting down & deleting ZaneOps
   - [ ] authenticate with token (require token UI+API in ZaneOps)
   - [ ] Deploy a service using the CLI
+- [ ] Tons of docs
+  - [ ] Installation & setup process using the CLI
+  - [ ] Examples of deploying different kind of apps
 
 ### v1 
 
@@ -91,8 +95,9 @@
 
 ### v2
 
+- [ ] Template support
+  - [ ] Allow also for seeding templates
 - [ ] CRONs support for services
-- [ ] Template List
 - [ ] Multi-server support
 
 ## 🍙 Getting Started

--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@
 
 ### <div align="center">A self-hosted PaaS for your web services, databases, CRONs, and everything you need for your next startup.</div>
 
-[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/zane-ops/zane-ops/badge)](https://securityscorecards.dev/viewer/?uri=github.com/zane-ops/zane-ops)
-
 ---
 
 ## 📸 Screenshots
@@ -57,6 +55,38 @@
 </p>
 
 > More to come
+
+## 🛣️ ROADMAP 
+
+### beta
+
+- [ ] Docker services frontend 
+  - [ ] Details page 
+  - [ ] Env variables page
+  - [ ] Settings page
+  - [ ] Single deployment page
+  - [ ] Single deployment application logs page
+  - [ ] Single deployment http logs page
+  - [ ] deploy & redeploy deployments
+- [ ] Project frontend
+  - [ ] settings page 
+- [ ] CLI
+  - [ ] install & setup zaneops
+  - [ ] authenticate with token (require token UI+API in ZaneOps)
+  - [ ] Deploy a service using the CLI
+
+### v1 
+
+- [ ] Rewrite from celery to temporal (not sure)
+- [ ] Managing environments (stating, production, and ephemeral envs)
+- [ ] Git services API
+  - [ ] create service from a public repo
+  - [ ] deploy service  
+    - [ ] Building service with nixpacks  
+  - [ ] archive service
+  - [ ] Pull Request environments
+  - [ ] Auto-comments with deployment status on github
+- [ ] Git services frontend (same as docker services)
 
 ## 🚀 Features
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@
 
 - [ ] Rewrite from celery to temporal (not sure)
 - [ ] Managing environments (stating, production, and ephemeral envs)
+- [ ] Support workers (A.K.A sleeping services)
 - [ ] Git services API
   - [ ] create service from a public repo
   - [ ] deploy service  

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 # <div align="center">Zane Ops</div>
 
-### <div align="center">A self-hosted PaaS for your web services, databases, CRONs, and everything you need for your next startup.</div>
+### <div align="center">ZaneOps is a self-hosted, open source platform for hosting static sites, web apps, databases, CRONS, Workers using docker swarm as the engine.</div>
 
 ---
 
@@ -86,40 +86,17 @@
   - [ ] archive service
   - [ ] Pull Request environments
   - [ ] Auto-comments with deployment status on github
-- [ ] Git services frontend (same as docker services)
+- [ ] Git services frontend & API (same as docker services)
 
-## 🚀 Features
+### v2
 
-- **Deploy Web Services**: Unleash your creativity by deploying web apps, starting a REDIS instance, creating a
-  PostgreSQL database, initiating a Bitcoin node, and more. It's your resources, go crazy!
-- **Git Push Deployment**: Automatically deploy apps from GitHub on push. Seamless and efficient.
-- **Preview Deployments**: Easily manage app versions, roll back to any version at any time, and control storage
-  duration—whether indefinitely or temporarily post-merge.
-- **Deploy Workers**: Ideal for one-off tasks that are removed post-execution.
-- **Deploy CRONs**: Automate recurring tasks by pinging endpoints or running commands regularly.
-- **Scaling**: Effortlessly scale your app to manage traffic spikes, up or down.
+- [ ] CRONs support for services
+- [ ] Template List
+- [ ] Multi-server support
 
 ## 🍙 Getting Started
 
-You can follow the steps in [here](./docs/deploying.md).
-
-## 📚 Terminologies
-
-- **Worker**: A lightweight, ephemeral unit of work or process designed to run a specific task. Workers are typically
-  utilized for one-off or background tasks that execute and then terminate upon completion.
-
-- **Service**: A persistent, scalable component of an application that runs continuously. Services act as the backbone
-  of your application, managing HTTP requests, executing background jobs, interfacing with databases, and more.
-
-- **CRON**: A scheduling system for executing tasks (known as CRON jobs) at specified times or intervals. There are two
-  types of CRON jobs:
-    - **Command CRONs**: These jobs execute specific commands or scripts at predetermined times or intervals.
-    - **HTTP CRONs**: These jobs make HTTP requests to specified URLs at set times or intervals, useful for triggering
-      webhooks or remote tasks.
-
-- **Preview Deployment**: A temporary deployment of a particular version of your application for testing and review
-  purposes before it goes live. Preview deployments facilitate quality assurance, stakeholder review, and integration
-  testing, enabling feedback and adjustments without impacting the production environment.
+All the steps to install and run ZaneOps are listed in the [documentation](https://zane.fredkiss.dev/docs).
 
 ## ❤️ Contributing
 

--- a/README.md
+++ b/README.md
@@ -72,11 +72,12 @@
   - [ ] settings page 
 - [ ] CLI
   - [ ] install & setup zaneops
-  - [ ] shutting down & deleting ZaneOps
+  - [ ] shutting down & uninstalling ZaneOps
+  - [ ] upgrading ZaneOps
   - [ ] authenticate with token (require token UI+API in ZaneOps)
   - [ ] Deploy a service using the CLI
 - [ ] Tons of docs
-  - [ ] Installation & setup process using the CLI
+  - [ ] Using the CLI
   - [ ] Examples of deploying different kind of apps
 
 ### v1 
@@ -95,9 +96,10 @@
 
 ### v2
 
+- [ ] Static websites support
+- [ ] CRONs support for services
 - [ ] Template support
   - [ ] Allow also for seeding templates
-- [ ] CRONs support for services
 - [ ] Multi-server support
 
 ## 🍙 Getting Started

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -53,11 +53,11 @@ export default defineConfig({
             {
               label: "Development",
               slug: "development/development"
-            },
-            {
-              label: "Architecture",
-              slug: "development/architecture"
             }
+            // {
+            //   label: "Architecture",
+            //   slug: "development/architecture"
+            // }
           ]
         },
         {


### PR DESCRIPTION
## Description

In this PR, I added an official ROADMAP for zaneops containing the missing features for a beta version & then a v1 and eventually a v2.

I always hate writing these as they remind me of the tremendous amount of work that is left 😑 . 
Thankfully, if we finish the beta, the features for the V1 will reuse a lot of the code we wrote for docker services.

I also removed the `architecture` section in the docs for now as it would stay not written for long.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```

