### PR TITLE
fix: mark stuck deployments as `removed` when a new deployment is succesfull

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -897,6 +897,14 @@ class DockerSwarmActivities:
                 await deployment.service.deployments.filter(
                     ~Q(hash=healthcheck_result.deployment_hash)
                 ).aupdate(is_current_production=False)
+                await deployment.service.deployments.filter(
+                    ~Q(hash=healthcheck_result.deployment_hash)
+                    & Q(finished_at__isnull=True),
+                ).aupdate(finished_at=timezone.now())
+                await deployment.service.deployments.filter(
+                    ~Q(hash=healthcheck_result.deployment_hash)
+                    & ~Q(status=DockerDeployment.DeploymentStatus.REMOVED),
+                ).aupdate(status=DockerDeployment.DeploymentStatus.REMOVED)
         except DockerDeployment.DoesNotExist:
             raise ApplicationError(
                 "Cannot save a non existent deployment.",

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -899,12 +899,18 @@ class DockerSwarmActivities:
                 ).aupdate(is_current_production=False)
                 await deployment.service.deployments.filter(
                     ~Q(hash=healthcheck_result.deployment_hash)
+                    & Q(
+                        status__in=[
+                            DockerDeployment.DeploymentStatus.PREPARING,
+                            DockerDeployment.DeploymentStatus.STARTING,
+                            DockerDeployment.DeploymentStatus.RESTARTING,
+                        ]
+                    )
                     & Q(finished_at__isnull=True),
-                ).aupdate(finished_at=timezone.now())
-                await deployment.service.deployments.filter(
-                    ~Q(hash=healthcheck_result.deployment_hash)
-                    & ~Q(status=DockerDeployment.DeploymentStatus.REMOVED),
-                ).aupdate(status=DockerDeployment.DeploymentStatus.REMOVED)
+                ).aupdate(
+                    finished_at=timezone.now(),
+                    status=DockerDeployment.DeploymentStatus.REMOVED,
+                )
         except DockerDeployment.DoesNotExist:
             raise ApplicationError(
                 "Cannot save a non existent deployment.",

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -3448,9 +3448,6 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
         self.assertEqual(
             DockerDeployment.DeploymentStatus.FAILED, second_deployment.status
         )
-        # self.assertIsNone(
-        #     self.fake_docker_client.get_deployment_service(second_deployment)
-        # )
 
         third_deployment = await (
             DockerDeployment.objects.filter(hash=third_deployment.hash)

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -353,6 +353,7 @@ class ProjectServiceListView(APIView):
                 DockerDeployment.DeploymentStatus.SLEEPING: "SLEEPING",
                 DockerDeployment.DeploymentStatus.QUEUED: "DEPLOYING",
                 DockerDeployment.DeploymentStatus.PREPARING: "DEPLOYING",
+                DockerDeployment.DeploymentStatus.CANCELLING: "DEPLOYING",
                 DockerDeployment.DeploymentStatus.STARTING: "DEPLOYING",
                 DockerDeployment.DeploymentStatus.RESTARTING: "UNHEALTHY",
             }


### PR DESCRIPTION
## Description

This PR fixes a bug on production where deployments which were stuck in the deploying step and weren't marked removed. This is because of a Bug that probably happenned in the temporal workflow step keeping them stuck.    

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
