### PR TITLE
🐛 fix URLs not matching the slug regex of django

### DIFF
--- a/backend/zane_api/tests/service.py
+++ b/backend/zane_api/tests/service.py
@@ -148,6 +148,29 @@ class DockerServiceCreateViewTest(AuthAPITestCase):
         ).first()
         self.assertIsNotNone(created_service)
 
+    def test_create_service_slug_accept_underscores(self):
+        owner = self.loginUser()
+        p = Project.objects.create(slug="zane-ops", owner=owner)
+
+        create_service_payload = {
+            "slug": "hello_nginx",
+            "image": "nginxdemos/hello:latest",
+        }
+
+        response = self.client.post(
+            reverse("zane_api:services.docker.create", kwargs={"project_slug": p.slug}),
+            data=create_service_payload,
+        )
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+        response = self.client.get(
+            reverse(
+                "zane_api:services.docker.details",
+                kwargs={"project_slug": p.slug, "service_slug": "hello_nginx"},
+            ),
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+
     def test_create_service_set_network_alias(self):
         owner = self.loginUser()
         p = Project.objects.create(slug="kiss-cam", owner=owner)

--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -5,6 +5,8 @@ from . import views
 
 app_name = "zane_api"
 
+DJANGO_SLUG_REGEX = r"[-a-zA-Z0-9_]+"
+
 urlpatterns = [
     re_path(r"^auth/me/?$", views.AuthedView.as_view(), name="auth.me"),
     re_path(
@@ -23,12 +25,12 @@ urlpatterns = [
         name="projects.archived.list",
     ),
     re_path(
-        r"^projects/(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)/$",
+        rf"^projects/(?P<slug>{DJANGO_SLUG_REGEX})/$",
         views.ProjectDetailsView.as_view(),
         name="projects.details",
     ),
     re_path(
-        r"^projects/(?P<slug>[a-z0-9]+(?:-[a-z0-9]+)*)/service-list/$",
+        rf"^projects/(?P<slug>{DJANGO_SLUG_REGEX})/service-list/$",
         views.ProjectServiceListView.as_view(),
         name="projects.service_list",
     ),
@@ -49,13 +51,13 @@ urlpatterns = [
         name="docker.check_port_mapping",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/create-service/docker/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/create-service/docker/?$",
         views.CreateDockerServiceAPIView.as_view(),
         name="services.docker.create",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/request-service-changes/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/request-service-changes/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/?$",
         views.RequestDockerServiceDeploymentChangesAPIView.as_view(),
         name="services.docker.request_deployment_changes",
     ),
@@ -64,8 +66,8 @@ urlpatterns = [
 if settings.DEBUG:
     urlpatterns += [
         re_path(
-            r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/request-service-changes/docker"
-            r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/_bulk/?$",
+            rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/request-service-changes/docker"
+            rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/_bulk/?$",
             views.BulkRequestDockerServiceDeploymentChangesAPIView.as_view(),
         ),
         re_path(
@@ -88,68 +90,68 @@ urlpatterns += [
         name="logs.tail",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/cancel-service-changes/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/(?P<change_id>[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/cancel-service-changes/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/(?P<change_id>[a-zA-Z0-9]+(?:_[a-zA-Z0-9]+)*)/?$",
         views.CancelDockerServiceDeploymentChangesAPIView.as_view(),
         name="services.docker.cancel_deployment_changes",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/deploy-service/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/deploy-service/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/?$",
         views.ApplyDockerServiceDeploymentChangesAPIView.as_view(),
         name="services.docker.deploy_service",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/deploy-service/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/deploy-service/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
         views.RedeployDockerServiceAPIView.as_view(),
         name="services.docker.redeploy_service",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/cancel-deployment/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/cancel-deployment/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
         views.CancelDockerServiceDeploymentAPIView.as_view(),
         name="services.docker.cancel_deployment",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/archive-service/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/archive-service/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/?$",
         views.ArchiveDockerServiceAPIView.as_view(),
         name="services.docker.archive",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/toggle-service/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/toggle-service/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/?$",
         views.ToggleDockerServiceAPIView.as_view(),
         name="services.docker.toggle",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/service-details/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/service-details/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/?$",
         views.DockerServiceDetailsAPIView.as_view(),
         name="services.docker.details",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/service-details/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/deployments/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/service-details/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/deployments/?$",
         views.DockerServiceDeploymentsAPIView.as_view(),
         name="services.docker.deployments_list",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/service-details/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/deployments/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/service-details/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/deployments/(?P<deployment_hash>[a-zA-Z0-9-_]+)/?$",
         views.DockerServiceDeploymentSingleAPIView.as_view(),
         name="services.docker.deployment_single",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/service-details/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/deployments/(?P<deployment_hash>[a-zA-Z0-9-_]+)/logs/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/service-details/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/deployments/(?P<deployment_hash>[a-zA-Z0-9-_]+)/logs/?$",
         views.DockerServiceDeploymentLogsAPIView.as_view(),
         name="services.docker.deployment_logs",
     ),
     re_path(
-        r"^projects/(?P<project_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/service-details/docker"
-        r"/(?P<service_slug>[a-z0-9]+(?:-[a-z0-9]+)*)/deployments/(?P<deployment_hash>[a-zA-Z0-9-_]+)/http-logs/?$",
+        rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/service-details/docker"
+        rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/deployments/(?P<deployment_hash>[a-zA-Z0-9-_]+)/http-logs/?$",
         views.DockerServiceDeploymentHttpLogsAPIView.as_view(),
         name="services.docker.deployment_http_logs",
     ),

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -123,7 +123,7 @@ class CreateDockerServiceAPIView(APIView):
                         project=project,
                     )
 
-                    service.network_alias = f"{service.slug}-{service.unprefixed_id}"
+                    service.network_alias = f"zn-{service.slug}-{service.unprefixed_id}"
 
                     initial_changes = [
                         DockerDeploymentChange(

--- a/deploy.mk
+++ b/deploy.mk
@@ -87,7 +87,6 @@ remove: ### Take down zaneops
 delete-resources: ### Delete all resources created by zaneops
 	@echo "Taking down zaneops..."
 	docker stack rm zane
-	docker network rm zane
 	@echo "Removing zane-ops volumes..."
 	docker volume rm $$(docker volume ls --filter "label=zane.stack=true" -q)
 	@echo "Removing down all services created by zane-ops..."
@@ -96,3 +95,5 @@ delete-resources: ### Delete all resources created by zaneops
 	docker network rm $$(docker network ls --filter "label=zane-managed=true" -q) || true
 	@echo "Removing all volumes created by zane-ops..."
 	docker volume rm $$(docker volume ls --filter "label=zane-managed=true" -q) || true
+	@echo "Removing zane-ops network..."
+	docker network rm zane

--- a/docker/start-docker-stack.sh
+++ b/docker/start-docker-stack.sh
@@ -24,14 +24,7 @@ source ./attach-proxy-networks.sh
 echo "Scaling up all zane-ops services..."
 
 # File containing the services to scale up
-exclude_label="zane-allow-sleeping=true"
-services=$(docker service ls --filter "label=zane-managed=true" --format "{{.ID}}" | xargs -I {} sh -c 'docker service inspect {} | grep -q "'$exclude_label'" || echo {}')
-echo "$services" | while IFS= read -r service; do
-  if [[ -n "$service" ]]; then
-    echo "Scaling down service: $service"
-    docker service scale --detach $service=1
-  fi
-done
+docker service ls --filter "label=zane-managed=true" -q |  xargs -P 0 -I {} docker service scale --detach {}=1
 
 # Wait until Ctrl+C is pressed
 echo "Server launched at http://localhost:5678/"

--- a/docker/stop-docker-stack.sh
+++ b/docker/stop-docker-stack.sh
@@ -3,11 +3,6 @@ echo "Removing the proxy and the docker-compose stack..."
 docker stack rm zane && docker-compose down --remove-orphans
 
 echo "Scaling down all zane-ops services..."
-services=$(docker service ls --filter "label=zane-managed=true" --format "{{.ID}}")
-echo "$services" | while IFS= read -r service; do
-  if [[ -n "$service" ]]; then
-    echo "Scaling down service: $service"
-    docker service scale --detach $service=0
-  fi
-done
+docker service ls --filter "label=zane-managed=true" -q | xargs -P 0 -I {} docker service scale --detach {}=0
+
 echo "Done undeploying the stack"


### PR DESCRIPTION
## Description

In this PR we fixed the bug where if we created projects or services with slugs containing underscores (`_`) or starting/ending with hyphens (`-`), the API would raise a 404 because it didn't match the regex we set for the routes, so to fix it we made the regex for the slugs used in the routes match the one from django. 

fixes #246 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
