### PR TITLE
:bug: Fix bug with temporal jobs failing background jobs because the worker hasn't run in a long time and DB connections have been dropped

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -12,6 +12,7 @@ from .main import create_schedule, delete_schedule, pause_schedule, unpause_sche
 
 with workflow.unsafe.imports_passed_through():
     from .schedules import MonitorDockerDeploymentWorkflow
+    from django import db
     import docker
     import docker.errors
     from ..models import (
@@ -1027,6 +1028,17 @@ class DockerSwarmActivities:
             deployment,
             f"Volumes deleted succesfully for deployment {Colors.YELLOW}{deployment.deployment_hash}{Colors.ENDC}  ✅",
         )
+
+    @activity.defn
+    async def close_faulty_db_connections(self):
+        """
+        This is to fix a bug we encountered when the worker hadn't run any job for a long time,
+        after that time, Django lost the DB connections, what is needed is to close the connection
+        so that Django can recreate the connection.
+        https://stackoverflow.com/questions/31504591/interfaceerror-connection-already-closed-using-django-celery-scrapy
+        """
+        for conn in db.connections.all():
+            conn.close_if_unusable_or_obsolete()
 
     @activity.defn
     async def scale_down_service_deployment(self, deployment: SimpleDeploymentDetails):

--- a/backend/zane_api/temporal/schedules/activities.py
+++ b/backend/zane_api/temporal/schedules/activities.py
@@ -35,6 +35,17 @@ class MonitorDockerDeploymentActivities:
         self.docker_client = get_docker_client()
 
     @activity.defn
+    async def monitor_close_faulty_db_connections(self):
+        """
+        This is to fix a bug we encountered when the worker hadn't run any job for a long time,
+        after that time, Django lost the DB connections, what is needed is to close the connection
+        so that Django can recreate the connection.
+        https://stackoverflow.com/questions/31504591/interfaceerror-connection-already-closed-using-django-celery-scrapy
+        """
+        for conn in db.connections.all():
+            conn.close_if_unusable_or_obsolete()
+
+    @activity.defn
     async def run_deployment_monitor_healthcheck(
         self,
         details: HealthcheckDeploymentDetails,

--- a/backend/zane_api/temporal/schedules/workflows.py
+++ b/backend/zane_api/temporal/schedules/workflows.py
@@ -18,6 +18,12 @@ class MonitorDockerDeploymentWorkflow:
         retry_policy = RetryPolicy(
             maximum_attempts=5, maximum_interval=timedelta(seconds=30)
         )
+        print(f"Running activity `monitor_close_faulty_db_connections()`")
+        await workflow.execute_activity_method(
+            MonitorDockerDeploymentActivities.monitor_close_faulty_db_connections,
+            retry_policy=retry_policy,
+            start_to_close_timeout=timedelta(seconds=10),
+        )
 
         print(f"Running activity `run_deployment_monitor_healthcheck({payload=})`")
         healthcheck_timeout = (

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -599,6 +599,7 @@ def get_workflows_and_activities():
         activities=[
             swarm_activities.save_cancelled_deployment,
             swarm_activities.close_faulty_db_connections,
+            monitor_activities.monitor_close_faulty_db_connections,
             swarm_activities.unexpose_docker_deployment_from_http,
             swarm_activities.remove_changed_urls_in_deployment,
             swarm_activities.attach_network_to_proxy,

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -38,6 +38,12 @@ class CreateProjectResourcesWorkflow:
             maximum_attempts=5, maximum_interval=timedelta(seconds=30)
         )
 
+        await workflow.execute_activity_method(
+            DockerSwarmActivities.close_faulty_db_connections,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=retry_policy,
+        )
+
         print(f"Running activity `create_project_network({payload=})`")
         network_id = await workflow.execute_activity_method(
             DockerSwarmActivities.create_project_network,
@@ -64,6 +70,12 @@ class RemoveProjectResourcesWorkflow:
         print(f"\nRunning workflow `RemoveProjectResourcesWorkflow` with {payload=}")
         retry_policy = RetryPolicy(
             maximum_attempts=5, maximum_interval=timedelta(seconds=30)
+        )
+
+        await workflow.execute_activity_method(
+            DockerSwarmActivities.close_faulty_db_connections,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=retry_policy,
         )
 
         print(f"Running activity `get_archived_project_services({payload=})`")
@@ -170,6 +182,12 @@ class DeployDockerServiceWorkflow:
 
         print(
             f"\nRunning workflow `DeployDockerServiceWorkflow` with payload={deployment}"
+        )
+
+        await workflow.execute_activity_method(
+            DockerSwarmActivities.close_faulty_db_connections,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=self.retry_policy,
         )
 
         pause_at_step = (
@@ -512,6 +530,12 @@ class ArchiveDockerServiceWorkflow:
             maximum_attempts=5, maximum_interval=timedelta(seconds=30)
         )
 
+        await workflow.execute_activity_method(
+            DockerSwarmActivities.close_faulty_db_connections,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=retry_policy,
+        )
+
         print(f"Running activity `unexpose_docker_service_from_http({service=})`")
         await workflow.execute_activity_method(
             DockerSwarmActivities.unexpose_docker_service_from_http,
@@ -536,6 +560,12 @@ class ToggleDockerServiceWorkflow:
         print(f"\nRunning workflow `ToggleDockerServiceWorkflow` with {deployment=}")
         retry_policy = RetryPolicy(
             maximum_attempts=5, maximum_interval=timedelta(seconds=30)
+        )
+
+        await workflow.execute_activity_method(
+            DockerSwarmActivities.close_faulty_db_connections,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=retry_policy,
         )
 
         if deployment.status == DockerDeployment.DeploymentStatus.SLEEPING:
@@ -568,6 +598,7 @@ def get_workflows_and_activities():
         ],
         activities=[
             swarm_activities.save_cancelled_deployment,
+            swarm_activities.close_faulty_db_connections,
             swarm_activities.unexpose_docker_deployment_from_http,
             swarm_activities.remove_changed_urls_in_deployment,
             swarm_activities.attach_network_to_proxy,


### PR DESCRIPTION
## Description

As the title says, when the temporal-worker hasn't run a job in a long time, django might drop the database connections to them, to fix it, we close faulty db connections at the start of each job, this way django will need to recreate the connections next time it needs to make a DB query. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
