### PR TITLE
Feat/cancel deployment

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Install dependencies
         run: |
           cd backend
-          pip install uv==0.1.0
+          pip install uv==0.4.2
           uv venv
           uv pip install -r requirements.txt
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ setup: ### Initial setup of the project
 	chmod a+x ./backend/venv/bin/activate
 	. ./backend/venv/bin/activate
 	echo 'installing dependencies...'
-	pip install uv
+	pip install uv==0.4.2
 	uv pip install -r ./backend/requirements.txt
 	pnpm install --frozen-lockfile
 	echo 'initializating docker swarm'

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,7 +4,7 @@ FROM python:3.11.7
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN pip install uv==0.1.0
+RUN pip install uv==0.4.2
 RUN uv venv /venv
 COPY requirements.txt requirements.txt
 ENV VIRTUAL_ENV=/venv

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -5,7 +5,7 @@ WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
 
-RUN pip install uv==0.1.0
+RUN pip install uv==0.4.2
 ENV VIRTUAL_ENV=/venv
 RUN uv venv /venv
 COPY requirements.txt requirements.txt

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -313,7 +313,6 @@ SPECTACULAR_SETTINGS = {
             ("SLEEPING", "Sleeping"),
             ("NOT_DEPLOYED_YET", "Not deployed yet"),
             ("DEPLOYING", "Deploying"),
-            ("CANCELLED", "Cancelled"),
         ),
     },
     "POSTPROCESSING_HOOKS": [

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -91,5 +91,4 @@ uvloop==0.19.0
 vine==5.1.0
 watchdog==4.0.0
 wcwidth==0.2.13
-wrapt==1.16.0
 zope-interface==6.4.post2

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -86,11 +86,10 @@ typing-extensions==4.12.2
 tzdata==2024.1
 uritemplate==4.1.1
 urllib3==2.2.0
-uv==0.1.0
+uv==0.4.2
 uvloop==0.19.0
 vine==5.1.0
 watchdog==4.0.0
 wcwidth==0.2.13
 wrapt==1.16.0
-wrapt-timeout-decorator==1.5.1
 zope-interface==6.4.post2

--- a/backend/zane_api/dtos.py
+++ b/backend/zane_api/dtos.py
@@ -6,7 +6,7 @@ from typing import List, Optional, Dict, Any, Literal
 class VolumeDto:
     container_path: str
     mode: Literal["READ_ONLY", "READ_WRITE"]
-    name: str = None
+    name: Optional[str] = None
     host_path: Optional[str] = None
     id: Optional[str] = None
 

--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -590,6 +590,23 @@ class DockerDeployment(BaseDeployment):
     service_snapshot = models.JSONField(null=True)
     commit_message = models.TextField(default="update service")
 
+    @classmethod
+    def get_next_deployment_slot(
+        cls,
+        latest_production_deployment: Optional["DockerDeployment"],
+    ) -> str:
+        if (
+            latest_production_deployment is not None
+            and latest_production_deployment.slot
+            == DockerDeployment.DeploymentSlot.BLUE
+            and latest_production_deployment.status
+            != DockerDeployment.DeploymentStatus.FAILED
+            # 👆🏽 technically this can only be true for the initial deployment
+            # for the next deployments, when they fail, they will not be promoted to production
+        ):
+            return DockerDeployment.DeploymentSlot.GREEN
+        return DockerDeployment.DeploymentSlot.BLUE
+
     @property
     def workflow_id(self):
         return f"deploy-{self.service.id}-{self.service.project_id}"

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -759,7 +759,8 @@ class DockerSwarmActivities:
     @activity.defn
     async def save_cancelled_deployment(self, deployment: DockerDeploymentDetails):
         await DockerDeployment.objects.filter(hash=deployment.hash).aupdate(
-            status=DockerDeployment.DeploymentStatus.CANCELLED
+            status=DockerDeployment.DeploymentStatus.CANCELLED,
+            status_reason="Deployment cancelled.",
         )
 
     @activity.defn

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -735,6 +735,7 @@ class DockerSwarmActivities:
                 service_id=latest_production_deployment.service_id,
                 project_id=deployment.service.project_id,
                 status=latest_production_deployment.status,
+                url=latest_production_deployment.url,
             )
         return None
 

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -762,6 +762,11 @@ class DockerSwarmActivities:
             status=DockerDeployment.DeploymentStatus.CANCELLED,
             status_reason="Deployment cancelled.",
         )
+        await deployment_log(
+            deployment,
+            f"Deployment {Colors.YELLOW}{deployment.hash}{Colors.ENDC}"
+            f" finished with status {Colors.GREY}{DockerDeployment.DeploymentStatus.CANCELLED}{Colors.ENDC}.",
+        )
 
     @activity.defn
     async def finish_and_save_deployment(

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -654,7 +654,7 @@ class DockerSwarmActivities:
     @activity.defn
     async def finish_and_save_deployment(
         self, healthcheck_result: DeploymentHealthcheckResult
-    ) -> Optional[SimpleDeploymentDetails]:
+    ) -> str:
         try:
             deployment: DockerDeployment = (
                 await DockerDeployment.objects.filter(

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -761,6 +761,7 @@ class DockerSwarmActivities:
         await DockerDeployment.objects.filter(hash=deployment.hash).aupdate(
             status=DockerDeployment.DeploymentStatus.CANCELLED,
             status_reason="Deployment cancelled.",
+            finished_at=timezone.now(),
         )
         await deployment_log(
             deployment,

--- a/backend/zane_api/temporal/main.py
+++ b/backend/zane_api/temporal/main.py
@@ -1,7 +1,9 @@
 from datetime import timedelta
 from typing import Any, Awaitable, Callable, Union
 
+import temporalio.common
 from temporalio import workflow
+from temporalio.service import RPCError
 
 with workflow.unsafe.imports_passed_through():
     from asgiref.sync import async_to_sync
@@ -97,3 +99,26 @@ async def start_workflow(
         pass
 
     return client.get_workflow_handle(id)
+
+
+@async_to_sync
+async def workflow_signal(
+    workflow: Union[str, Callable[..., Awaitable[Any]]],
+    workflow_id: str,
+    signal: Union[str, Callable[..., Awaitable[Any]]],
+    arg: Any = temporalio.common._arg_unset,
+    timeout: timedelta = timedelta(seconds=5),
+):
+    client = await get_temporalio_client()
+    workflow_handle = await client.get_workflow_handle_for(
+        workflow=workflow, workflow_id=workflow_id
+    )
+    try:
+        await workflow_handle.signal(
+            signal,
+            arg=arg,
+            rpc_timeout=timeout,
+        )
+    except RPCError:
+        # probably because the signal sent to the workflow could not be executed
+        pass

--- a/backend/zane_api/temporal/main.py
+++ b/backend/zane_api/temporal/main.py
@@ -110,7 +110,7 @@ async def workflow_signal(
     timeout: timedelta = timedelta(seconds=5),
 ):
     client = await get_temporalio_client()
-    workflow_handle = await client.get_workflow_handle_for(
+    workflow_handle = client.get_workflow_handle_for(
         workflow=workflow, workflow_id=workflow_id
     )
     try:

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -79,7 +79,7 @@ class DockerDeploymentDetails:
         pause_at_step: Enum = None,
     ):
         return cls(
-            pause_at_step=pause_at_step.value,
+            pause_at_step=pause_at_step.value if pause_at_step is not None else 0,
             hash=deployment.hash,
             slot=deployment.slot,
             auth_token=auth_token,

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -36,14 +36,11 @@ class DockerDeploymentDetails:
     auth_token: str
     unprefixed_hash: str
     queued_at: str
+    workflow_id: str
     service: DockerServiceSnapshot
     url: Optional[str] = None
     changes: List[DeploymentChangeDto] = field(default_factory=list)
     pause_at_step: int = 0
-
-    @property
-    def workflow_id(self):
-        return f"deploy-{self.service.id}-{self.service.project_id}"
 
     @classmethod
     def from_deployment(
@@ -71,6 +68,7 @@ class DockerDeploymentDetails:
                 )
                 for change in deployment.changes.all()
             ],
+            workflow_id=deployment.workflow_id,
         )
 
     @classmethod

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -172,3 +172,8 @@ class DeployDockerServiceWorkflowResult:
     deployment_status: str
     healthcheck_result: Optional[DeploymentHealthcheckResult] = None
     next_queued_deployment: Optional[DockerDeploymentDetails] = None
+
+
+@dataclass
+class CancelDeploymentSignalInput:
+    deployment_hash: str

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -99,6 +99,7 @@ class DockerDeploymentDetails:
                 )
                 async for change in deployment.changes.all()
             ],
+            workflow_id=deployment.workflow_id,
         )
 
     @property

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -125,6 +125,13 @@ class DeploymentHealthcheckResult:
 
 
 @dataclass
+class DeploymentCreateVolumesResult:
+    deployment_hash: str
+    service_id: str
+    created_volumes: List[VolumeDto] = field(default_factory=list)
+
+
+@dataclass
 class SimpleDeploymentDetails:
     hash: str
     project_id: str

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -88,3 +88,16 @@ class HealthcheckDeploymentDetails:
     deployment: SimpleDeploymentDetails
     auth_token: str
     healthcheck: Optional[HealthCheckDto] = None
+
+
+@dataclass
+class CancelDeploymentResult:
+    success: bool
+    message: Optional[str] = None
+
+
+@dataclass
+class DeployDockerServiceWorkflowResult:
+    deployment_status: str
+    healthcheck_result: Optional[DeploymentHealthcheckResult] = None
+    next_queued_deployment: Optional[DeploymentDetails] = None

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -162,12 +162,6 @@ class HealthcheckDeploymentDetails:
 
 
 @dataclass
-class CancelDeploymentResult:
-    success: bool
-    message: Optional[str] = None
-
-
-@dataclass
 class DeployDockerServiceWorkflowResult:
     deployment_status: str
     healthcheck_result: Optional[DeploymentHealthcheckResult] = None

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -1,5 +1,4 @@
 import asyncio
-from dataclasses import dataclass
 from datetime import timedelta
 from enum import Enum, auto
 from typing import Optional, List
@@ -115,12 +114,6 @@ class RemoveProjectResourcesWorkflow:
             start_to_close_timeout=timedelta(seconds=10),
             retry_policy=retry_policy,
         )
-
-
-@dataclass
-class CancelDeploymentResult:
-    success: bool
-    message: Optional[str] = None
 
 
 class DockerDeploymentStep(Enum):

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -179,6 +179,19 @@ class DeployDockerServiceWorkflow:
         )
 
         async def check_for_cancellation():
+            """
+            This function allows us to pause and potentially bypass the workflow's execution
+            during testing. It is useful for stopping the workflow at specific points to
+            simulate and handle cancellation.
+
+            Because workflows are asynchronous, the workflow might progress to another step
+            by the time the user triggers `cancel_deployment`. This function helps ensure
+            that the workflow can pause at a predefined step (indicated by `pause_at_step`)
+            and wait for a cancellation signal.
+
+            Note: `pause_at_step`  is intended only for testing and should not be used in
+            the application logic.
+            """
             if pause_at_step is not None:
                 if pause_at_step != self.last_completed_step:
                     return False

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -413,7 +413,12 @@ class DeployDockerServiceWorkflow:
                     retry_policy=retry_policy,
                 )
         if self.last_completed_step >= DockerDeploymentStep.VOLUMES_CREATED:
-            raise NotImplementedError
+            await workflow.execute_activity_method(
+                DockerSwarmActivities.delete_created_volumes,
+                deployment,
+                start_to_close_timeout=timedelta(seconds=5),
+                retry_policy=retry_policy,
+            )
 
         await workflow.execute_activity_method(
             DockerSwarmActivities.save_cancelled_deployment,
@@ -555,6 +560,7 @@ def get_workflows_and_activities():
             swarm_activities.prepare_deployment,
             swarm_activities.scale_down_service_deployment,
             swarm_activities.create_docker_volumes_for_service,
+            swarm_activities.delete_created_volumes,
             swarm_activities.create_swarm_service_for_docker_deployment,
             swarm_activities.run_deployment_healthcheck,
             swarm_activities.expose_docker_deployment_to_http,

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -394,7 +394,11 @@ class DeployDockerServiceWorkflow:
         if self.last_completed_step >= DockerDeploymentStep.SWARM_SERVICE_CREATED:
             await workflow.execute_activity_method(
                 DockerSwarmActivities.scale_down_and_remove_docker_service_deployment,
-                deployment,
+                SimpleDeploymentDetails(
+                    hash=deployment.hash,
+                    service_id=deployment.service.id,
+                    project_id=deployment.service.project_id,
+                ),
                 start_to_close_timeout=timedelta(seconds=60),
                 retry_policy=retry_policy,
             )

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -249,7 +249,7 @@ class AuthAPITestCase(APITestCase):
         return user
 
     @asynccontextmanager
-    async def workflowEnvironment(self, patch_start_workflow: bool = True):
+    async def workflowEnvironment(self):
         env = await WorkflowEnvironment.start_time_skipping()
         await env.__aenter__()
         worker = Worker(
@@ -313,11 +313,8 @@ class AuthAPITestCase(APITestCase):
         patch_temporal_delete_schedule.start()
         mock_get_client = patch_temporal_client.start()
         mock_client = mock_get_client.return_value
-        mock_client.start_workflow.side_effect = (
-            env.client.execute_workflow
-            if patch_start_workflow
-            else env.client.start_workflow
-        )
+        mock_client.start_workflow.side_effect = env.client.execute_workflow
+        mock_client.get_workflow_handle_for = env.client.get_workflow_handle_for
 
         patch_transaction_on_commit = patch(
             "django.db.transaction.on_commit", side_effect=collect_commit_callbacks

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -180,7 +180,6 @@ class AsyncCustomAPIClient(AsyncClient):
     CELERY_BROKER_URL="memory://",
     CELERY_TASK_STORE_EAGER_RESULT=True,
     CADDY_PROXY_ADMIN_HOST="http://127.0.0.1:2020",
-    TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT=timedelta(seconds=10),
 )
 class APITestCase(TestCase):
     def setUp(self):

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -430,7 +430,9 @@ class AuthAPITestCase(APITestCase):
             data=create_service_payload,
         )
         self.assertEqual(status.HTTP_201_CREATED, response.status_code)
-        service = await DockerRegistryService.objects.aget(slug="redis")
+        service: DockerRegistryService = await DockerRegistryService.objects.aget(
+            slug="redis"
+        )
 
         other_changes = other_changes if other_changes is not None else []
         if with_healthcheck:
@@ -462,12 +464,7 @@ class AuthAPITestCase(APITestCase):
             ),
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        service = (
-            await DockerRegistryService.objects.filter(id=service.id)
-            .select_related("project", "healthcheck")
-            .prefetch_related("volumes", "env_variables", "urls")
-            .afirst()
-        )
+        await service.arefresh_from_db()
         return project, service
 
     async def acreate_and_deploy_caddy_docker_service(
@@ -541,12 +538,7 @@ class AuthAPITestCase(APITestCase):
             ),
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        service = (
-            await DockerRegistryService.objects.filter(id=service.id)
-            .select_related("project", "healthcheck")
-            .prefetch_related("volumes", "env_variables", "urls")
-            .afirst()
-        )
+        await service.arefresh_from_db()
         return project, service
 
     def create_and_deploy_caddy_docker_service(

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -180,6 +180,7 @@ class AsyncCustomAPIClient(AsyncClient):
     CELERY_BROKER_URL="memory://",
     CELERY_TASK_STORE_EAGER_RESULT=True,
     CADDY_PROXY_ADMIN_HOST="http://127.0.0.1:2020",
+    TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT=timedelta(seconds=10),
 )
 class APITestCase(TestCase):
     def setUp(self):

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -174,7 +174,7 @@ class AsyncCustomAPIClient(AsyncClient):
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         }
     },
-    # DEBUG=True,  # uncomment for debugging celery tasks
+    # DEBUG=True,  # uncomment for debugging temporalio workflows
     CELERY_TASK_ALWAYS_EAGER=True,
     CELERY_EAGER_PROPAGATES_EXCEPTIONS=True,
     CELERY_BROKER_URL="memory://",
@@ -462,7 +462,12 @@ class AuthAPITestCase(APITestCase):
             ),
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        await service.arefresh_from_db()
+        service = (
+            await DockerRegistryService.objects.filter(id=service.id)
+            .select_related("project", "healthcheck")
+            .prefetch_related("volumes", "env_variables", "urls")
+            .afirst()
+        )
         return project, service
 
     async def acreate_and_deploy_caddy_docker_service(
@@ -536,7 +541,12 @@ class AuthAPITestCase(APITestCase):
             ),
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
-        await service.arefresh_from_db()
+        service = (
+            await DockerRegistryService.objects.filter(id=service.id)
+            .select_related("project", "healthcheck")
+            .prefetch_related("volumes", "env_variables", "urls")
+            .afirst()
+        )
         return project, service
 
     def create_and_deploy_caddy_docker_service(

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -249,7 +249,7 @@ class AuthAPITestCase(APITestCase):
         return user
 
     @asynccontextmanager
-    async def workflowEnvironment(self):
+    async def workflowEnvironment(self, patch_start_workflow: bool = True):
         env = await WorkflowEnvironment.start_time_skipping()
         await env.__aenter__()
         worker = Worker(
@@ -313,7 +313,11 @@ class AuthAPITestCase(APITestCase):
         patch_temporal_delete_schedule.start()
         mock_get_client = patch_temporal_client.start()
         mock_client = mock_get_client.return_value
-        mock_client.start_workflow.side_effect = env.client.execute_workflow
+        mock_client.start_workflow.side_effect = (
+            env.client.execute_workflow
+            if patch_start_workflow
+            else env.client.start_workflow
+        )
 
         patch_transaction_on_commit = patch(
             "django.db.transaction.on_commit", side_effect=collect_commit_callbacks

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -10,6 +10,7 @@ from django.db.models import Q
 from django.urls import reverse
 from rest_framework import status
 from rest_framework.authtoken.models import Token
+from temporalio.common import RetryPolicy
 from temporalio.testing import WorkflowEnvironment
 
 from .base import AuthAPITestCase
@@ -4241,6 +4242,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow=DeployDockerServiceWorkflow.run,
                 arg=payload,
                 id=payload.workflow_id,
+                retry_policy=RetryPolicy(
+                    maximum_attempts=1,
+                ),
                 task_queue=settings.TEMPORALIO_MAIN_TASK_QUEUE,
                 execution_timeout=settings.TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT,
             )
@@ -4301,6 +4305,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow=DeployDockerServiceWorkflow.run,
                 arg=payload,
                 id=payload.workflow_id,
+                retry_policy=RetryPolicy(
+                    maximum_attempts=1,
+                ),
                 task_queue=settings.TEMPORALIO_MAIN_TASK_QUEUE,
                 execution_timeout=settings.TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT,
             )
@@ -4369,6 +4376,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow=DeployDockerServiceWorkflow.run,
                 arg=payload,
                 id=payload.workflow_id,
+                retry_policy=RetryPolicy(
+                    maximum_attempts=1,
+                ),
                 task_queue=settings.TEMPORALIO_MAIN_TASK_QUEUE,
                 execution_timeout=settings.TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT,
             )
@@ -4434,6 +4444,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow=DeployDockerServiceWorkflow.run,
                 arg=payload,
                 id=payload.workflow_id,
+                retry_policy=RetryPolicy(
+                    maximum_attempts=1,
+                ),
                 task_queue=settings.TEMPORALIO_MAIN_TASK_QUEUE,
                 execution_timeout=settings.TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT,
             )
@@ -4484,6 +4497,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow=DeployDockerServiceWorkflow.run,
                 arg=payload,
                 id=payload.workflow_id,
+                retry_policy=RetryPolicy(
+                    maximum_attempts=1,
+                ),
                 task_queue=settings.TEMPORALIO_MAIN_TASK_QUEUE,
                 execution_timeout=settings.TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT,
             )
@@ -4570,6 +4586,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow=DeployDockerServiceWorkflow.run,
                 arg=payload,
                 id=payload.workflow_id,
+                retry_policy=RetryPolicy(
+                    maximum_attempts=1,
+                ),
                 task_queue=settings.TEMPORALIO_MAIN_TASK_QUEUE,
                 execution_timeout=settings.TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT,
             )
@@ -4627,6 +4646,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow=DeployDockerServiceWorkflow.run,
                 arg=payload,
                 id=payload.workflow_id,
+                retry_policy=RetryPolicy(
+                    maximum_attempts=1,
+                ),
                 task_queue=settings.TEMPORALIO_MAIN_TASK_QUEUE,
                 execution_timeout=settings.TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT,
             )
@@ -4676,6 +4698,9 @@ class DockerServiceCancelDeploymentViewTests(AuthAPITestCase):
                 workflow=DeployDockerServiceWorkflow.run,
                 arg=payload,
                 id=payload.workflow_id,
+                retry_policy=RetryPolicy(
+                    maximum_attempts=1,
+                ),
                 task_queue=settings.TEMPORALIO_MAIN_TASK_QUEUE,
                 execution_timeout=settings.TEMPORALIO_WORKFLOW_EXECUTION_MAX_TIMEOUT,
             )

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -33,6 +33,7 @@ from ..temporal import (
     DockerDeploymentStep,
     DeployDockerServiceWorkflow,
     DeployDockerServiceWorkflowResult,
+    CancelDeploymentSignalInput,
 )
 from ..utils import convert_value_to_bytes
 
@@ -4224,7 +4225,7 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
             service_snapshot = await sync_to_async(
                 lambda: DockerServiceSerializer(service).data
             )()
-            new_deployment = await DockerDeployment.objects.acreate(
+            new_deployment: DockerDeployment = await DockerDeployment.objects.acreate(
                 service_snapshot=service_snapshot,
                 service=service,
             )
@@ -4248,6 +4249,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow_handle.result(),
                 workflow_handle.signal(
                     DeployDockerServiceWorkflow.cancel_deployment,
+                    arg=CancelDeploymentSignalInput(
+                        deployment_hash=new_deployment.hash
+                    ),
                     rpc_timeout=timedelta(seconds=5),
                 ),
             )  # type: DeployDockerServiceWorkflowResult, None
@@ -4305,6 +4309,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow_handle.result(),
                 workflow_handle.signal(
                     DeployDockerServiceWorkflow.cancel_deployment,
+                    arg=CancelDeploymentSignalInput(
+                        deployment_hash=new_deployment.hash
+                    ),
                     rpc_timeout=timedelta(seconds=5),
                 ),
             )  # type: DeployDockerServiceWorkflowResult, None
@@ -4370,6 +4377,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow_handle.result(),
                 workflow_handle.signal(
                     DeployDockerServiceWorkflow.cancel_deployment,
+                    arg=CancelDeploymentSignalInput(
+                        deployment_hash=new_deployment.hash
+                    ),
                     rpc_timeout=timedelta(seconds=5),
                 ),
             )  # type: DeployDockerServiceWorkflowResult, None
@@ -4406,8 +4416,6 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
             owner = await self.aLoginUser()
             p, service = await self.acreate_and_deploy_redis_docker_service()
 
-            production_deployment = await service.alatest_production_deployment
-
             new_deployment = await DockerDeployment.objects.acreate(
                 service=service,
                 service_snapshot=await sync_to_async(
@@ -4434,6 +4442,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow_handle.result(),
                 workflow_handle.signal(
                     DeployDockerServiceWorkflow.cancel_deployment,
+                    arg=CancelDeploymentSignalInput(
+                        deployment_hash=new_deployment.hash
+                    ),
                     rpc_timeout=timedelta(seconds=5),
                 ),
             )  # type: DeployDockerServiceWorkflowResult, None
@@ -4481,6 +4492,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow_handle.result(),
                 workflow_handle.signal(
                     DeployDockerServiceWorkflow.cancel_deployment,
+                    arg=CancelDeploymentSignalInput(
+                        deployment_hash=new_deployment.hash
+                    ),
                     rpc_timeout=timedelta(seconds=5),
                 ),
             )  # type: DeployDockerServiceWorkflowResult, None
@@ -4564,6 +4578,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow_handle.result(),
                 workflow_handle.signal(
                     DeployDockerServiceWorkflow.cancel_deployment,
+                    arg=CancelDeploymentSignalInput(
+                        deployment_hash=new_deployment.hash
+                    ),
                     rpc_timeout=timedelta(seconds=5),
                 ),
             )  # type: DeployDockerServiceWorkflowResult, None
@@ -4618,6 +4635,9 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 workflow_handle.result(),
                 workflow_handle.signal(
                     DeployDockerServiceWorkflow.cancel_deployment,
+                    arg=CancelDeploymentSignalInput(
+                        deployment_hash=new_deployment.hash
+                    ),
                     rpc_timeout=timedelta(seconds=5),
                 ),
             )  # type: DeployDockerServiceWorkflowResult, None

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -4315,5 +4315,4 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
                 new_deployment
             )
             self.assertIsNone(docker_deployment)
-            print(self.fake_docker_client.volume_map)
             self.assertEqual(0, len(self.fake_docker_client.volume_map))

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -4262,24 +4262,24 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
     async def test_cancel_deployment_at_volume_created_step(self):
         async with self.workflowEnvironment() as env:  # type: WorkflowEnvironment
             owner = await self.aLoginUser()
-            p, service = await self.acreate_and_deploy_redis_docker_service(
-                other_changes=[
-                    DockerDeploymentChange(
-                        field=DockerDeploymentChange.ChangeField.VOLUMES,
-                        type=DockerDeploymentChange.ChangeType.ADD,
-                        new_value={
-                            "container_path": "/data",
-                            "mode": Volume.VolumeMode.READ_WRITE,
-                        },
-                    ),
-                ]
-            )
+            p, service = await self.acreate_and_deploy_redis_docker_service()
+
             service_snapshot = await sync_to_async(
                 lambda: DockerServiceSerializer(service).data
             )()
             new_deployment = await DockerDeployment.objects.acreate(
                 service_snapshot=service_snapshot,
                 service=service,
+            )
+            await DockerDeploymentChange.objects.acreate(
+                field=DockerDeploymentChange.ChangeField.VOLUMES,
+                type=DockerDeploymentChange.ChangeType.ADD,
+                new_value={
+                    "container_path": "/data",
+                    "mode": Volume.VolumeMode.READ_WRITE,
+                },
+                service=service,
+                deployment=new_deployment,
             )
 
             token = await Token.objects.aget(user=owner)

--- a/backend/zane_api/tests/project.py
+++ b/backend/zane_api/tests/project.py
@@ -2,7 +2,6 @@ from unittest.mock import patch
 
 from django.urls import reverse
 from rest_framework import status
-from temporalio.client import WorkflowFailureError
 
 from .base import AuthAPITestCase
 from ..models import (
@@ -466,21 +465,6 @@ class DockerRemoveNetworkTest(AuthAPITestCase):
             reverse("zane_api:projects.details", kwargs={"slug": project.slug})
         )
         self.assertEqual(status.HTTP_204_NO_CONTENT, response.status_code)
-        archived_project: ArchivedProject = await ArchivedProject.objects.filter(
-            original_id=project.id
-        ).afirst()
-        self.assertIsNotNone(archived_project)
-        self.assertIsNone(self.fake_docker_client.get_network(project))
-        self.assertEqual(0, len(self.fake_docker_client.get_networks()))
-
-    async def test_with_nonexistent_network(self):
-        owner = await self.aLoginUser()
-        project = await Project.objects.acreate(slug="zane-ops", owner=owner)
-        with self.assertRaises(WorkflowFailureError):
-            await self.async_client.delete(
-                reverse("zane_api:projects.details", kwargs={"slug": project.slug})
-            )
-
         archived_project: ArchivedProject = await ArchivedProject.objects.filter(
             original_id=project.id
         ).afirst()

--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -108,7 +108,7 @@ urlpatterns += [
     re_path(
         r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/cancel-deployment/docker"
         r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
-        views.RedeployDockerServiceAPIView.as_view(),
+        views.CancelDockerServiceDeploymentAPIView.as_view(),
         name="services.docker.cancel_deployment",
     ),
     re_path(

--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -106,6 +106,12 @@ urlpatterns += [
         name="services.docker.redeploy_service",
     ),
     re_path(
+        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/cancel-deployment/docker"
+        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
+        views.RedeployDockerServiceAPIView.as_view(),
+        name="services.docker.cancel_deployment",
+    ),
+    re_path(
         r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/archive-service/docker"
         r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/?$",
         views.ArchiveDockerServiceAPIView.as_view(),

--- a/backend/zane_api/utils.py
+++ b/backend/zane_api/utils.py
@@ -241,4 +241,5 @@ class Colors:
     BLUE = "\033[94m"
     YELLOW = "\033[93m"
     RED = "\033[91m"
+    GREY = "\033[90m"
     ENDC = "\033[0m"  # Reset to default color

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -12,7 +12,7 @@ from drf_spectacular.utils import (
     PolymorphicProxySerializer,
 )
 from faker import Faker
-from rest_framework import status, exceptions, serializers
+from rest_framework import status, exceptions
 from rest_framework.authtoken.models import Token
 from rest_framework.generics import ListAPIView, RetrieveAPIView
 from rest_framework.request import Request
@@ -81,6 +81,7 @@ from ..temporal import (
     SimpleDeploymentDetails,
     ToggleDockerServiceWorkflow,
     workflow_signal,
+    CancelDeploymentSignalInput,
 )
 
 
@@ -636,13 +637,7 @@ class CancelDockerServiceDeploymentAPIView(APIView):
     @transaction.atomic()
     @extend_schema(
         request=None,
-        responses={
-            409: ErrorResponse409Serializer,
-            200: inline_serializer(
-                name="CancelDockerServiveDeploymentResponseSerializer",
-                fields={"success": serializers.BooleanField()},
-            ),
-        },
+        responses={409: ErrorResponse409Serializer, 200: DockerServiceSerializer},
         operation_id="cancelDockerServiceDeployment",
         summary="Cancel deployment",
         description="Cancel a deployment in progress.",
@@ -698,7 +693,8 @@ class CancelDockerServiceDeploymentAPIView(APIView):
             )
         )
 
-        return Response({"sucess": True}, status=status.HTTP_200_OK)
+        response = DockerServiceDeploymentSerializer(deployment)
+        return Response(response.data, status=status.HTTP_200_OK)
 
 
 class GetDockerServiceAPIView(APIView):

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -688,6 +688,7 @@ class CancelDockerServiceDeploymentAPIView(APIView):
         transaction.on_commit(
             lambda: workflow_signal(
                 workflow=DeployDockerServiceWorkflow.run,
+                arg=CancelDeploymentSignalInput(deployment_hash=deployment.hash),
                 signal=DeployDockerServiceWorkflow.cancel_deployment,
                 workflow_id=deployment.workflow_id,
             )

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -1070,7 +1070,6 @@ class BaseServiceCardSerializer(serializers.Serializer):
         ("SLEEPING", _("Sleeping")),
         ("NOT_DEPLOYED_YET", _("Not deployed yet")),
         ("DEPLOYING", _("Deploying")),
-        ("CANCELLED", _("Cancelled")),
     )
     status = serializers.ChoiceField(choices=STATUS_CHOICES)
     id = serializers.CharField(required=True)

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -5712,7 +5712,6 @@ components:
       - SLEEPING
       - NOT_DEPLOYED_YET
       - DEPLOYING
-      - CANCELLED
       type: string
       description: |-
         * `HEALTHY` - Healthy
@@ -5720,7 +5719,6 @@ components:
         * `SLEEPING` - Sleeping
         * `NOT_DEPLOYED_YET` - Not deployed yet
         * `DEPLOYING` - Deploying
-        * `CANCELLED` - Cancelled
     SimpleLog:
       type: object
       properties:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -1073,7 +1073,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/CancelDockerServiveDeploymentResponse'
+                $ref: '#/components/schemas/DockerService'
           description: ''
   /api/projects/{project_slug}/cancel-service-changes/docker/{service_slug}/{change_id}/:
     delete:
@@ -2676,13 +2676,6 @@ components:
         propertyName: type
         mapping:
           client_error: '#/components/schemas/ParseErrorResponse'
-    CancelDockerServiveDeploymentResponse:
-      type: object
-      properties:
-        success:
-          type: boolean
-      required:
-      - success
     CheckIfPortIsAvailableError:
       oneOf:
       - $ref: '#/components/schemas/CheckIfPortIsAvailableNonFieldErrorsErrorComponent'

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -979,6 +979,102 @@ paths:
           description: ''
         '204':
           description: No response body
+  /api/projects/{project_slug}/cancel-deployment/docker/{service_slug}/{deployment_hash}/:
+    put:
+      operationId: cancelDockerServiceDeployment
+      description: Cancel a deployment in progress.
+      summary: Cancel deployment
+      parameters:
+      - in: path
+        name: deployment_hash
+        schema:
+          type: string
+          pattern: ^[a-zA-Z0-9-_]+$
+        required: true
+      - in: path
+        name: project_slug
+        schema:
+          type: string
+          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+        required: true
+      - in: path
+        name: service_slug
+        schema:
+          type: string
+          pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
+        required: true
+      tags:
+      - projects
+      security:
+      - cookieAuth: []
+      responses:
+        '400':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelDockerServiceDeploymentErrorResponse400'
+          description: ''
+        '401':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse401'
+              examples:
+                AuthenticationFailed:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: authentication_failed
+                      detail: Incorrect authentication credentials.
+                      attr: null
+                NotAuthenticated:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_authenticated
+                      detail: Authentication credentials were not provided.
+                      attr: null
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse404'
+              examples:
+                NotFound:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: not_found
+                      detail: Not found.
+                      attr: null
+          description: ''
+        '429':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse429'
+              examples:
+                Throttled:
+                  value:
+                    type: client_error
+                    errors:
+                    - code: throttled
+                      detail: Request was throttled.
+                      attr: null
+          description: ''
+        '409':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse409'
+          description: ''
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CancelDockerServiveDeploymentResponse'
+          description: ''
   /api/projects/{project_slug}/cancel-service-changes/docker/{service_slug}/{change_id}/:
     delete:
       operationId: cancelDeploymentChanges
@@ -2573,6 +2669,20 @@ components:
         propertyName: type
         mapping:
           client_error: '#/components/schemas/ParseErrorResponse'
+    CancelDockerServiceDeploymentErrorResponse400:
+      oneOf:
+      - $ref: '#/components/schemas/ParseErrorResponse'
+      discriminator:
+        propertyName: type
+        mapping:
+          client_error: '#/components/schemas/ParseErrorResponse'
+    CancelDockerServiveDeploymentResponse:
+      type: object
+      properties:
+        success:
+          type: boolean
+      required:
+      - success
     CheckIfPortIsAvailableError:
       oneOf:
       - $ref: '#/components/schemas/CheckIfPortIsAvailableNonFieldErrorsErrorComponent'


### PR DESCRIPTION
## Description

In this PR, we implemented a new feature for cancelling running deployments. How it works :
- The workflow that runs a deployment receive a cancellation signal, up until the workflow hasn't reached the step `finish_and_save_deployment` yet, else the cancellation will be ignored. 
- If the deployment has already finished, the cancel operation will be ignored
- If the deployment hasn't started yet, we automatically modify the state of the deployment to `CANCELLED`, even if the deployment just started, the workflow will eventually reflect the state of the deployment. 

There is also some refactors made : 
- to prevent repeating ourselves, we added a lot of the deployment methods that are used everywhere, ex: getting the next deployment slot, getting the payload to send to the deployment workflow, etc
- Same done to the request made to the proxy in preparation for the future
- We removed the `CANCELLED` status from the UI, in the project detail page because it doesn't give us any real productive information, and when a deployment is cancelled, it is rolled back and the UI should show the status of the last deployment instead

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
