### PR TITLE
🔧 use a smaller image size for building `backend` component

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -2,3 +2,5 @@ lib/
 venv/
 __pycache__/
 .DS_Store
+venv/
+package.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.7
+FROM python:3.11.7-alpine
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.11.7-slim
 
+RUN apt update && yes | apt install gcc python3-dev
+
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.7-alpine
+FROM python:3.11.7-slim
 
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,6 +1,8 @@
 FROM python:3.11.7-slim
 WORKDIR /app
 
+RUN apt update && yes | apt install gcc python3-dev
+
 # set environment variables
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:3.11.7-alpine
+FROM python:3.11.7-slim
 WORKDIR /app
 
 # set environment variables

--- a/backend/Dockerfile.prod
+++ b/backend/Dockerfile.prod
@@ -1,4 +1,4 @@
-FROM python:3.11.7
+FROM python:3.11.7-alpine
 WORKDIR /app
 
 # set environment variables


### PR DESCRIPTION
## Description

To reduce the image size, the current image is more than `1GB` :
![Capture d’écran 2024-09-10 à 19 21 12](https://github.com/user-attachments/assets/674ba068-9e15-4460-b2e4-450a246a0df8)

The new size is `~800mo`, I tried using `alpine` but it didn't seem to build correctly, some packages (notably temporalio), were not being installed correctly. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
