### PR TITLE
♻️ Add command to proxy docker image

### DIFF
--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -14,3 +14,4 @@ RUN apk add --no-cache wget
 
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY default-caddy-config-${ENVIRONMENT}.json /config/caddy/autosave.json
+CMD caddy run --resume


### PR DESCRIPTION
## Description

In this PR, I changed the docker image for the proxy to use `caddy run --resume`, in prepration for the usage in github actions, since github action don't support commands.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
