### PR TITLE
📝 do not copy `openapi.yaml` file in the docs API reference

### DIFF
--- a/Dockerfile.docs
+++ b/Dockerfile.docs
@@ -4,5 +4,4 @@ FROM caddy:2.8-alpine
 WORKDIR /var/www/html
 
 COPY ./docs/dist/ ./docs
-COPY ./openapi/schema.yml ./docs/openapi.yaml
 COPY ./docs/Caddyfile /etc/caddy/Caddyfile

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "dev": "cp ../openapi/schema.yml ./public/openapi.yaml && astro dev --port 3000 --host",
+    "dev": "astro dev --port 3000 --host",
     "start": "astro dev",
     "build": "astro check && astro build",
     "preview": "astro preview",

--- a/docs/src/pages/api-reference/openapi.astro
+++ b/docs/src/pages/api-reference/openapi.astro
@@ -22,7 +22,7 @@ import logo from "../../assets/Logo.svg";
           <a href="//github.com/zane-ops/zane-ops" target="_blank" rel="noreferer noopener">Github</a>
         </nav>
         </header> 
-        <script id="api-reference" is:inline data-url="/docs/openapi.yaml"></script>
+        <script id="api-reference" is:inline data-url="https://raw.githubusercontent.com/zane-ops/zane-ops/refs/heads/main/openapi/schema.yml"></script>
         <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>
   </body>
 </html>


### PR DESCRIPTION
## Description

This will make it so that when we add or update an API endpoint, we do not need to redeploy the docs website.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
