### PR TITLE
👷 re-enable and fix django tests on CI

### DIFF
--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -43,5 +43,5 @@ jobs:
         run: |
           cd backend
           source .venv/bin/activate
-          echo "Disabling tests for now"
-          # python manage.py test --parallel
+          # echo "Disabling tests for now"
+          python manage.py test --parallel

--- a/.github/workflows/pytests.yaml
+++ b/.github/workflows/pytests.yaml
@@ -7,6 +7,7 @@ on:
 jobs:
   run-tests:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     
     services:
       postgres:

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -219,9 +219,13 @@ class DeployDockerServiceWorkflow:
                 )
                 start_time = workflow.time()
                 print(f"{workflow.time()=}, {start_time=}")
-                await workflow.wait_condition(
-                    lambda: self.cancellation_requested, timeout=timedelta(seconds=30)
-                )
+                try:
+                    await workflow.wait_condition(
+                        lambda: self.cancellation_requested,
+                        timeout=timedelta(seconds=30),
+                    )
+                except TimeoutError as error:
+                    print(f"TimeoutError {error=}")
                 print(
                     f"result check_for_cancellation({pause_at_step=}, {last_completed_step=}) = {self.cancellation_requested}"
                 )

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -182,53 +182,52 @@ class DeployDockerServiceWorkflow:
         print(
             f"\nRunning workflow `DeployDockerServiceWorkflow` with payload={deployment}"
         )
+        await workflow.execute_activity_method(
+            DockerSwarmActivities.close_faulty_db_connections,
+            start_to_close_timeout=timedelta(seconds=10),
+            retry_policy=self.retry_policy,
+        )
+
+        pause_at_step = (
+            DockerDeploymentStep(deployment.pause_at_step)
+            if deployment.pause_at_step > 0
+            else None
+        )
+
+        async def check_for_cancellation(
+            last_completed_step: DockerDeploymentStep,
+        ):
+            """
+            This function allows us to pause and potentially bypass the workflow's execution
+            during testing. It is useful for stopping the workflow at specific points to
+            simulate and handle cancellation.
+
+            Because workflows are asynchronous, the workflow might progress to another step
+            by the time the user triggers `cancel_deployment`. This function helps ensure
+            that the workflow can pause at a predefined step (indicated by `pause_at_step`)
+            and wait for a cancellation signal.
+
+            Note: `pause_at_step`  is intended only for testing and should not be used in
+            the application logic.
+            """
+            if pause_at_step is not None:
+                if pause_at_step != last_completed_step:
+                    return False
+
+                print(
+                    f"await check_for_cancellation({pause_at_step=}, {last_completed_step=})"
+                )
+                start_time = workflow.time()
+                print(f"{workflow.time()=}, {start_time=}")
+                await workflow.wait_condition(
+                    lambda: self.cancellation_requested, timeout=timedelta(seconds=30)
+                )
+                print(
+                    f"result check_for_cancellation({pause_at_step=}, {last_completed_step=}) = {self.cancellation_requested}"
+                )
+            return self.cancellation_requested
+
         try:
-            await workflow.execute_activity_method(
-                DockerSwarmActivities.close_faulty_db_connections,
-                start_to_close_timeout=timedelta(seconds=10),
-                retry_policy=self.retry_policy,
-            )
-
-            pause_at_step = (
-                DockerDeploymentStep(deployment.pause_at_step)
-                if deployment.pause_at_step > 0
-                else None
-            )
-
-            async def check_for_cancellation(
-                last_completed_step: DockerDeploymentStep,
-            ):
-                """
-                This function allows us to pause and potentially bypass the workflow's execution
-                during testing. It is useful for stopping the workflow at specific points to
-                simulate and handle cancellation.
-
-                Because workflows are asynchronous, the workflow might progress to another step
-                by the time the user triggers `cancel_deployment`. This function helps ensure
-                that the workflow can pause at a predefined step (indicated by `pause_at_step`)
-                and wait for a cancellation signal.
-
-                Note: `pause_at_step`  is intended only for testing and should not be used in
-                the application logic.
-                """
-                if pause_at_step is not None:
-                    if pause_at_step != last_completed_step:
-                        return False
-
-                    print(
-                        f"await check_for_cancellation({pause_at_step=}, {last_completed_step=})"
-                    )
-                    timeout = 5
-                    start_time = workflow.time()
-                    while (
-                        workflow.time() - start_time
-                    ) < timeout and not self.cancellation_requested:
-                        await asyncio.sleep(1)
-                    print(
-                        f"result check_for_cancellation({pause_at_step=}, {last_completed_step=}) = {self.cancellation_requested}"
-                    )
-                return self.cancellation_requested
-
             await workflow.execute_activity_method(
                 DockerSwarmActivities.prepare_deployment,
                 deployment,

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -4770,7 +4770,7 @@ class DockerServiceDeploymentCancelTests(AuthAPITestCase):
 
 
 class DockerServiceCancelDeploymentViewTests(AuthAPITestCase):
-    async def test_cancel_deployment(self):
+    async def test_cancel_deployment_simple(self):
         async with self.workflowEnvironment() as env:  # type: WorkflowEnvironment
             await asyncio.sleep(5)
             owner = await self.aLoginUser()


### PR DESCRIPTION
## Description

I don't actually know why tests sometimes don't work on CI then work again on the next commit, I get timeout errors suddenly and I actually don't know how to fix them. The tests will be re-enabled for CI, with a timeout of 5 minutes max instead of running indefinitely when they fail, to be sure. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
