### PR TITLE
:recycle: separate backend images in specific components

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -45,6 +45,7 @@ SECRET_KEY = os.environ.get(
 TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "DEVELOPMENT")
 PRODUCTION_ENV = "PRODUCTION"
+BACKEND_COMPONENT = os.environ.get("BACKEND_COMPONENT", "API")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = ENVIRONMENT != PRODUCTION_ENV
@@ -349,7 +350,7 @@ DEFAULT_HEALTHCHECK_TIMEOUT = 30  # seconds
 DEFAULT_HEALTHCHECK_INTERVAL = 30  # seconds
 DEFAULT_HEALTHCHECK_WAIT_INTERVAL = 5.0  # seconds
 
-if not TESTING:
+if not TESTING and BACKEND_COMPONENT == "API":
     register_zaneops_app_on_proxy(
         proxy_url=CADDY_PROXY_ADMIN_HOST,
         zane_app_domain=ZANE_APP_DOMAIN,

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -23,6 +23,8 @@ services:
       - db
       - redis
     network_mode: host
+    environment:
+      BACKEND_COMPONENT: WORKER
   registry:
     image: registry:2
     container_name: zane-registry

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -1,18 +1,17 @@
 x-backend-vars: &env-vars
-  environment:
-    ENVIRONMENT: PRODUCTION
-    REDIS_URL: redis://zane.valkey:6379/0
-    DB_HOST: zane.db
-    DB_PORT: 5432
-    DB_NAME: zane
-    DB_USER: ${ZANE_DB_USER:-zane}
-    DB_PASSWORD: ${ZANE_DB_PASSWORD}
-    ROOT_DOMAIN: ${ROOT_DOMAIN}
-    ZANE_APP_DOMAIN: ${ZANE_APP_DOMAIN}
-    DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
-    CADDY_PROXY_ADMIN_HOST: http://zane.proxy:2019
-    ZANE_FLUENTD_HOST: unix://${ZANE_APP_DIRECTORY:-/var/www/zaneops}/.fluentd/fluentd.sock
-    TEMPORALIO_SERVER_URL: zane.temporal:7233
+  ENVIRONMENT: PRODUCTION
+  REDIS_URL: redis://zane.valkey:6379/0
+  DB_HOST: zane.db
+  DB_PORT: 5432
+  DB_NAME: zane
+  DB_USER: ${ZANE_DB_USER:-zane}
+  DB_PASSWORD: ${ZANE_DB_PASSWORD}
+  ROOT_DOMAIN: ${ROOT_DOMAIN}
+  ZANE_APP_DOMAIN: ${ZANE_APP_DOMAIN}
+  DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+  CADDY_PROXY_ADMIN_HOST: http://zane.proxy:2019
+  ZANE_FLUENTD_HOST: unix://${ZANE_APP_DIRECTORY:-/var/www/zaneops}/.fluentd/fluentd.sock
+  TEMPORALIO_SERVER_URL: zane.temporal:7233
 
 services:
   proxy:
@@ -107,7 +106,8 @@ services:
         aliases:
           - zane.api
           - zane.api.zaneops.internal
-    <<: *env-vars
+    environment:
+      <<: *env-vars
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
     depends_on:
@@ -115,7 +115,7 @@ services:
       - valkey
       - proxy
   temporal-server:
-    entrypoint: ["/etc/temporal/entrypoint.sh"]
+    entrypoint: [ "/etc/temporal/entrypoint.sh" ]
     environment:
       - DB=postgres12
       - DB_PORT=5432
@@ -164,7 +164,9 @@ services:
       - valkey
       - proxy
       - temporal-server
-    <<: *env-vars
+    environment:
+      <<: *env-vars
+      BACKEND_COMPONENT: WORKER
     deploy:
       replicas: 1
       update_config:
@@ -207,7 +209,7 @@ services:
         aliases:
           - zane.valkey
     healthcheck:
-      test: ["CMD", "valkey-cli", "ping"]
+      test: [ "CMD", "valkey-cli", "ping" ]
       interval: 5s
       retries: 10
       timeout: 2s
@@ -237,7 +239,7 @@ services:
           cpus: "1"
           memory: 500M
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      test: [ "CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}" ]
       interval: 10s
       retries: 5
       start_period: 30s


### PR DESCRIPTION
## Description

In this PR, we added a new concept named backend components, since the `backend` image will be reused for different things, this allows us to identify which component it is used for. 
As of now, we only have two components that use the backend image, the API and temporal worker, but in the future, there will also be the builder. 
This also allows us to not call the proxy to register the URLs of the API & front in `settings.py` for the other components, only the API is supposed to do that. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
