### PR TITLE
fix: logs rendering perf by removing tanstack virtual overscan

### DIFF
--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -125,7 +125,6 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
     count: logs.length,
     getScrollElement: () => logContentRef.current,
     estimateSize: () => 16 * 2,
-    overscan: 25,
     paddingStart: 16,
     paddingEnd: 8
   });


### PR DESCRIPTION
## Description

Makes logs rendering more performant by removing the overscan of 25 logs to always load. This way if we have only two logs visible in the viewport with BIG ANSI texts, they won't affect the perf as much as if they were 25 (the default). 

It was causing performance issues because the `AnsiHtml` component would run a parsing of all the 25 big logs (which is not very fast), so to mitigate this, we only allow it to parse the logs visible logs. 

The 25 overscan value was an arbitrary number so that the scrolling would be smoother.

fixes #293 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
