### PR TITLE
🔧  run the dev server at `http://localhost:5678` instead of the `sslip.io` domain

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ You can open a new issue with this [issue form](https://github.com/zane-ops/zane
     pnpm run  --filter='!backend' --recursive --parallel dev
     ```
 
-   Wait until you see `Server launched at http://app.127-0-0-1.sslip.io` in the terminal . Then, start the development server for the API:
+   Wait until you see `Server launched at http://localhost:5678` in the terminal . Then, start the development server for the API:
     ```shell
     make dev-api
     # or
@@ -72,7 +72,7 @@ You can open a new issue with this [issue form](https://github.com/zane-ops/zane
 
 5. Open the source code and start working :
 
-   The app should be available at http://app.127-0-0-1.sslip.io
+   The app should be available at http://localhost:5678
 
 ## Debugging
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -72,11 +72,11 @@ ALLOWED_HOSTS = (
     if ENVIRONMENT != PRODUCTION_ENV
     else [f".{ROOT_DOMAIN}", f"zane.api.zaneops.internal"]
 )
-SESSION_COOKIE_DOMAIN = f".{ROOT_DOMAIN}"
+SESSION_COOKIE_DOMAIN = f".{ROOT_DOMAIN}" if ENVIRONMENT == PRODUCTION_ENV else None
 
 # This is necessary for making sure that CSRF protections work on production
 CSRF_TRUSTED_ORIGINS = (
-    [f"https://{ZANE_APP_DOMAIN}", f"http://{ZANE_APP_DOMAIN}"]
+    [f"https://{ZANE_APP_DOMAIN}", f"http://{ZANE_APP_DOMAIN}", "http://localhost:5678"]
     if ENVIRONMENT != PRODUCTION_ENV
     else [f"https://{ZANE_APP_DOMAIN}"]
 )

--- a/docker/start-docker-stack.sh
+++ b/docker/start-docker-stack.sh
@@ -34,7 +34,7 @@ echo "$services" | while IFS= read -r service; do
 done
 
 # Wait until Ctrl+C is pressed
-echo "Server launched at http://app.127-0-0-1.sslip.io/"
+echo "Server launched at http://localhost:5678/"
 echo "Press Ctrl+C to stop everything..."
 while true; do
   sleep 1

--- a/docs/src/content/docs/development/development.mdx
+++ b/docs/src/content/docs/development/development.mdx
@@ -47,7 +47,7 @@ import {FileTree, Steps, Aside} from '@astrojs/starlight/components';
     pnpm run  --filter='!backend' --recursive --parallel dev
     ```
 
-   Wait until you see `Server launched at http://app.127-0-0-1.sslip.io` in the terminal . Then, start the development server for the API:
+   Wait until you see `Server launched at http://localhost:5678` in the terminal . Then, start the development server for the API:
     ```shell
     make dev-api
     # or
@@ -62,7 +62,7 @@ import {FileTree, Steps, Aside} from '@astrojs/starlight/components';
 
 5. Open the source code and start working :
 
-   The app should be available at http://app.127-0-0-1.sslip.io
+   The app should be available at http://localhost:5678
 
 </Steps>
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,9 +6,14 @@ import { defineConfig } from "vite";
 // https://vitejs.dev/config/
 export default defineConfig({
   server: {
-    port: 5678
+    port: 5678,
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:8000",
+        changeOrigin: true
+      }
+    }
   },
-
   plugins: [react(), TanStackRouterVite()],
   resolve: {
     alias: {


### PR DESCRIPTION
## Description

This change is only for the development environment, instead of starting the dev server at `app.127-0-0-1.sslip.io`, we use the port where the frontend is running. This is because the dev server would cause a full reload when we deploy a new service which has at least one url. 

This is an issue with caddy (and not with vite), documented here https://github.com/caddyserver/caddy/issues/6420. Basically, for services which have urls, when we deploy them, we need to update the configuration of caddy, and when this configuration is updated, caddy closes all the websocket connections causing all clients to reconnect. This is not a big issue, but in DEV, vite will issue a full reload when the connection is closed. This was annoying too me, so I made it so that the DEV server for vite doesn't use the proxy and for each requests to `/api` to be proxied via vite to the backend running on another port, as well as to relax the permisssions on the backend so that sessions domains & csrf aren't enforced on DEV.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
