### PR TITLE
:recycle: Do not use changes to remove old volumes

### DIFF
--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -196,9 +196,15 @@ class DeployDockerServiceWorkflow:
             if pause_at_step is not None:
                 if pause_at_step != last_completed_step:
                     return False
-                await workflow.wait_condition(
-                    lambda: self.cancellation_requested, timeout=timedelta(seconds=5)
-                )
+                try:
+                    await workflow.wait_condition(
+                        lambda: self.cancellation_requested,
+                        timeout=timedelta(seconds=5),
+                    )
+                except Exception:
+                    raise ApplicationError(
+                        non_retryable=True, message="Workflow condition timed out !!"
+                    )
             return self.cancellation_requested
 
         await workflow.execute_activity_method(

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -195,17 +195,17 @@ class DeployDockerServiceWorkflow:
             the application logic.
             """
             if pause_at_step is not None:
-                print(f"SHOULD PAUSE @ {pause_at_step=} and {last_completed_step=}")
                 if pause_at_step != last_completed_step:
                     return False
                 try:
-                    print(f"WAITING FOR : {pause_at_step=}")
                     await workflow.wait_condition(
                         lambda: self.cancellation_requested,
-                        timeout=timedelta(seconds=5),
+                        timeout=timedelta(seconds=10),
                     )
                 except Exception as e:
-                    print(f"exception={e}")
+                    print(
+                        f"check_for_cancellation({pause_at_step=}, {last_completed_step=}), exception={e}"
+                    )
                     traceback.print_exc()
                     raise ApplicationError(
                         non_retryable=True, message="Workflow condition timed out !!"

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -194,9 +194,11 @@ class DeployDockerServiceWorkflow:
             the application logic.
             """
             if pause_at_step is not None:
+                print(f"SHOULD PAUSE @ {pause_at_step=} and {last_completed_step=}")
                 if pause_at_step != last_completed_step:
                     return False
                 try:
+                    print(f"WAITING FOR : {pause_at_step=}")
                     await workflow.wait_condition(
                         lambda: self.cancellation_requested,
                         timeout=timedelta(seconds=5),

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -1,4 +1,5 @@
 import asyncio
+import traceback
 from datetime import timedelta
 from enum import Enum, auto
 from typing import Optional, List
@@ -203,7 +204,9 @@ class DeployDockerServiceWorkflow:
                         lambda: self.cancellation_requested,
                         timeout=timedelta(seconds=5),
                     )
-                except Exception:
+                except Exception as e:
+                    print(f"exception={e}")
+                    traceback.print_exc()
                     raise ApplicationError(
                         non_retryable=True, message="Workflow condition timed out !!"
                     )


### PR DESCRIPTION
## Description

In this PR, we fixed a sneaky bug for when we have to remove old volumes created by previous deployments in the deployment process.  

Previously if a deployment failed it would not delete those volumes if the next deployment does not have changes of type `REMOVE` volumes  in them. 
Now, we only remove old deployment by comparing all the volumes to the volumes attached to the service and removing any that is not.  

There is also persistent annoying flaky tests that I tried to mitigate by being more lenient on the `wait_condition` in `DeployDockerServiceWorkflow`. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
