### PR TITLE
fix: port conflict during redeployment by forcefully unbinding ports from old deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,29 +73,22 @@ You can view all the in-app screenshots in the [documentation](https://zane.fred
 <summary>Click to see the roadmap</summary>
 
 - **beta** :
-   - [ ] Docker services frontend 
-     - [ ] Details page 
-     - [ ] Env variables page
-     - [ ] Settings page
-     - [ ] Single deployment page
+   - [x] Docker services frontend 
+     - [x] Details page 
+     - [x] Env variables page
+     - [x] Settings page
      - [ ] Single deployment application logs page
+     - [ ] Single deployment page details 
      - [ ] Single deployment http logs page
-     - [ ] deploy & redeploy deployments
+     - [x] deploy & redeploy deployments
    - [ ] Project frontend
      - [ ] settings page 
-   - [ ] CLI
-     - [ ] install & setup zaneops
-     - [ ] shutting down & uninstalling ZaneOps
-     - [ ] upgrading ZaneOps
-     - [ ] authenticate with token (require token UI+API in ZaneOps)
-     - [ ] Deploy a service using the CLI
-   - [ ] Tons of docs
-     - [ ] Using the CLI
+   - [ ] Tons of tutorials
      - [ ] Examples of deploying different kind of apps
+  - [x] Rewrite from celery to temporal (not sure)
 
 - **v1** :
 
-  - [ ] Rewrite from celery to temporal (not sure)
   - [ ] Managing environments (stating, production, and ephemeral envs)
   - [ ] Support workers (A.K.A sleeping services)
   - [ ] Git services API
@@ -103,12 +96,17 @@ You can view all the in-app screenshots in the [documentation](https://zane.fred
     - [ ] deploy service  
       - [ ] Building service with nixpacks  
     - [ ] archive service
-    - [ ] Pull Request environments
+    - [ ] Pull Request environments & deploying automatically
     - [ ] Auto-comments with deployment status on github
   - [ ] Git services frontend & API (same as docker services)
 
 - **v2** :
-
+  - [ ] CLI
+     - [ ] install & setup zaneops
+     - [ ] shutting down & uninstalling ZaneOps
+     - [ ] upgrading ZaneOps
+     - [ ] authenticate with token (require token UI+API in ZaneOps)
+     - [ ] Deploy a service using the CLI
   - [ ] Static websites support
   - [ ] CRONs support for services
   - [ ] Template support

--- a/backend/zane_api/temporal/schedules/activities.py
+++ b/backend/zane_api/temporal/schedules/activities.py
@@ -203,6 +203,7 @@ class MonitorDockerDeploymentActivities:
                 non_retryable=True,
             )
         else:
-            deployment.status_reason = healthcheck_result.reason
-            deployment.status = healthcheck_result.status
-            await deployment.asave()
+            if deployment.status != DockerDeployment.DeploymentStatus.SLEEPING:
+                deployment.status_reason = healthcheck_result.reason
+                deployment.status = healthcheck_result.status
+                await deployment.asave()

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -138,6 +138,7 @@ class SimpleDeploymentDetails:
     service_id: str
     status: Optional[str] = None
     url: Optional[str] = None
+    service_snapshot: Optional[DockerServiceSnapshot] = None
 
     @property
     def monitor_schedule_id(self):

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -492,7 +492,7 @@ class AuthAPITestCase(APITestCase):
             slug="caddy"
         )
 
-        service.network_alias = f"{service.slug}-{service.unprefixed_id}"
+        service.network_alias = f"zn-{service.slug}-{service.unprefixed_id}"
         await service.asave()
 
         other_changes = other_changes if other_changes is not None else []
@@ -670,10 +670,13 @@ class FakeDockerClient:
         def remove(self):
             self.parent.services_remove(self.name)
 
-        def update(self, networks: list):
-            self.attrs["Spec"]["TaskTemplate"]["Networks"] = [
-                {"Target": network} for network in networks
-            ]
+        def update(self, **kwargs):
+            if "networks" in kwargs:
+                self.attrs["Spec"]["TaskTemplate"]["Networks"] = [
+                    {"Target": network} for network in kwargs["networks"]
+                ]
+            if kwargs.get("mode") == {"Replicated": {"Replicas": 0}}:
+                self.swarm_tasks = []
 
         def tasks(self, *args, **kwargs):
             return self.swarm_tasks

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -3623,10 +3623,12 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
             ],
             any_order=True,
         )
-        fake_service.scale.assert_has_calls(
-            [call(1)],
-            any_order=True,
+        fake_service.update.assert_called()
+        scaled_up = any(
+            call.kwargs.get("mode") == {"Replicated": {"Replicas": 1}}
+            for call in fake_service.update.call_args_list
         )
+        self.assertTrue(scaled_up)
 
     async def test_update_url_delete_old_url_from_caddy(self):
         p, service = await self.acreate_and_deploy_caddy_docker_service()
@@ -3797,8 +3799,12 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
                 project_id=first_deployment.service.project_id,
             )
         )
-        self.assertEqual(2, fake_service.scale.call_count)
-        fake_service.scale.assert_called_with(0)
+        fake_service.update.assert_called()
+        scaled_down = any(
+            call.kwargs.get("mode") == {"Replicated": {"Replicas": 0}}
+            for call in fake_service.update.call_args_list
+        )
+        self.assertTrue(scaled_down)
 
     async def test_dont_do_zero_downtime_when_updating_with_host_ports(self):
         project, service = await self.acreate_and_deploy_redis_docker_service()
@@ -3862,8 +3868,12 @@ class DockerServiceDeploymentUpdateViewTests(AuthAPITestCase):
                 project_id=first_deployment.service.project_id,
             )
         )
-        self.assertEqual(2, fake_service.scale.call_count)
-        fake_service.scale.assert_called_with(0)
+        fake_service.update.assert_called()
+        scaled_down = any(
+            call.kwargs.get("mode") == {"Replicated": {"Replicas": 0}}
+            for call in fake_service.update.call_args_list
+        )
+        self.assertTrue(scaled_down)
 
     async def test_update_service_remove_previous_monitor_task(self):
         project, service = await self.acreate_and_deploy_redis_docker_service()
@@ -4208,7 +4218,12 @@ class DockerToggleServiceViewTests(AuthAPITestCase):
                 project_id=first_deployment.service.project_id,
             )
         )
-        fake_service.scale.assert_called_with(0)
+        fake_service.update.assert_called()
+        scaled_up = any(
+            call.kwargs.get("mode") == {"Replicated": {"Replicas": 0}}
+            for call in fake_service.update.call_args_list
+        )
+        self.assertTrue(scaled_up)
         monitor_schedule = self.get_workflow_schedule_by_id(
             first_deployment.monitor_schedule_id
         )
@@ -4277,7 +4292,12 @@ class DockerToggleServiceViewTests(AuthAPITestCase):
                 project_id=first_deployment.service.project_id,
             )
         )
-        fake_service.scale.assert_called_with(1)
+        fake_service.update.assert_called()
+        scaled_up = any(
+            call.kwargs.get("mode") == {"Replicated": {"Replicas": 1}}
+            for call in fake_service.update.call_args_list
+        )
+        self.assertTrue(scaled_up)
         monitor_schedule = self.get_workflow_schedule_by_id(
             first_deployment.monitor_schedule_id
         )

--- a/backend/zane_api/tests/deployment.py
+++ b/backend/zane_api/tests/deployment.py
@@ -2952,7 +2952,7 @@ class DockerServiceDeploymentCreateResourceTests(AuthAPITestCase):
                     new_value={
                         "container_path": "/delete",
                         "host_path": "/delete",
-                        "mode": Volume.VolumeMode.READ_WRITE,
+                        "mode": Volume.VolumeMode.READ_ONLY,
                     },
                 ),
             ]

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -1113,6 +1113,7 @@ class ToggleDockerServiceAPIView(APIView):
             project_id=project.id,
             service_id=service.id,
             status=production_deployment.status,
+            service_snapshot=production_deployment.service_snapshot,
         )
         transaction.on_commit(
             lambda: start_workflow(

--- a/docker/start-docker-stack.sh
+++ b/docker/start-docker-stack.sh
@@ -24,7 +24,7 @@ source ./attach-proxy-networks.sh
 echo "Scaling up all zane-ops services..."
 
 # File containing the services to scale up
-docker service ls --filter "label=zane-managed=true" -q |  xargs -P 0 -I {} docker service scale --detach {}=1
+docker service ls --filter "label=zane-managed=true" --filter "label=status=active" -q |  xargs -P 0 -I {} docker service scale --detach {}=1
 
 # Wait until Ctrl+C is pressed
 echo "Server launched at http://localhost:5678/"

--- a/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug.services.docker.$service_slug/settings.lazy.tsx
@@ -149,7 +149,7 @@ function SettingsPage() {
           </div>
         </section>
 
-        <section id="danger-zone" className="flex gap-1 scroll-mt-20">
+        <section id="danger" className="flex gap-1 scroll-mt-20">
           <div className="w-16 hidden md:flex flex-col items-center">
             <div className="flex rounded-full size-10 flex-none items-center justify-center p-1 border-2 border-red-500">
               <FlameIcon size={15} className="flex-none text-red-500" />
@@ -166,7 +166,7 @@ function SettingsPage() {
         <nav className="sticky top-20">
           <ul className="flex flex-col gap-2 text-grey">
             <li>
-              <Link to="./#details">Details</Link>
+              <Link to="./#main">Details</Link>
             </li>
             <li>
               <Link to="./#source">Source</Link>
@@ -181,7 +181,7 @@ function SettingsPage() {
               <Link to="./#volumes">Volumes</Link>
             </li>
             <li className="text-red-400">
-              <a href="#danger-zone">Danger Zone</a>
+              <Link to="./#danger">Danger Zone</Link>
             </li>
           </ul>
         </nav>


### PR DESCRIPTION
## Description

> This is to fix a bug with exposed ports conflicting with a new deployment, the new deployment creates a service that needs the ports of the service to be available, but it is still used by the old deployment. 
> To fix this we scale down and remove the ports from the old services
> and reattach the ports to the old service if the new deployment fails

fixes #263 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
