### PR TITLE
:heavy_minus_sign: Remove daphne & use gunicorn instead

### DIFF
--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -15,4 +15,4 @@ COPY . /app
 
 EXPOSE 8000
 
-CMD /bin/bash -c "source /venv/bin/activate && python manage.py migrate && daphne -b 0.0.0.0 -p 8000 backend.asgi:application"
+CMD /bin/bash -c "source /venv/bin/activate && python manage.py migrate && gunicorn --log-level=info -b 0.0.0.0:8000 backend.wsgi:application"

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -91,7 +91,6 @@ SESSION_EXTEND_PERIOD = 7
 # Application definition
 
 INSTALLED_APPS = [
-    "daphne",
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,7 +3,6 @@ amqp==5.2.0
 asgiref==3.7.2
 async-property==0.2.2
 attrs==23.2.0
-autobahn==23.6.2
 automat==22.10.0
 billiard==4.2.0
 black==24.3.0
@@ -19,7 +18,6 @@ click-repl==0.3.0
 constantly==23.10.4
 cron-descriptor==1.4.3
 cryptography==41.0.7
-daphne==4.1.2
 dill==0.3.8
 django==5.0.4
 django-celery-beat==2.6.0


### PR DESCRIPTION
## Description

I did this because I stumbled on a bug where the API would hang indefinitely, the fix was to remove daphne package, instead we will use gunicorn like before. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
