### PR TITLE
Fix/deployment logs not being saved in DEV

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -326,7 +326,6 @@ def get_caddy_request_for_url(
     service: DockerServiceSnapshot,
     current_deployment_hash: str = None,
     current_deployment_slot: str = None,
-    service_id: str = None,
     previous_deployment_hash: str = None,
     previous_deployment_slot: str = None,
 ):
@@ -348,7 +347,7 @@ def get_caddy_request_for_url(
         {
             "handler": "log_append",
             "key": "zane_service_id",
-            "value": service_id,
+            "value": service.id,
         },
         {
             "handler": "log_append",
@@ -369,6 +368,15 @@ def get_caddy_request_for_url(
             "handler": "log_append",
             "key": "zane_request_id",
             "value": "{http.request.uuid}",
+        },
+        {
+            "handler": "request",
+            "request": {
+                "add": {
+                    "server": ["zaneops"],
+                    "x-request-id": ["{http.request.uuid}"],
+                },
+            },
         },
     ]
 
@@ -493,7 +501,6 @@ def upsert_url_in_proxy(
         service,
         current_deployment_hash=deployment.hash,
         current_deployment_slot=deployment.slot,
-        service_id=deployment.service.id,
         previous_deployment_hash=(
             previous_deployment.hash if previous_deployment is not None else None
         ),

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -370,8 +370,8 @@ def get_caddy_request_for_url(
             "value": "{http.request.uuid}",
         },
         {
-            "handler": "request",
-            "request": {
+            "handler": "headers",
+            "response": {
                 "add": {
                     "server": ["zaneops"],
                     "x-request-id": ["{http.request.uuid}"],

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -377,6 +377,11 @@ def get_caddy_request_for_url(
                     "x-request-id": ["{http.request.uuid}"],
                 },
             },
+            "request": {
+                "add": {
+                    "x-request-id": ["{http.request.uuid}"],
+                },
+            },
         },
     ]
 

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -365,6 +365,11 @@ def get_caddy_request_for_url(
             "key": "zane_deployment_upstream",
             "value": "{http.reverse_proxy.upstream.hostport}",
         },
+        {
+            "handler": "log_append",
+            "key": "zane_request_id",
+            "value": "{http.request.uuid}",
+        },
     ]
 
     if url.strip_prefix:

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -1000,6 +1000,7 @@ class DockerContainerLogsResponseSerializer(serializers.Serializer):
 class DeploymentLogsFilterSet(django_filters.FilterSet):
     time = django_filters.DateTimeFromToRangeFilter()
     content = django_filters.CharFilter(method="filter_content")
+    source = django_filters.MultipleChoiceFilter(choices=SimpleLog.LogSource.choices)
 
     @staticmethod
     def filter_content(queryset: QuerySet, name: str, value: str):
@@ -1009,7 +1010,7 @@ class DeploymentLogsFilterSet(django_filters.FilterSet):
 
     class Meta:
         model = SimpleLog
-        fields = ["level", "content", "time"]
+        fields = ["level", "content", "time", "source"]
 
 
 class DeploymentLogsPagination(pagination.CursorPagination):

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -1034,6 +1034,7 @@ class DeploymentHttpLogsFilterSet(django_filters.FilterSet):
             "request_host",
             "status",
             "request_ip",
+            "request_id",
         ]
 
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
     network_mode: host
     environment:
       BACKEND_COMPONENT: WORKER
+      ZANE_FLUENTD_HOST: unix://${HOME}/.fluentd/fluentd.sock
   registry:
     image: registry:2
     container_name: zane-registry

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -2054,6 +2054,22 @@ paths:
           pattern: ^[a-z0-9]+(?:-[a-z0-9]+)*$
         required: true
       - in: query
+        name: source
+        schema:
+          type: array
+          items:
+            type: string
+            enum:
+            - PROXY
+            - SERVICE
+            - SYSTEM
+        description: |-
+          * `SYSTEM` - System Logs
+          * `PROXY` - Proxy Logs
+          * `SERVICE` - Service Logs
+        explode: true
+        style: form
+      - in: query
         name: time_after
         schema:
           type: string
@@ -4751,12 +4767,14 @@ components:
       - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListLevelErrorComponent'
       - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListContentErrorComponent'
       - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListTimeErrorComponent'
+      - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListSourceErrorComponent'
       discriminator:
         propertyName: attr
         mapping:
           level: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListLevelErrorComponent'
           content: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListContentErrorComponent'
           time: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListTimeErrorComponent'
+          source: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListSourceErrorComponent'
     ProjectsServiceDetailsDockerDeploymentsLogsListErrorResponse400:
       oneOf:
       - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsLogsListValidationError'
@@ -4779,6 +4797,28 @@ components:
           - invalid_choice
           type: string
           description: '* `invalid_choice` - invalid_choice'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    ProjectsServiceDetailsDockerDeploymentsLogsListSourceErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - source
+          type: string
+          description: '* `source` - source'
+        code:
+          enum:
+          - invalid_choice
+          - invalid_list
+          type: string
+          description: |-
+            * `invalid_choice` - invalid_choice
+            * `invalid_list` - invalid_list
         detail:
           type: string
       required:

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -1887,6 +1887,10 @@ paths:
         schema:
           type: string
       - in: query
+        name: request_id
+        schema:
+          type: string
+      - in: query
         name: request_ip
         schema:
           type: string
@@ -4522,6 +4526,7 @@ components:
       - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListRequestHostErrorComponent'
       - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListStatusErrorComponent'
       - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListRequestIpErrorComponent'
+      - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListRequestIdErrorComponent'
       discriminator:
         propertyName: attr
         mapping:
@@ -4531,6 +4536,7 @@ components:
           request_host: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListRequestHostErrorComponent'
           status: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListStatusErrorComponent'
           request_ip: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListRequestIpErrorComponent'
+          request_id: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListRequestIdErrorComponent'
     ProjectsServiceDetailsDockerDeploymentsHttpLogsListErrorResponse400:
       oneOf:
       - $ref: '#/components/schemas/ProjectsServiceDetailsDockerDeploymentsHttpLogsListValidationError'
@@ -4548,6 +4554,25 @@ components:
           - request_host
           type: string
           description: '* `request_host` - request_host'
+        code:
+          enum:
+          - null_characters_not_allowed
+          type: string
+          description: '* `null_characters_not_allowed` - null_characters_not_allowed'
+        detail:
+          type: string
+      required:
+      - attr
+      - code
+      - detail
+    ProjectsServiceDetailsDockerDeploymentsHttpLogsListRequestIdErrorComponent:
+      type: object
+      properties:
+        attr:
+          enum:
+          - request_id
+          type: string
+          description: '* `request_id` - request_id'
         code:
           enum:
           - null_characters_not_allowed


### PR DESCRIPTION
## Description

This PR fixes a bug where deployment logs for services weren't saved in `DEV`, this is because when we moved from celery to temporalio, we exposed the temporal worker to `network_host` and we forgot to include `ZANE_FLUENTD_HOST` env variable, we assumed that the default value of `unix://$HOME/.fluentd/fluentd.sock` would automatically resolve the `$HOME` env variable to the correct value, but since the worker is run inside of a container, that is not the case. 

The fix is to pass the `$ZANE_FLUENTD_HOST` to the image from the outside, like we do in production.

In this PR, there is also some new features : 
- we modified the `logs` endpoint to allow filtering by one or multiple sources.
- we modified the `http-logs` endpoint to allow filtering by `request_id`
- we include the request id in the service htttp logs so that it has a value (the default was `null`), that ID is also sent to the browser so the user can use it to filter in the UI 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
