### PR TITLE
refactor: use a custom docker image for the proxy

### DIFF
--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -48,6 +48,12 @@ services:
           memory: 200M
     ports:
       - "443:443"
+    healthcheck:
+      test: ["CMD-SHELL", "curl", "-f", "http://localhost:2019/config/"]
+      interval: 10s
+      retries: 5
+      start_period: 5s
+      timeout: 10s
     volumes:
       - caddy-data:/data
       - caddy-config:/config

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -1,12 +1,6 @@
-ARG CADDY_VERSION=2.8
-FROM caddy:${CADDY_VERSION}-builder AS builder
+FROM ghcr.io/fredkiss3/caddy-cloudflare:2.8.4-alpine
 
 LABEL org.opencontainers.image.source=https://github.com/zane-ops/zane-ops
-
-RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare
-
-FROM caddy:${CADDY_VERSION}-alpine
 
 ARG ENVIRONMENT=dev
 

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -2,6 +2,7 @@ FROM ghcr.io/fredkiss3/caddy-cloudflare:2.8.4-alpine
 
 LABEL org.opencontainers.image.source=https://github.com/zane-ops/zane-ops
 
+ARG ENVIRONMENT=dev
 RUN apk add --no-cache curl
 
 COPY default-caddy-config-${ENVIRONMENT}.json /config/caddy/autosave.json

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -2,10 +2,7 @@ FROM ghcr.io/fredkiss3/caddy-cloudflare:2.8.4-alpine
 
 LABEL org.opencontainers.image.source=https://github.com/zane-ops/zane-ops
 
-ARG ENVIRONMENT=dev
+RUN apk add --no-cache curl
 
-RUN apk add --no-cache wget
-
-COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY default-caddy-config-${ENVIRONMENT}.json /config/caddy/autosave.json
 CMD caddy run --resume


### PR DESCRIPTION
## Description

- This way we don't have to build the image for the proxy from source, it will be way faster.
- We will also use REDIS for the storage of the certificates and config

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
