### PR TITLE
fix: when the change is empty show `<empty>` in the command input instead of the old value

### DIFF
--- a/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
@@ -1945,17 +1945,17 @@ function ServiceCommandForm({ className }: ServiceFormProps) {
   const startingCommandChange = service?.unapplied_changes.find(
     (change) => change.field === "command"
   );
+  const isEmptyChange =
+    startingCommandChange !== undefined &&
+    startingCommandChange.new_value === null;
 
-  const command =
-    (startingCommandChange?.new_value as string) ?? service?.command;
+  const command = isEmptyChange
+    ? ""
+    : (startingCommandChange?.new_value as string) ?? service?.command;
 
   const errors = getFormErrorsFromResponseData(
     updateStartingCommandMutation.data
   );
-
-  const isEmptyChange =
-    startingCommandChange !== undefined &&
-    startingCommandChange.new_value === null;
 
   const formRef = React.useRef<React.ElementRef<"form">>(null);
 


### PR DESCRIPTION
## Description

same as the PR title.

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
