### PR TITLE
fix: safari highlight not working 

### DIFF
--- a/frontend/src/components/service-cards.tsx
+++ b/frontend/src/components/service-cards.tsx
@@ -56,7 +56,10 @@ export function DockerServiceCard({
       <TooltipProvider>
         <Tooltip delayDuration={0}>
           <TooltipTrigger asChild>
-            <span className="absolute cursor-pointer flex h-4 w-4 -top-1 -right-1 z-10">
+            <span
+              tabIndex={0}
+              className="absolute cursor-pointer flex h-4 w-4 -top-1 -right-1 z-10"
+            >
               {status !== "NOT_DEPLOYED_YET" && status !== "CANCELLED" && (
                 <span
                   className={cn(
@@ -84,6 +87,7 @@ export function DockerServiceCard({
                   }
                 )}
               ></span>
+              <span className="sr-only">{status}</span>
             </span>
           </TooltipTrigger>
           <TooltipContent>

--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -309,7 +309,7 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
       <div
         className={cn(
           "col-span-12 flex flex-col gap-2",
-          searchParams.isMaximized ? "container px-0 h-[82svh]" : "h-[65svh]"
+          searchParams.isMaximized ? "container px-0 h-[82dvh]" : "h-[65dvh]"
         )}
       >
         <div className="rounded-t-sm w-full flex gap-2 flex-col md:flex-row flex-wrap lg:flex-nowrap">

--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -590,7 +590,7 @@ const Log = React.memo(
             {supportsCSSCustomHighlightsAPI() ? (
               <pre
                 data-highlight="true"
-                className="text-wrap text-start relative select-none text-transparent break-all col-start-1 col-end-1 row-start-1 row-end-1"
+                className="text-wrap text-start relative z-[-1] text-transparent break-all col-start-1 col-end-1 row-start-1 row-end-1"
               >
                 {content_text}
               </pre>

--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -593,7 +593,7 @@ const Log = React.memo(
           <div className="grid relative z-10">
             <AnsiHtml
               aria-hidden="true"
-              className="text-wrap text-start break-all select-auto z-10 whitespace-pre relative col-start-1 col-end-1 row-start-1 row-end-1"
+              className="text-wrap text-start break-all z-10 mix-blend-color dark:mix-blend-color-dodge whitespace-pre relative col-start-1 col-end-1 row-start-1 row-end-1"
               text={content}
             />
             {supportsCSSCustomHighlightsAPI() ? (

--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -513,7 +513,7 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
                           className="w-full py-2 text-center -scale-y-100 text-grey italic"
                           ref={refetchRef}
                         >
-                          -- LIVE ⚡️ new log entries will appear here --
+                          -- LIVE <Ping /> new log entries will appear here --
                         </div>
                       )}
 
@@ -550,6 +550,15 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
         </pre>
       </div>
     </div>
+  );
+}
+
+function Ping() {
+  return (
+    <span className="relative inline-flex h-2 w-2">
+      <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-500 opacity-75"></span>
+      <span className="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span>
+    </span>
   );
 }
 


### PR DESCRIPTION
## Description

The CSS highlight API requires that your element can be selected, so the class that we used `select-none` which corresponds to the css : `user-select: none`, disabled it, making it not work as expected.

So the fix is to remove this class, and we can prevent selecting the invisible text by pushing it behind the visible text.

fix #291 
fix #300 

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
