### PR TITLE
🐛 specify change field of `urls` when cancelling a service.

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -1649,11 +1649,13 @@ class DockerSwarmActivities:
             URLDto.from_dict(change.new_value)
             for change in deployment.changes
             if change.type == DockerDeploymentChange.ChangeType.ADD
+            and change.field == DockerDeploymentChange.ChangeField.URLS
         ]
         updated_url_changes = [
             change
             for change in deployment.changes
             if change.type == DockerDeploymentChange.ChangeType.UPDATE
+            and change.field == DockerDeploymentChange.ChangeField.URLS
         ]
         for url in new_urls:
             ZaneProxyClient.remove_service_url(deployment.service.id, url)


### PR DESCRIPTION
## Description

This fixes a bug when a user cancels a deployment, it would throw an error because we don't filter the changes by the correct type. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
