### PR TITLE
fix: Caddy not generating SSL certificates correctly

### DIFF
--- a/.github/workflows/build-push-images-canary.yaml
+++ b/.github/workflows/build-push-images-canary.yaml
@@ -38,6 +38,7 @@ jobs:
           tags: ghcr.io/zane-ops/proxy:canary,ghcr.io/zane-ops/proxy:${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/zane-ops/proxy:canary
           cache-to: type=inline
+          build-args: ENVIRONMENT=prod
   build-push-frontend:
     name: Build and Push Zane Frontend
     runs-on: ubuntu-latest

--- a/.github/workflows/build-push-images-dev.yaml
+++ b/.github/workflows/build-push-images-dev.yaml
@@ -36,6 +36,7 @@ jobs:
             type=registry,ref=ghcr.io/zane-ops/proxy:pr-${{ github.event.pull_request.number }}
             type=registry,ref=ghcr.io/zane-ops/proxy:canary
           cache-to: type=inline
+          build-args: ENVIRONMENT=prod
   build-push-frontend:
     name: Build and Push Zane Frontend
     runs-on: ubuntu-latest

--- a/deploy.mk
+++ b/deploy.mk
@@ -74,7 +74,7 @@ deploy: ### Install and deploy zaneops
 	@docker service ls --filter "label=zane-managed=true" --filter "label=status=active" -q | xargs -P 0 -I {} docker service scale --detach {}=1
 	@echo "🏁 Deploy done, Please give this is a little minutes before accessing your website 🏁"
 	@echo -e "You can monitor the services deployed by running \x1b[94mdocker service ls --filter label=\"zane.stack=true\"\x1b[0m"
-	@echo -e "Wait for all services (except for \x1b[94mzane_temporal-admin-tools\x1b[0m) to show up as \x1b[94mreplicated   1/1\x1b[0m to attest that everything started succesfully"
+	@echo -e "Wait for all services (except for \x1b[90mzane_temporal-admin-tools\x1b[0m) to show up as \x1b[94mreplicated   1/1\x1b[0m to attest that everything started succesfully"
 
 create-user: ### Create the first user to login in into the dashboard
 	@docker exec -it $$(docker ps -qf "name=zane_api") /bin/bash -c "source /venv/bin/activate && python manage.py createsuperuser"

--- a/deploy.mk
+++ b/deploy.mk
@@ -73,8 +73,8 @@ deploy: ### Install and deploy zaneops
 	@. ./attach-proxy-networks.sh
 	@docker service ls --filter "label=zane-managed=true" --filter "label=status=active" -q | xargs -P 0 -I {} docker service scale --detach {}=1
 	@echo "🏁 Deploy done, Please give this is a little minutes before accessing your website 🏁"
-	@echo -e "You can monitor the services deployed by running \x1b[94mdocker service ls --filter label=\"zane.stack=true\"\x1b[0m"
-	@echo -e "Wait for all services (except for \x1b[90mzane_temporal-admin-tools\x1b[0m) to show up as \x1b[94mreplicated   1/1\x1b[0m to attest that everything started succesfully"
+	@echo -e "You can monitor the services deployed by running \x1b[96mdocker service ls --filter label=\"zane.stack=true\"\x1b[0m"
+	@echo -e "Wait for all services (except for \x1b[90mzane_temporal-admin-tools\x1b[0m) to show up as \x1b[96mreplicated   1/1\x1b[0m to attest that everything started succesfully"
 
 create-user: ### Create the first user to login in into the dashboard
 	@docker exec -it $$(docker ps -qf "name=zane_api") /bin/bash -c "source /venv/bin/activate && python manage.py createsuperuser"

--- a/deploy.mk
+++ b/deploy.mk
@@ -75,7 +75,7 @@ deploy: ### Install and deploy zaneops
 	@echo -e "====== \x1b[94mDONE Deploying ZaneOps ✅\x1b[0m ======"
 
 deploy-with-http: ### Install and deploy zaneops with the HTTP port enabled : better suited for tests and local installation
-	@echo -e "====== \x1b[94mDeploying ZaneOps\x1b[0m \x1b[38;5;208m⚠️ with HTTP enabled ⚠️\x1b[0m... ======"
+	@echo -e "====== \x1b[94mDeploying ZaneOps\x1b[0m \x1b[38;5;208m⚠️  with HTTP enabled ⚠️\x1b[0m... ======"
 	@set -a; . ./.env; set +a && docker stack deploy --with-registry-auth --compose-file docker-stack.prod.yaml --compose-file docker-stack.prod-http.yaml zane;
 	@. ./attach-proxy-networks.sh
 	@docker service ls --filter "label=zane-managed=true" --filter "label=status=active" -q | xargs -P 0 -I {} docker service scale --detach {}=1

--- a/deploy.mk
+++ b/deploy.mk
@@ -65,16 +65,24 @@ setup: ### Launch initial setup before installing zaneops
 	@echo "Setup finished 🏁"
 
 deploy: ### Install and deploy zaneops
-	@echo "🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀"
-	@echo "    🚀   DEPLOYMENT OF ZANEOPS   🚀"
-	@echo "🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀🚀"
-	@echo "Deploying zaneops...🔄"
+	@echo -e "====== \x1b[94mDeploying ZaneOps...🔄\x1b[0m ======"
+	@set -a; . ./.env; set +a && docker stack deploy --with-registry-auth --compose-file docker-stack.prod.yaml zane;
+	@. ./attach-proxy-networks.sh
+	@docker service ls --filter "label=zane-managed=true" --filter "label=status=active" -q | xargs -P 0 -I {} docker service scale --detach {}=1
+	@echo "🏁 Deploy done, Please give this is a little minutes before accessing your website 🏁"
+	@echo -e "You can monitor the services deployed by running \x1b[96mdocker service ls --filter label=\"zane.stack=true\"\x1b[0m"
+	@echo -e "Wait for all services (except for \x1b[90mzane_temporal-admin-tools\x1b[0m) to show up as \x1b[96mreplicated   1/1\x1b[0m to attest that everything started succesfully"
+	@echo -e "====== \x1b[94mDONE Deploying ZaneOps ✅\x1b[0m ======"
+
+deploy-with-http: ### Install and deploy zaneops with the HTTP port enabled : better suited for tests and local installation
+	@echo -e "====== \x1b[94mDeploying ZaneOps\x1b[0m \x1b[38;5;208m⚠️ with HTTP enabled ⚠️\x1b[0m... ======"
 	@set -a; . ./.env; set +a && docker stack deploy --with-registry-auth --compose-file docker-stack.prod.yaml --compose-file docker-stack.prod-http.yaml zane;
 	@. ./attach-proxy-networks.sh
 	@docker service ls --filter "label=zane-managed=true" --filter "label=status=active" -q | xargs -P 0 -I {} docker service scale --detach {}=1
 	@echo "🏁 Deploy done, Please give this is a little minutes before accessing your website 🏁"
 	@echo -e "You can monitor the services deployed by running \x1b[96mdocker service ls --filter label=\"zane.stack=true\"\x1b[0m"
 	@echo -e "Wait for all services (except for \x1b[90mzane_temporal-admin-tools\x1b[0m) to show up as \x1b[96mreplicated   1/1\x1b[0m to attest that everything started succesfully"
+	@echo -e "====== \x1b[94mDONE Deploying ZaneOps ✅\x1b[0m ======"
 
 create-user: ### Create the first user to login in into the dashboard
 	@docker exec -it $$(docker ps -qf "name=zane_api") /bin/bash -c "source /venv/bin/activate && python manage.py createsuperuser"

--- a/deploy.mk
+++ b/deploy.mk
@@ -73,8 +73,8 @@ deploy: ### Install and deploy zaneops
 	@. ./attach-proxy-networks.sh
 	@docker service ls --filter "label=zane-managed=true" --filter "label=status=active" -q | xargs -P 0 -I {} docker service scale --detach {}=1
 	@echo "🏁 Deploy done, Please give this is a little minutes before accessing your website 🏁"
-	@echo "You can monitor the services deployed by running \x1b[92mdocker service ls --filter label=\"zane.stack=true\"\x1b[0m"
-	@echo "Wait for all services (except for \`zane_temporal-admin-tools\`) to show up as \x1b[92mreplicated   1/1\x1b[0m to attest that everything started succesfully"
+	@echo -e "You can monitor the services deployed by running \x1b[94mdocker service ls --filter label=\"zane.stack=true\"\x1b[0m"
+	@echo -e "Wait for all services (except for \x1b[94mzane_temporal-admin-tools\x1b[0m) to show up as \x1b[94mreplicated   1/1\x1b[0m to attest that everything started succesfully"
 
 create-user: ### Create the first user to login in into the dashboard
 	@docker exec -it $$(docker ps -qf "name=zane_api") /bin/bash -c "source /venv/bin/activate && python manage.py createsuperuser"

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -1,12 +1,6 @@
-ARG CADDY_VERSION=2.8
-FROM caddy:${CADDY_VERSION}-builder AS builder
+FROM ghcr.io/fredkiss3/caddy-cloudflare:2.8.4-alpine
 
 LABEL org.opencontainers.image.source=https://github.com/zane-ops/zane-ops
-
-RUN xcaddy build \
-    --with github.com/caddy-dns/cloudflare
-
-FROM caddy:${CADDY_VERSION}-alpine
 
 ARG ENVIRONMENT=dev
 

--- a/docker/proxy/Dockerfile
+++ b/docker/proxy/Dockerfile
@@ -6,6 +6,5 @@ ARG ENVIRONMENT=dev
 
 RUN apk add --no-cache wget
 
-COPY --from=builder /usr/bin/caddy /usr/bin/caddy
 COPY default-caddy-config-${ENVIRONMENT}.json /config/caddy/autosave.json
 CMD caddy run --resume

--- a/frontend/src/components/helper/auth-redirect.tsx
+++ b/frontend/src/components/helper/auth-redirect.tsx
@@ -20,9 +20,12 @@ export function withAuthRedirect(WrappedComponent: ComponentType<any>) {
 
       navigate({
         to: "/login",
-        search: {
-          redirect_to: currentPath !== "/login" ? currentPath : ""
-        }
+        search:
+          currentPath !== "/login"
+            ? {
+                redirect_to: currentPath
+              }
+            : undefined
       });
       return null;
     }

--- a/frontend/src/components/helper/auth-redirect.tsx
+++ b/frontend/src/components/helper/auth-redirect.tsx
@@ -17,10 +17,11 @@ export function withAuthRedirect(WrappedComponent: ComponentType<any>) {
     const user = query.data?.data?.user;
     if (!user) {
       const currentPath = window.location.pathname;
+
       navigate({
         to: "/login",
         search: {
-          redirect_to: currentPath
+          redirect_to: currentPath !== "/login" ? currentPath : ""
         }
       });
       return null;


### PR DESCRIPTION
## Description

The bug was happening because we build the proxy image with the default config for the `dev` environment 🤦🏾 , to fix this with added the build-arg `ENVIRONMENT` variable and set it to `prod`

fixes #308 

We also included some other changes in this PR : 
- Changed the deploy script to generate a `sslip.io` subdomain with the IP of the server (if they are on Linux) 
- Fixed a bug with auth-redirect, we should not redirect to login
- we also moved from building the proxy image from scratch everytime to using a prebuilt image
- we added another command for deploying the app, by default it will execute in https-only, but you can deploy with `http` enabled, the backend will automatically restrict the ports open on caddy accordingly :
  <br/>
  ```shell
  make deploy-with-http
  ```
- But Moving from https to http or vice versa requires stopping then restarting the stack : 
   <br/>
  ```shell
  make stop && make deploy # or make deploy-with-https
  ```

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
