### PR TITLE
🩹 add env variable to allow logging in to zaneops via HTTP on production

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -46,19 +46,24 @@ TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
 ENVIRONMENT = os.environ.get("ENVIRONMENT", "DEVELOPMENT")
 PRODUCTION_ENV = "PRODUCTION"
 BACKEND_COMPONENT = os.environ.get("BACKEND_COMPONENT", "API")
+__DANGEROUS_ALLOW_HTTP_SESSION = (
+    os.environ.get("__DANGEROUS_ALLOW_HTTP_SESSION") == "true"
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = ENVIRONMENT != PRODUCTION_ENV
 # SECURE_SSL_REDIRECT = ENVIRONMENT == PRODUCTION_ENV
-CSRF_COOKIE_SECURE = ENVIRONMENT == PRODUCTION_ENV
-SESSION_COOKIE_SECURE = ENVIRONMENT == PRODUCTION_ENV
+CSRF_COOKIE_SECURE = __DANGEROUS_ALLOW_HTTP_SESSION or ENVIRONMENT == PRODUCTION_ENV
+SESSION_COOKIE_SECURE = __DANGEROUS_ALLOW_HTTP_SESSION or ENVIRONMENT == PRODUCTION_ENV
 REDIS_URL = os.environ.get("REDIS_URL", "redis://127.0.0.1:6381/0")
-SECURE_HSTS_SECONDS = 0 if ENVIRONMENT != PRODUCTION_ENV else 60
+SECURE_HSTS_SECONDS = (
+    0 if (__DANGEROUS_ALLOW_HTTP_SESSION or ENVIRONMENT != PRODUCTION_ENV) else 60
+)
 
 # We will only support one root domain on production
 # And it will be in the format domain.com (without `http://` or `https://`)
 ROOT_DOMAIN = os.environ.get("ROOT_DOMAIN", "127-0-0-1.sslip.io")
-ZANE_APP_DOMAIN = os.environ.get("ZANE_APP_DOMAIN", "app.127-0-0-1.sslip.io")
+ZANE_APP_DOMAIN = os.environ.get("ZANE_APP_DOMAIN", "127-0-0-1.sslip.io")
 ZANE_INTERNAL_DOMAIN = "zaneops.internal"
 
 ALLOWED_HOSTS = (

--- a/docs/src/content/docs/get-started.mdx
+++ b/docs/src/content/docs/get-started.mdx
@@ -1,5 +1,5 @@
 ---
-title: Install ZaneOps on a server or locally
+title: Installing ZaneOps
 description: 'Guide to setting up and installing ZaneOps'
 ---
 
@@ -116,4 +116,11 @@ make delete-resources
 ### Installing Locally 
 
 ZaneOps can be installed locally with minimal configuration changes. 
-To do this, keep the `ZANE_APP_DOMAIN` and `ROOT_DOMAIN` environment variables set to http://127-0-0-1.sslip.io.
+To do this :
+- keep the `ZANE_APP_DOMAIN` and `ROOT_DOMAIN` environment variables set to http://127-0-0-1.sslip.io.
+- add the `__DANGEROUS_ALLOW_HTTP_SESSION` environment variable to `.env` and set its value to `true`
+
+<Aside type="caution" title="Important">
+You can enable the `__DANGEROUS_ALLOW_HTTP_SESSION` environment variable in production to access your ZaneOps instance over HTTP.
+However, this is strongly discouraged, as it exposes your application to potential security vulnerabilities, including man-in-the-middle attacks.
+</Aside>


### PR DESCRIPTION
## Description

fix #239 

As said in the issue :
> This is caused by the fact that the url to use for local testing is not an URL that the user owns, so the certificate generated by the proxy (caddy) is not valid, when we the use http it doesn't work because we specified in the API that the session cookie should only work on https.

We fixed this by adding an environment variable that allow accessing zaneops through http even on production.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
