### PR TITLE
feat: update service image and credentials

### DIFF
--- a/frontend/src/lib/hooks/use-cancel-docker-service-change-mutation.ts
+++ b/frontend/src/lib/hooks/use-cancel-docker-service-change-mutation.ts
@@ -1,0 +1,45 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "~/api/client";
+import { serviceKeys } from "~/key-factories";
+import { getCsrfTokenHeader } from "~/utils";
+
+export function useCancelDockerServiceChangeMutation(
+  project_slug: string,
+  service_slug: string
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (change_id: string) => {
+      const { error, data } = await apiClient.DELETE(
+        "/api/projects/{project_slug}/cancel-service-changes/docker/{service_slug}/{change_id}/",
+        {
+          headers: {
+            ...(await getCsrfTokenHeader())
+          },
+          params: {
+            path: {
+              project_slug,
+              service_slug,
+              change_id
+            }
+          }
+        }
+      );
+      if (error) {
+        const fullErrorMessage = error.errors
+          .map((err) => err.detail)
+          .join(" ");
+
+        throw new Error(fullErrorMessage);
+      }
+
+      if (data) {
+        await queryClient.invalidateQueries({
+          queryKey: serviceKeys.single(project_slug, service_slug, "docker"),
+          exact: true
+        });
+        return;
+      }
+    }
+  });
+}

--- a/frontend/src/lib/hooks/use-docker-service-single-query.ts
+++ b/frontend/src/lib/hooks/use-docker-service-single-query.ts
@@ -31,3 +31,11 @@ export function useDockerServiceSingleQuery(
     }
   });
 }
+
+export type DockerService = Exclude<
+  Exclude<
+    ReturnType<typeof useDockerServiceSingleQuery>["data"],
+    undefined
+  >["data"],
+  undefined
+>;

--- a/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
@@ -23,7 +23,6 @@ import {
   PencilLineIcon,
   Plus,
   PlusIcon,
-  SunriseIcon,
   SunsetIcon,
   Trash2,
   Trash2Icon,
@@ -72,7 +71,7 @@ import {
   useDockerServiceSingleQuery
 } from "~/lib/hooks/use-docker-service-single-query";
 import { cn, getFormErrorsFromResponseData } from "~/lib/utils";
-import { getCsrfTokenHeader, wait } from "~/utils";
+import { getCsrfTokenHeader } from "~/utils";
 
 export const Route = createLazyFileRoute(
   "/_dashboard/project/$project_slug/services/docker/$service_slug/settings"

--- a/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
@@ -571,6 +571,7 @@ function ServiceImageCredentialsForm({ className }: ServiceFormProps) {
           queryKey: serviceKeys.single(project_slug, service_slug, "docker"),
           exact: true
         });
+        setIsPasswordShown(false);
         return;
       }
     }
@@ -617,17 +618,10 @@ function ServiceImageCredentialsForm({ className }: ServiceFormProps) {
             }
           });
         } else {
-          updateCredentialsMutation.mutate(
-            {
-              username: formData.get("username")?.toString(),
-              password: formData.get("password")?.toString()
-            },
-            {
-              onSuccess() {
-                setIsPasswordShown(false);
-              }
-            }
-          );
+          updateCredentialsMutation.mutate({
+            username: formData.get("username")?.toString(),
+            password: formData.get("password")?.toString()
+          });
         }
       }}
       className={cn("flex flex-col gap-4 w-full items-start", className)}


### PR DESCRIPTION
## Description

In this PR we implemented the logic for updating the service image and credentials in the UI.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
