### PR TITLE
🔨 Create default namespace & enable archival & visibility in temporal prod script

### DIFF
--- a/deploy.mk
+++ b/deploy.mk
@@ -54,6 +54,9 @@ deploy: ### Install and deploy zaneops
 	set -a; . ./.env; set +a && docker stack deploy --detach=false --with-registry-auth --compose-file docker-stack.prod.yaml zane; \
 	fi
 	@. ./attach-proxy-networks.sh
+	@docker exec -it $(docker ps -qf "name=zane_temporal-server") tctl --ns default namespace register -rd 3 || true
+	@docker exec -it $(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --history-archival-state enabled default || true
+	@docker exec -it $(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --visibility-archival-state enabled default || true
 	@echo "Deploy done, Please give this is a little minutes before accessing your website 🏁"
 	@echo "You can monitor the services deployed by running \`docker service ls --filter label=\"zane.stack=true\"\`"
 	@echo "Wait for all services to show up as \`replicated   1/1\` to attest that everything started succesfully"

--- a/deploy.mk
+++ b/deploy.mk
@@ -54,9 +54,9 @@ deploy: ### Install and deploy zaneops
 	set -a; . ./.env; set +a && docker stack deploy --detach=false --with-registry-auth --compose-file docker-stack.prod.yaml zane; \
 	fi
 	@. ./attach-proxy-networks.sh
-	@docker exec -it $$(docker ps -qf "name=zane_temporal-server") tctl --ns default namespace register -rd 3 || true
-	@docker exec -it $$(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --history-archival-state enabled default || true
-	@docker exec -it $$(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --visibility-archival-state enabled default || true
+	@docker exec $$(docker ps -qf "name=zane_temporal-server") tctl --ns default namespace register -rd 3 || true
+	@docker exec $$(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --history-archival-state enabled default || true
+	@docker exec $$(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --visibility-archival-state enabled default || true
 	@echo "Deploy done, Please give this is a little minutes before accessing your website 🏁"
 	@echo "You can monitor the services deployed by running \`docker service ls --filter label=\"zane.stack=true\"\`"
 	@echo "Wait for all services to show up as \`replicated   1/1\` to attest that everything started succesfully"

--- a/deploy.mk
+++ b/deploy.mk
@@ -54,9 +54,9 @@ deploy: ### Install and deploy zaneops
 	set -a; . ./.env; set +a && docker stack deploy --detach=false --with-registry-auth --compose-file docker-stack.prod.yaml zane; \
 	fi
 	@. ./attach-proxy-networks.sh
-	@docker exec -it $(docker ps -qf "name=zane_temporal-server") tctl --ns default namespace register -rd 3 || true
-	@docker exec -it $(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --history-archival-state enabled default || true
-	@docker exec -it $(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --visibility-archival-state enabled default || true
+	@docker exec -it $$(docker ps -qf "name=zane_temporal-server") tctl --ns default namespace register -rd 3 || true
+	@docker exec -it $$(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --history-archival-state enabled default || true
+	@docker exec -it $$(docker ps -qf "name=zane_temporal-server") temporal operator namespace update --visibility-archival-state enabled default || true
 	@echo "Deploy done, Please give this is a little minutes before accessing your website 🏁"
 	@echo "You can monitor the services deployed by running \`docker service ls --filter label=\"zane.stack=true\"\`"
 	@echo "Wait for all services to show up as \`replicated   1/1\` to attest that everything started succesfully"


### PR DESCRIPTION
## Description

This is necessary for temporal to work on production, the `default` namespace is not created by default, so we create it in the script that deploys the app.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
