### PR TITLE
✨ inject system env variables in zaneops

### DIFF
--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -244,6 +244,56 @@ class DockerRegistryService(BaseService):
         )
 
     @property
+    def system_env_variables(self) -> list[dict[str, str]]:
+        return [
+            {
+                "key": "ZANE",
+                "value": "1",
+                "comment": "Is the service deployed on zaneops?",
+            },
+            {
+                "key": "ZANE_PRIVATE_DOMAIN",
+                "value": f"{self.network_alias}.{settings.ZANE_INTERNAL_DOMAIN}",
+                "comment": "The domain used to reach this service on the same project",
+            },
+            {
+                "key": "ZANE_DEPLOYMENT_TYPE",
+                "value": "docker",
+                "comment": "The type of the service",
+            },
+            {
+                "key": "ZANE_SERVICE_ID",
+                "value": self.id,
+                "comment": "The service ID",
+            },
+            {
+                "key": "ZANE_SERVICE_NAME",
+                "value": self.slug,
+                "comment": "The name of this service",
+            },
+            {
+                "key": "ZANE_PROJECT_ID",
+                "value": self.project_id,
+                "comment": "The id for the project this service belongs to",
+            },
+            {
+                "key": "ZANE_DEPLOYMENT_SLOT",
+                "value": "{{deployment.slot}}",
+                "comment": "The slot for each deployment it can be `blue` or `green`, this is also sent as the header `x-zane-dpl-slot`",
+            },
+            {
+                "key": "ZANE_DEPLOYMENT_HASH",
+                "value": "{{deployment.hash}}",
+                "comment": "The hash of each deployment, this is also sent as a header `x-zane-dpl-hash`",
+            },
+            {
+                "key": "ZANE_DEPLOYMENT_URL",
+                "value": "{{deployment.url}}",
+                "comment": "The url of each deployment, this is empty for services that don't have any url.",
+            },
+        ]
+
+    @property
     def latest_production_deployment(self) -> Union["DockerDeployment", None]:
         return (
             self.deployments.filter(is_current_production=True)

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -147,6 +147,12 @@ class ResourceLimitsSerializer(serializers.Serializer):
     memory = MemoryLimitSerializer(required=True, allow_null=True)
 
 
+class SystemEnvVariablesSerializer(serializers.Serializer):
+    key = serializers.CharField(allow_null=False)
+    value = serializers.CharField(allow_null=False)
+    comment = serializers.CharField(allow_null=False)
+
+
 class DockerServiceSerializer(ModelSerializer):
     volumes = VolumeSerializer(read_only=True, many=True)
     urls = URLModelSerializer(read_only=True, many=True)
@@ -159,6 +165,9 @@ class DockerServiceSerializer(ModelSerializer):
     unapplied_changes = DockerDeploymentChangeSerializer(many=True, read_only=True)
     credentials = DockerCredentialSerializer(allow_null=True)
     resource_limits = ResourceLimitsSerializer(allow_null=True)
+    system_env_variables = SystemEnvVariablesSerializer(
+        allow_null=False, many=True, default=[]
+    )
 
     class Meta:
         model = models.DockerRegistryService
@@ -180,6 +189,7 @@ class DockerServiceSerializer(ModelSerializer):
             "network_alias",
             "unapplied_changes",
             "resource_limits",
+            "system_env_variables",
         ]
 
 

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -1286,7 +1286,7 @@ class DockerSwarmActivities:
                 [
                     f"ZANE=1",
                     f"ZANE_DEPLOYMENT_SLOT={deployment.slot}",
-                    f"ZANE_DEPLOYMENT_HASH={deployment.unprefixed_hash}",
+                    f"ZANE_DEPLOYMENT_HASH={deployment.hash}",
                     f"ZANE_DEPLOYMENT_TYPE=docker",
                     f"ZANE_PRIVATE_DOMAIN={service.network_alias}",
                     f"ZANE_SERVICE_ID={service.id}",

--- a/openapi/schema.yml
+++ b/openapi/schema.yml
@@ -3172,6 +3172,11 @@ components:
           allOf:
           - $ref: '#/components/schemas/ResourceLimits'
           nullable: true
+        system_env_variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/SystemEnvVariables'
+          default: []
       required:
       - command
       - created_at
@@ -3186,6 +3191,7 @@ components:
       - project_id
       - resource_limits
       - slug
+      - system_env_variables
       - unapplied_changes
       - updated_at
       - urls
@@ -3454,6 +3460,11 @@ components:
           allOf:
           - $ref: '#/components/schemas/ResourceLimits'
           nullable: true
+        system_env_variables:
+          type: array
+          items:
+            $ref: '#/components/schemas/SystemEnvVariables'
+          default: []
       required:
       - command
       - created_at
@@ -3468,6 +3479,7 @@ components:
       - project_id
       - resource_limits
       - slug
+      - system_env_variables
       - unapplied_changes
       - updated_at
       - urls
@@ -6009,6 +6021,19 @@ components:
         * `SYSTEM` - System Logs
         * `PROXY` - Proxy Logs
         * `SERVICE` - Service Logs
+    SystemEnvVariables:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+        comment:
+          type: string
+      required:
+      - comment
+      - key
+      - value
     ToggleDockerServiceErrorResponse400:
       oneOf:
       - $ref: '#/components/schemas/ParseErrorResponse'


### PR DESCRIPTION
## Description

This PR introduces the system environment variables in the API response to show in the UI, it was already done in the backend, but now it is sent to be shown in the frontend so that users are aware of that. 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
