### PR TITLE
refactor: show error message when a change is not feasible

### DIFF
--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -456,7 +456,7 @@ class CancelDockerServiceDeploymentChangesAPIView(APIView):
             )
             if snapshot.image is None:
                 raise ResourceConflict(
-                    detail="Cannot delete this change because it would remove the image of the service."
+                    detail="Cannot revert this change because it would remove the image of the service."
                 )
 
             if found_change.field == "ports" or found_change.field == "urls":
@@ -469,7 +469,7 @@ class CancelDockerServiceDeploymentChangesAPIView(APIView):
                 )
                 if is_healthcheck_path and service_is_not_exposed_to_http:
                     raise ResourceConflict(
-                        f"Cannot delete this change because there is a healthcheck of type `path` attached to the service"
+                        f"Cannot revert this change because there is a healthcheck of type `path` attached to the service"
                         f" and the service is not exposed to the public through an URL or another HTTP port"
                     )
 

--- a/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
@@ -31,6 +31,7 @@ import {
   XIcon
 } from "lucide-react";
 import * as React from "react";
+import { toast } from "sonner";
 import { type RequestInput, apiClient } from "~/api/client";
 import { Code } from "~/components/code";
 import { withAuthRedirect } from "~/components/helper/auth-redirect";
@@ -483,9 +484,16 @@ function ServiceImageForm({ className }: ServiceFormProps) {
             </span>
             {serviceImageChange !== undefined ? (
               <form
-                action={() =>
-                  cancelImageChangeMutation.mutate(serviceImageChange.id)
-                }
+                action={() => {
+                  cancelImageChangeMutation.mutate(serviceImageChange.id, {
+                    onError(error) {
+                      toast.error("Error", {
+                        closeButton: true,
+                        description: error.message
+                      });
+                    }
+                  });
+                }}
               >
                 <SubmitButton
                   isPending={cancelImageChangeMutation.isPending}
@@ -615,6 +623,12 @@ function ServiceImageCredentialsForm({ className }: ServiceFormProps) {
           cancelCredentialsChangeMutation.mutate(serviceCredentialsChange.id, {
             onSuccess() {
               formRef.current?.reset();
+            },
+            onError(error) {
+              toast.error("Error", {
+                closeButton: true,
+                description: error.message
+              });
             }
           });
         } else {


### PR DESCRIPTION
## Description

In this PR, we added a little feedback for when a change is not possible to revert, the API would send the response but it wasn't shown in the UI, this PR adds that in form of a little toast.

We also changed the error messages in the backend a little to be more in line with the expressions we use in the frontend.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
