### PR TITLE
fix: do not copy response headers as they are already sent with `copy_response`

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -524,7 +524,6 @@ class ZaneProxyClient:
                                 },
                                 {
                                     "handle": [
-                                        {"handler": "copy_response_headers"},
                                         {"handler": "copy_response"},
                                     ]
                                 },


### PR DESCRIPTION
## Description
fixes #255 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
