### PR TITLE
Fix: pulling image should not timeout the deployment workflow

### DIFF
--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -284,6 +284,13 @@ class DeployDockerServiceWorkflow:
             )
 
         await workflow.execute_activity_method(
+            DockerSwarmActivities.pull_image_for_deployment,
+            deployment,
+            start_to_close_timeout=timedelta(seconds=60),
+            retry_policy=self.retry_policy,
+        )
+
+        await workflow.execute_activity_method(
             DockerSwarmActivities.create_swarm_service_for_docker_deployment,
             deployment,
             start_to_close_timeout=timedelta(seconds=30),
@@ -610,6 +617,7 @@ def get_workflows_and_activities():
             swarm_activities.get_archived_project_services,
             swarm_activities.prepare_deployment,
             swarm_activities.scale_down_service_deployment,
+            swarm_activities.pull_image_for_deployment,
             swarm_activities.create_docker_volumes_for_service,
             swarm_activities.delete_created_volumes,
             swarm_activities.create_swarm_service_for_docker_deployment,

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -297,6 +297,18 @@ class DeployDockerServiceWorkflow:
                 reason=str(e.cause),
                 service_id=deployment.service.id,
             )
+            final_deployment_status = await workflow.execute_activity_method(
+                DockerSwarmActivities.finish_and_save_deployment,
+                healthcheck_result,
+                start_to_close_timeout=timedelta(seconds=5),
+                retry_policy=self.retry_policy,
+            )
+            next_queued_deployment = await self.queue_next_deployment(deployment)
+            return DeployDockerServiceWorkflowResult(
+                deployment_status=final_deployment_status,
+                healthcheck_result=healthcheck_result,
+                next_queued_deployment=next_queued_deployment,
+            )
         else:
             await workflow.execute_activity_method(
                 DockerSwarmActivities.create_swarm_service_for_docker_deployment,
@@ -398,7 +410,6 @@ class DeployDockerServiceWorkflow:
                         start_to_close_timeout=timedelta(seconds=30),
                         retry_policy=self.retry_policy,
                     )
-        finally:
             final_deployment_status = await workflow.execute_activity_method(
                 DockerSwarmActivities.finish_and_save_deployment,
                 healthcheck_result,

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -858,11 +858,12 @@ class FakeDockerClient:
             },
         ]
 
-    def images_pull(self, repository: str, tag: str = None, *args, **kwargs):
-        if tag is not None:
-            self.pulled_images.add(f"{repository}:{tag}")
-        else:
-            self.pulled_images.add(repository)
+    def images_pull(self, repository: str, *args, **kwargs):
+        if repository == self.NONEXISTANT_IMAGE:
+            raise docker.errors.ImageNotFound(
+                f"The image `{repository}` does not exists."
+            )
+        self.pulled_images.add(repository)
 
     def image_get_registry_data(self, image: str, auth_config: dict):
         if auth_config is not None:


### PR DESCRIPTION
## Description

This PR fixes an issue in which when the user updates a service and uses a nonexistent image, the deploy workflow times out, this is because we didn't handle when an image doesn't exists. Temporalio would retry the `create_swarm_service` activity and fail after hitting all the steps. 
To fix this, we separated the image pulling into its own activity and catched the error when the image doesn't exist. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
