### PR TITLE
feat: new `LIVE ⚡️` indicator

### DIFF
--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -510,7 +510,12 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
                         <div ref={loadNextPageRef} className="w-full h-px" />
                       )}
                       {virtualRow.index === 0 && (
-                        <div className="w-full h-px" ref={refetchRef} />
+                        <div
+                          className="w-full py-2 text-center -scale-y-100 text-grey italic"
+                          ref={refetchRef}
+                        >
+                          -- LIVE ⚡️ new log entries will appear here --
+                        </div>
                       )}
 
                       <Log


### PR DESCRIPTION
## Description

it looks like this : 
<img width="393" alt="Capture d’écran 2024-11-18 à 01 37 36" src="https://github.com/user-attachments/assets/a88ab1bd-7064-4ab3-9983-1567967c10d6">

closes #292 


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
