### PR TITLE
Some fixes related to deployments

### DIFF
--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -683,7 +683,10 @@ class CancelDockerServiceDeploymentAPIView(APIView):
             DockerDeployment.DeploymentStatus.STARTING,
             DockerDeployment.DeploymentStatus.RESTARTING,
         ]:
-            raise ResourceConflict(detail="Cannot cancel already finished deployment.")
+            raise ResourceConflict(
+                detail="This deployment cannot be cancelled as it has already finished "
+                       "or is in the process of cancelling."
+            )
 
         if deployment.started_at is None:
             deployment.status = DockerDeployment.DeploymentStatus.CANCELLED

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -677,7 +677,12 @@ class CancelDockerServiceDeploymentAPIView(APIView):
                 detail=f"A deployment with the hash `{deployment_hash}` does not exist for this service."
             )
 
-        if deployment.finished_at is not None:
+        if deployment.finished_at is not None or deployment.status not in [
+            DockerDeployment.DeploymentStatus.QUEUED,
+            DockerDeployment.DeploymentStatus.PREPARING,
+            DockerDeployment.DeploymentStatus.STARTING,
+            DockerDeployment.DeploymentStatus.RESTARTING,
+        ]:
             raise ResourceConflict(detail="Cannot cancel already finished deployment.")
 
         if deployment.started_at is None:

--- a/frontend/src/components/deployment-cards.tsx
+++ b/frontend/src/components/deployment-cards.tsx
@@ -93,12 +93,25 @@ export function DockerDeploymentCard({
   }
 
   // all deployments statuse that match these filters can be cancelled
-  const cancellableDeploymentsStatuses = [
+  const cancellableDeploymentsStatuses: Array<typeof status> = [
     "QUEUED",
     "PREPARING",
     "STARTING",
     "RESTARTING"
   ];
+
+  const runningDeploymentsStatuses: Array<typeof status> = [
+    "QUEUED",
+    "PREPARING",
+    "STARTING",
+    "RESTARTING",
+    "CANCELLING"
+  ];
+
+  const isCancellable = cancellableDeploymentsStatuses.includes(status);
+  const isRedeployable =
+    !is_current_production &&
+    (finished_at || !runningDeploymentsStatuses.includes(status));
 
   return (
     <div
@@ -259,7 +272,7 @@ export function DockerDeploymentCard({
                   })
                 }
               />
-              {!is_current_production && finished_at && (
+              {isRedeployable && (
                 <MenubarContentItem
                   icon={Redo2}
                   text="Redeploy"
@@ -279,7 +292,7 @@ export function DockerDeploymentCard({
                   }
                 />
               )}
-              {cancellableDeploymentsStatuses.includes(status) && (
+              {isCancellable && (
                 <MenubarContentItem
                   className="text-red-500"
                   icon={Ban}

--- a/frontend/src/components/deployment-cards.tsx
+++ b/frontend/src/components/deployment-cards.tsx
@@ -92,6 +92,14 @@ export function DockerDeploymentCard({
     image += ":latest";
   }
 
+  // all deployments statuse that match these filters can be cancelled
+  const cancellableDeploymentsStatuses = [
+    "QUEUED",
+    "PREPARING",
+    "STARTING",
+    "RESTARTING"
+  ];
+
   return (
     <div
       className={cn(
@@ -177,7 +185,7 @@ export function DockerDeploymentCard({
                   )}
                 </span>
               ) : (
-                !started_at && !finished_at && <span>-</span>
+                !started_at && <span>-</span>
               )}
             </div>
             <div className="gap-1 inline-flex items-center">
@@ -271,7 +279,7 @@ export function DockerDeploymentCard({
                   }
                 />
               )}
-              {!finished_at && (
+              {cancellableDeploymentsStatuses.includes(status) && (
                 <MenubarContentItem
                   className="text-red-500"
                   icon={Ban}

--- a/frontend/src/components/deployment-cards.tsx
+++ b/frontend/src/components/deployment-cards.tsx
@@ -185,7 +185,7 @@ export function DockerDeploymentCard({
                   )}
                 </span>
               ) : (
-                !started_at && <span>-</span>
+                <span>-</span>
               )}
             </div>
             <div className="gap-1 inline-flex items-center">


### PR DESCRIPTION
## Description

In this PR, we fixed multiple issues :
- We made it so that only deployments that have not finished yet can be cancelled and if we already cancelled a previous deployment, the cancel request can be ignored.
- When we mark stuck deployments as `REMOVED`, we need to set the `started_at` and `finished_at` only if the corresponding property was null
- in the frontend, we fixed the deployment dropdown menu to show the `cancel` & `redeploy` on the correct states.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
