### PR TITLE
refactor: auto-setup TLS app on proxy & secure internal endpoints

### DIFF
--- a/backend/backend/bootstrap.py
+++ b/backend/backend/bootstrap.py
@@ -76,7 +76,7 @@ def register_zaneops_app_on_proxy(
 
         if 200 <= response.status_code < 300:
             print(
-                f"[{Colors.BLUE}{config_id}{Colors.ENDC}] Updated proxy configuration succesfully ✅\n"
+                f"[{Colors.BLUE}{config_id}{Colors.ENDC}] Updated proxy configuration succesfully ✅"
             )
         else:
             print(
@@ -107,7 +107,7 @@ def register_zaneops_app_on_proxy(
     )
     if 200 <= response.status_code < 300:
         print(
-            f"[{Colors.BLUE}root.apps.tls{Colors.ENDC}] Updated proxy configuration succesfully ✅\n"
+            f"[{Colors.BLUE}root.apps.tls{Colors.ENDC}] Updated proxy configuration succesfully ✅"
         )
     else:
         print(

--- a/backend/backend/bootstrap.py
+++ b/backend/backend/bootstrap.py
@@ -10,6 +10,7 @@ def register_zaneops_app_on_proxy(
     zane_app_domain: str,
     zane_api_internal_domain: str,
     zane_front_internal_domain: str,
+    internal_tls: bool = False,
 ):
     url_configurations = [
         {
@@ -73,7 +74,55 @@ def register_zaneops_app_on_proxy(
                 f"{proxy_url}/id/{config_id}", timeout=5, json=config
             )
 
-        print(
-            f"[{config_id}] Got Response from proxy :\n {response.status_code=}\n {response.text=}\n"
+        if 200 <= response.status_code < 300:
+            print(
+                f"[{Colors.BLUE}{config_id}{Colors.ENDC}] Updated proxy configuration succesfully ✅\n"
+            )
+        else:
+            print(
+                f"[{Colors.RED}{config_id}{Colors.ENDC}] ❌ Got an error when trying to update the proxy ❌"
+            )
+            print(f"With status code : {Colors.RED}{response.status_code}{Colors.ENDC}")
+            print(f"With response data : {Colors.ORANGE}{response.text}{Colors.ENDC}\n")
+
+    tls_app_config = {
+        "automation": {
+            "policies": [{"on_demand": True}],
+            "on_demand": {
+                "permission": {
+                    "@id": "tls-endpoint",
+                    "endpoint": f"http://{zane_api_internal_domain}/api/_proxy/check-certiticates",
+                    "module": "http",
+                }
+            },
+        }
+    }
+
+    if internal_tls:
+        tls_app_config["automation"]["policies"][0].update(
+            {"issuers": [{"module": "internal"}]}
         )
+    response = requests.patch(
+        f"{proxy_url}/id/root/apps/tls", timeout=5, json=tls_app_config
+    )
+    if 200 <= response.status_code < 300:
+        print(
+            f"[{Colors.BLUE}root.apps.tls{Colors.ENDC}] Updated proxy configuration succesfully ✅\n"
+        )
+    else:
+        print(
+            f"[{Colors.RED}root.apps.tls{Colors.ENDC}] ❌ Got an error when trying to update the proxy ❌"
+        )
+        print(f"With status code : {Colors.RED}{response.status_code}{Colors.ENDC}")
+        print(f"With response data : {Colors.ORANGE}{response.text}{Colors.ENDC}\n")
+
     return
+
+
+class Colors:
+    GREEN = "\033[92m"
+    BLUE = "\033[94m"
+    ORANGE = "\033[38;5;208m"
+    RED = "\033[91m"
+    GREY = "\033[90m"
+    ENDC = "\033[0m"  # Reset to default color

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -382,4 +382,5 @@ if BACKEND_COMPONENT == "API":
         zane_app_domain=ZANE_APP_DOMAIN,
         zane_api_internal_domain=ZANE_API_SERVICE_INTERNAL_DOMAIN,
         zane_front_internal_domain=ZANE_FRONT_SERVICE_INTERNAL_DOMAIN,
+        internal_tls=DEBUG,
     )

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -245,15 +245,6 @@ LOGGING = {
     },
 }
 
-if DEBUG and not os.environ.get("SILENT"):
-    LOGGING["loggers"].update(
-        {
-            "django.db.backends": {
-                "level": "DEBUG",
-                "handlers": ["console"],
-            },
-        }
-    )
 
 # Django Rest framework
 

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -47,7 +47,14 @@ class CustomAPIClient(APIClient):
         self.parent = parent
 
     def post(
-        self, path, data=None, format=None, content_type=None, follow=False, **extra
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type=None,
+        follow=False,
+        headers=None,
+        **extra,
     ):
         if type(data) is not str:
             data = json.dumps(data)
@@ -55,14 +62,24 @@ class CustomAPIClient(APIClient):
             path=path,
             data=data,
             format=format,
+            headers=headers,
+            follow=follow,
             content_type=(
                 content_type if content_type is not None else "application/json"
             ),
+            **extra,
         )
         return response
 
     def put(
-        self, path, data=None, format=None, content_type=None, follow=False, **extra
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type=None,
+        follow=False,
+        headers=None,
+        **extra,
     ):
         if type(data) is not str:
             data = json.dumps(data)
@@ -74,11 +91,21 @@ class CustomAPIClient(APIClient):
             content_type=(
                 content_type if content_type is not None else "application/json"
             ),
+            follow=follow,
+            headers=headers,
+            **extra,
         )
         return response
 
     def patch(
-        self, path, data=None, format=None, content_type=None, follow=False, **extra
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type=None,
+        follow=False,
+        headers=None,
+        **extra,
     ):
         if type(data) is not str:
             data = json.dumps(data)
@@ -89,11 +116,21 @@ class CustomAPIClient(APIClient):
             content_type=(
                 content_type if content_type is not None else "application/json"
             ),
+            follow=follow,
+            headers=headers,
+            **extra,
         )
         return response
 
     def delete(
-        self, path, data=None, format=None, content_type=None, follow=False, **extra
+        self,
+        path,
+        data=None,
+        format=None,
+        content_type=None,
+        follow=False,
+        headers=None,
+        **extra,
     ):
         if type(data) is not str:
             data = json.dumps(data)
@@ -104,6 +141,9 @@ class CustomAPIClient(APIClient):
             content_type=(
                 content_type if content_type is not None else "application/json"
             ),
+            follow=follow,
+            headers=headers,
+            **extra,
         )
         return response
 

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -153,7 +153,15 @@ class AsyncCustomAPIClient(AsyncClient):
         super().__init__(enforce_csrf_checks=False, **defaults)
         self.parent = parent
 
-    async def post(self, path, data=None, content_type=None, follow=False, **extra):
+    async def post(
+        self,
+        path,
+        data=None,
+        content_type=None,
+        follow=False,
+        headers=None,
+        **extra,
+    ):
         if type(data) is not str:
             data = json.dumps(data)
         async with self.parent.acaptureCommitCallbacks(execute=True):
@@ -163,10 +171,21 @@ class AsyncCustomAPIClient(AsyncClient):
                 content_type=(
                     content_type if content_type is not None else "application/json"
                 ),
+                follow=follow,
+                headers=headers,
+                **extra,
             )
         return response
 
-    async def put(self, path, data=None, content_type=None, follow=False, **extra):
+    async def put(
+        self,
+        path,
+        data=None,
+        content_type=None,
+        follow=False,
+        headers=None,
+        **extra,
+    ):
         if type(data) is not str:
             data = json.dumps(data)
 
@@ -177,10 +196,21 @@ class AsyncCustomAPIClient(AsyncClient):
                 content_type=(
                     content_type if content_type is not None else "application/json"
                 ),
+                follow=follow,
+                headers=headers,
+                **extra,
             )
         return response
 
-    async def patch(self, path, data=None, content_type=None, follow=False, **extra):
+    async def patch(
+        self,
+        path,
+        data=None,
+        content_type=None,
+        follow=False,
+        headers=None,
+        **extra,
+    ):
         if type(data) is not str:
             data = json.dumps(data)
 
@@ -191,10 +221,21 @@ class AsyncCustomAPIClient(AsyncClient):
                 content_type=(
                     content_type if content_type is not None else "application/json"
                 ),
+                follow=follow,
+                headers=headers,
+                **extra,
             )
         return response
 
-    async def delete(self, path, data=None, content_type=None, follow=False, **extra):
+    async def delete(
+        self,
+        path,
+        data=None,
+        content_type=None,
+        follow=False,
+        headers=None,
+        **extra,
+    ):
         if type(data) is not str:
             data = json.dumps(data)
         async with self.parent.acaptureCommitCallbacks(execute=True):
@@ -204,6 +245,9 @@ class AsyncCustomAPIClient(AsyncClient):
                 content_type=(
                     content_type if content_type is not None else "application/json"
                 ),
+                follow=follow,
+                headers=headers,
+                **extra,
             )
         return response
 

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -11,6 +11,7 @@ from temporalio.testing import WorkflowEnvironment
 
 from temporalio.common import RetryPolicy
 
+
 from ..temporal.schedules.workflows import CleanupAppLogsWorkflow
 from .base import AuthAPITestCase
 from ..models import SimpleLog, DockerDeployment, DockerRegistryService, HttpLog
@@ -32,7 +33,9 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
         json_log = json.loads(simple_proxy_logs[0]["log"])
 
         response = self.client.post(
-            reverse("zane_api:logs.ingest"), data=simple_proxy_logs
+            reverse("zane_api:logs.ingest"),
+            data=simple_proxy_logs,
+            headers={"X-Secret": settings.SECRET_KEY},
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -142,7 +145,11 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
             },
         ]
 
-        response = self.client.post(reverse("zane_api:logs.ingest"), data=simple_logs)
+        response = self.client.post(
+            reverse("zane_api:logs.ingest"),
+            data=simple_logs,
+            headers={"X-Secret": settings.SECRET_KEY},
+        )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
         self.assertEqual(len(simple_logs), deployment.logs.count())
@@ -738,7 +745,9 @@ class HttpLogViewTests(AuthAPITestCase):
         ]
 
         response = self.client.post(
-            reverse("zane_api:logs.ingest"), data=simple_proxy_logs
+            reverse("zane_api:logs.ingest"),
+            data=simple_proxy_logs,
+            headers={"X-Secret": settings.SECRET_KEY},
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -783,7 +792,9 @@ class HttpLogViewTests(AuthAPITestCase):
         ]
 
         response = self.client.post(
-            reverse("zane_api:logs.ingest"), data=simple_proxy_logs
+            reverse("zane_api:logs.ingest"),
+            headers={"X-Secret": settings.SECRET_KEY},
+            data=simple_proxy_logs,
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -1085,7 +1096,9 @@ class HTTPLogCollectViewTests(AuthAPITestCase):
         ]
 
         response = self.client.post(
-            reverse("zane_api:logs.ingest"), data=simple_proxy_logs
+            reverse("zane_api:logs.ingest"),
+            headers={"X-Secret": settings.SECRET_KEY},
+            data=simple_proxy_logs,
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(0, SimpleLog.objects.count())
@@ -1192,6 +1205,7 @@ class HTTPLogCollectViewTests(AuthAPITestCase):
 
         response = await self.async_client.post(
             reverse("zane_api:logs.ingest"),
+            headers={"X-Secret": settings.SECRET_KEY},
             data=first_deploy_proxy_logs + second_deploy_proxy_logs,
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from django.utils import timezone
 from django.conf import settings
 from temporalio.testing import WorkflowEnvironment
-
+import base64
 from temporalio.common import RetryPolicy
 
 
@@ -35,7 +35,9 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
         response = self.client.post(
             reverse("zane_api:logs.ingest"),
             data=simple_proxy_logs,
-            headers={"X-Secret": settings.SECRET_KEY},
+            headers={
+                "Authorization": f"Basic {base64.b64encode(f'zaneops:{settings.SECRET_KEY}'.encode()).decode()}"
+            },
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -148,7 +150,9 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
         response = self.client.post(
             reverse("zane_api:logs.ingest"),
             data=simple_logs,
-            headers={"X-Secret": settings.SECRET_KEY},
+            headers={
+                "Authorization": f"Basic {base64.b64encode(f'zaneops:{settings.SECRET_KEY}'.encode()).decode()}"
+            },
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -747,7 +751,9 @@ class HttpLogViewTests(AuthAPITestCase):
         response = self.client.post(
             reverse("zane_api:logs.ingest"),
             data=simple_proxy_logs,
-            headers={"X-Secret": settings.SECRET_KEY},
+            headers={
+                "Authorization": f"Basic {base64.b64encode(f'zaneops:{settings.SECRET_KEY}'.encode()).decode()}"
+            },
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -793,7 +799,9 @@ class HttpLogViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse("zane_api:logs.ingest"),
-            headers={"X-Secret": settings.SECRET_KEY},
+            headers={
+                "Authorization": f"Basic {base64.b64encode(f'zaneops:{settings.SECRET_KEY}'.encode()).decode()}"
+            },
             data=simple_proxy_logs,
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
@@ -1098,7 +1106,9 @@ class HTTPLogCollectViewTests(AuthAPITestCase):
         response = self.client.post(
             reverse("zane_api:logs.ingest"),
             data=simple_proxy_logs,
-            headers={"X-Secret": settings.SECRET_KEY},
+            headers={
+                "Authorization": f"Basic {base64.b64encode(f'zaneops:{settings.SECRET_KEY}'.encode()).decode()}"
+            },
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(0, SimpleLog.objects.count())
@@ -1205,7 +1215,9 @@ class HTTPLogCollectViewTests(AuthAPITestCase):
 
         response = await self.async_client.post(
             reverse("zane_api:logs.ingest"),
-            headers={"X-Secret": settings.SECRET_KEY},
+            headers={
+                "Authorization": f"Basic {base64.b64encode(f'zaneops:{settings.SECRET_KEY}'.encode()).decode()}"
+            },
             data=first_deploy_proxy_logs + second_deploy_proxy_logs,
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -1097,8 +1097,8 @@ class HTTPLogCollectViewTests(AuthAPITestCase):
 
         response = self.client.post(
             reverse("zane_api:logs.ingest"),
-            headers={"X-Secret": settings.SECRET_KEY},
             data=simple_proxy_logs,
+            headers={"X-Secret": settings.SECRET_KEY},
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(0, SimpleLog.objects.count())

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -32,7 +32,7 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
         json_log = json.loads(simple_proxy_logs[0]["log"])
 
         response = self.client.post(
-            reverse("zane_api:logs.tail"), data=simple_proxy_logs
+            reverse("zane_api:logs.ingest"), data=simple_proxy_logs
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -142,7 +142,7 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
             },
         ]
 
-        response = self.client.post(reverse("zane_api:logs.tail"), data=simple_logs)
+        response = self.client.post(reverse("zane_api:logs.ingest"), data=simple_logs)
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
         self.assertEqual(len(simple_logs), deployment.logs.count())
@@ -738,7 +738,7 @@ class HttpLogViewTests(AuthAPITestCase):
         ]
 
         response = self.client.post(
-            reverse("zane_api:logs.tail"), data=simple_proxy_logs
+            reverse("zane_api:logs.ingest"), data=simple_proxy_logs
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -783,7 +783,7 @@ class HttpLogViewTests(AuthAPITestCase):
         ]
 
         response = self.client.post(
-            reverse("zane_api:logs.tail"), data=simple_proxy_logs
+            reverse("zane_api:logs.ingest"), data=simple_proxy_logs
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
@@ -1085,7 +1085,7 @@ class HTTPLogCollectViewTests(AuthAPITestCase):
         ]
 
         response = self.client.post(
-            reverse("zane_api:logs.tail"), data=simple_proxy_logs
+            reverse("zane_api:logs.ingest"), data=simple_proxy_logs
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(0, SimpleLog.objects.count())
@@ -1191,7 +1191,7 @@ class HTTPLogCollectViewTests(AuthAPITestCase):
         ]
 
         response = await self.async_client.post(
-            reverse("zane_api:logs.tail"),
+            reverse("zane_api:logs.ingest"),
             data=first_deploy_proxy_logs + second_deploy_proxy_logs,
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)

--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -70,11 +70,6 @@ if settings.DEBUG:
             rf"/(?P<service_slug>{DJANGO_SLUG_REGEX})/_bulk/?$",
             views.BulkRequestDockerServiceDeploymentChangesAPIView.as_view(),
         ),
-        re_path(
-            "^_proxy/register-zane-to-proxy/?$",
-            views.RegisterZaneProxyAPIView.as_view(),
-            name="proxy.register_zane",
-        ),
     ]
 
 

--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -75,7 +75,7 @@ if settings.DEBUG:
 
 urlpatterns += [
     re_path(
-        "^_proxy/check-certiticates/?$",
+        r"^_proxy/check-certiticates/?$",
         views.CheckCertificatesAPIView.as_view(),
         name="proxy.check_certificates",
     ),

--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -80,9 +80,9 @@ urlpatterns += [
         name="proxy.check_certificates",
     ),
     re_path(
-        "^logs/tail/?$",
-        views.LogTailAPIView.as_view(),
-        name="logs.tail",
+        "^logs/ingest/?$",
+        views.LogIngestAPIView.as_view(),
+        name="logs.ingest",
     ),
     re_path(
         rf"^projects/(?P<project_slug>{DJANGO_SLUG_REGEX})/cancel-service-changes/docker"

--- a/backend/zane_api/views/base.py
+++ b/backend/zane_api/views/base.py
@@ -3,6 +3,9 @@ from typing import Any
 
 from drf_standardized_errors.handler import ExceptionHandler
 from rest_framework import exceptions, status
+from rest_framework.permissions import BasePermission
+from rest_framework.request import Request
+from django.conf import settings
 
 EMPTY_RESPONSE = {}
 EMPTY_PAGINATED_RESPONSE = OrderedDict(
@@ -70,3 +73,14 @@ def drf_spectular_mark_all_outputs_required(result: Any, **kwargs: Any):
             continue
         schema["required"] = sorted(schema["properties"].keys())
     return result
+
+
+class InternalZaneAppPermission(BasePermission):
+    """
+    Allow only internal zaneops apps like the proxy or fluentd.
+    This is set
+    """
+
+    def has_permission(self, request: Request, view: Any):
+        secret = request.headers.get("x-secret")
+        return secret == settings.SECRET_KEY

--- a/backend/zane_api/views/logs.py
+++ b/backend/zane_api/views/logs.py
@@ -11,6 +11,7 @@ from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
 
 from .base import InternalZaneAppPermission
+from ..utils import Colors
 
 from . import DeploymentLogsPagination, EMPTY_CURSOR_RESPONSE
 from .helpers import ZaneServices
@@ -157,6 +158,11 @@ class LogIngestAPIView(APIView):
                     "http_logs_inserted": len(http_logs),
                 }
             )
+            print("====== LOGS INGEST ======")
+            print(
+                f"Simple logs inserted = {Colors.BLUE}{len(simple_logs)}{Colors.ENDC}"
+            )
+            print(f"HTTP logs inserted = {Colors.BLUE}{len(http_logs)}{Colors.ENDC}")
             return Response(response.data, status=status.HTTP_200_OK)
 
 

--- a/backend/zane_api/views/logs.py
+++ b/backend/zane_api/views/logs.py
@@ -1,5 +1,4 @@
 import json
-import re
 from urllib.parse import urlparse
 
 from django_filters.rest_framework import DjangoFilterBackend
@@ -10,6 +9,8 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.throttling import ScopedRateThrottle
 from rest_framework.views import APIView
+
+from .base import InternalZaneAppPermission
 
 from . import DeploymentLogsPagination, EMPTY_CURSOR_RESPONSE
 from .helpers import ZaneServices
@@ -27,8 +28,8 @@ from ..serializers import SimpleLogSerializer
 
 
 @extend_schema(exclude=True)
-class LogTailAPIView(APIView):
-    permission_classes = [permissions.AllowAny]
+class LogIngestAPIView(APIView):
+    permission_classes = [InternalZaneAppPermission]
     throttle_scope = "log_collect"
     throttle_classes = [ScopedRateThrottle]
     serializer_class = DockerContainerLogsResponseSerializer

--- a/backend/zane_api/views/proxy.py
+++ b/backend/zane_api/views/proxy.py
@@ -1,4 +1,3 @@
-from backend.bootstrap import register_zaneops_app_on_proxy
 from django.conf import settings
 from drf_spectacular.utils import extend_schema
 from rest_framework import permissions, exceptions, status
@@ -9,20 +8,6 @@ from rest_framework.views import APIView
 from django.db.models import Q
 from . import serializers
 from ..models import URL, DockerDeployment, GitDeployment
-
-
-@extend_schema(exclude=True)
-class RegisterZaneProxyAPIView(APIView):
-    permission_classes = [permissions.AllowAny]
-
-    def post(self, request: Request):
-        register_zaneops_app_on_proxy(
-            proxy_url=settings.CADDY_PROXY_ADMIN_HOST,
-            zane_app_domain=settings.ZANE_APP_DOMAIN,
-            zane_api_internal_domain=settings.ZANE_API_SERVICE_INTERNAL_DOMAIN,
-            zane_front_internal_domain=settings.ZANE_FRONT_SERVICE_INTERNAL_DOMAIN,
-        )
-        return Response(data={"success": True}, status=status.HTTP_200_OK)
 
 
 class CertificateCheckSerializer(serializers.Serializer):

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -156,7 +156,8 @@ services:
         aliases:
           - zane.fluentd
     environment:
-      - API_HOST=host.docker.internal
+      API_HOST: host.docker.internal
+      DJANGO_SECRET_KEY: "django-insecure-^@$8fc&u2j)4@k+p+bg0ei8sm+@+pwq)hstk$a*0*7#k54kybx" # default value set in `settings.py`
     deploy:
       mode: global
 volumes:

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -157,7 +157,7 @@ services:
           - zane.fluentd
     environment:
       API_HOST: host.docker.internal
-      DJANGO_SECRET_KEY: "django-insecure-^@$8fc&u2j)4@k+p+bg0ei8sm+@+pwq)hstk$a*0*7#k54kybx" # default value set in `settings.py`
+      DJANGO_SECRET_KEY: "django-insecure-^@$8fc&u2j)4@k+p+bg0ei8sm+@+pwq)hstk$$a*0*7#k54kybx" # default value set in `settings.py`
     deploy:
       mode: global
 volumes:

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -324,7 +324,8 @@ services:
         aliases:
           - zane.fluentd
     environment:
-      - API_HOST=zane.api.zaneops.internal
+      API_HOST: zane.api.zaneops.internal
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
     deploy:
       replicas: 1
       restart_policy:

--- a/docker/fluentd/fluent.conf
+++ b/docker/fluentd/fluent.conf
@@ -27,7 +27,6 @@
 <match **>
   @type http
   endpoint "http://#{ENV['API_HOST']}:8000/api/logs/ingest"
-  headers {"X-Secret":"#{ENV['DJANGO_SECRET_KEY']}"}
   http_method post
   json_array true
   open_timeout 5
@@ -37,4 +36,9 @@
   <buffer>
     flush_interval 5s
   </buffer>
+  <auth>
+    method basic
+    username zaneops
+    password "#{ENV['DJANGO_SECRET_KEY']}"
+  </auth>
 </match>

--- a/docker/fluentd/fluent.conf
+++ b/docker/fluentd/fluent.conf
@@ -26,7 +26,8 @@
 
 <match **>
   @type http
-  endpoint "http://#{ENV['API_HOST']}:8000/api/logs/tail"
+  endpoint "http://#{ENV['API_HOST']}:8000/api/logs/ingest"
+  headers {"X-Secret":"#{ENV['DJANGO_SECRET_KEY']}"}
   http_method post
   json_array true
   open_timeout 5

--- a/docker/proxy/default-caddy-config-dev.json
+++ b/docker/proxy/default-caddy-config-dev.json
@@ -54,26 +54,6 @@
         }
       }
     },
-    "tls": {
-      "automation": {
-        "policies": [
-          {
-            "issuers": [
-              {
-                "module": "internal"
-              }
-            ],
-            "on_demand": true
-          }
-        ],
-        "on_demand": {
-          "permission": {
-            "@id": "tls-endpoint",
-            "endpoint": "http://host.docker.internal:8000/api/_proxy/check-certiticates",
-            "module": "http"
-          }
-        }
-      }
-    }
+    "tls": {}
   }
 }

--- a/docker/proxy/default-caddy-config-prod.json
+++ b/docker/proxy/default-caddy-config-prod.json
@@ -54,21 +54,6 @@
         }
       }
     },
-    "tls": {
-      "automation": {
-        "policies": [
-          {
-            "on_demand": true
-          }
-        ],
-        "on_demand": {
-          "permission": {
-            "@id": "tls-endpoint",
-            "endpoint": "http://zane.api.zaneops.internal:8000/api/_proxy/check-certiticates",
-            "module": "http"
-          }
-        }
-      }
-    }
+    "tls": {}
   }
 }

--- a/docker/start-docker-stack.sh
+++ b/docker/start-docker-stack.sh
@@ -27,7 +27,7 @@ echo "Scaling up all zane-ops services..."
 docker service ls --filter "label=zane-managed=true" --filter "label=status=active" -q |  xargs -P 0 -I {} docker service scale --detach {}=1
 
 # Wait until Ctrl+C is pressed
-echo "Server launched at http://localhost:5678/"
+echo -e "Server launched at \x1b[96mhttp://localhost:5678/\x1b[0m"
 echo "Press Ctrl+C to stop everything..."
 while true; do
   sleep 1


### PR DESCRIPTION
## Description

In this PR we added the ability for the API to automatically setup the TLS app on startup so that users would upgrade by just making another deploy. this way it mitigates the bug in #315 by not hardcoding that in the default json config.

closes #278 

We also added a way to secure internal endpoints : 
- The logs endpoint is secured with `Basic` authentication by providing the generated django secret key as the password, `fluentd` will use that automatically.
- I wanted to also secure the tls certificate check endpoint, but 1) it is not possible to pass the secret as headers or search params when configuring caddy 2) the endpoint is already rate-limited for anonymous users and only validates certificates for the ones that are actually needed

This PR require rerunning `make setup` for users in production to update the fluentd setup.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
