### PR TITLE
:recycle: New deployments should have a generated URL as long as there is a http port

### DIFF
--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -2590,6 +2590,10 @@ class DockerServiceDeploymentApplyChangesViewTests(AuthAPITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         updated_service = DockerRegistryService.objects.get(slug="app")
 
+        first_deployment = updated_service.deployments.first()
+        self.assertIsNotNone(first_deployment)
+        self.assertIsNotNone(first_deployment.url)
+
         new_port = updated_service.ports.filter(host__isnull=True).first()
         self.assertIsNotNone(new_port)
         self.assertEqual(80, new_port.forwarded)

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -519,7 +519,7 @@ class ApplyDockerServiceDeploymentChangesAPIView(APIView):
             )
             service.apply_pending_changes(deployment=new_deployment)
 
-            if len(service.urls.all()) > 0:
+            if service.http_port is not None:
                 new_deployment.url = f"{project.slug}-{service_slug}-docker-{new_deployment.unprefixed_hash}.{settings.ROOT_DOMAIN}".lower()
 
             latest_deployment = service.latest_production_deployment


### PR DESCRIPTION
## Description

This fixes a bug we encountered when deleting all urls for a service which previously had ones alongside a healthcheck of type `PATH`, the temporal job would fail because that healthcheck expected the new deployment to have a URL but a deployment url was only generated when there was at least one URL attached to the service. 
To fix, we instead generate a deployment URL when there is a http port associated to a service.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
