### PR TITLE
refactor: some UI changes

### DIFF
--- a/frontend/src/components/date-range-with-shortcuts.tsx
+++ b/frontend/src/components/date-range-with-shortcuts.tsx
@@ -1,17 +1,12 @@
 "use client";
 
-// import type { Table } from "@tanstack/react-table";
 import { format } from "date-fns";
 import { addDays, addHours, endOfDay, startOfDay } from "date-fns";
 import { Calendar as CalendarIcon } from "lucide-react";
-// import { useMemo } from "react";
 import * as React from "react";
 import type { DateRange } from "react-day-picker";
-// import type { DataTableTimerangeFilterField } from "~/lib/types";
-// import { isArrayOfDates } from "~/utils";
 
 import { useDebounce } from "use-debounce";
-import { kbdVariants } from "~/components/kbd";
 import { Button } from "~/components/ui/button";
 import { Calendar } from "~/components/ui/calendar";
 import { Input } from "~/components/ui/input";
@@ -36,7 +31,7 @@ export function DateRangeWithShortcuts({
   className,
   date,
   setDate,
-  presets = defaultPresets
+  presets
 }: DateRangeWithShortcutsProps) {
   return (
     <div className={cn("grid gap-2", className)}>
@@ -68,7 +63,11 @@ export function DateRangeWithShortcuts({
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">
           <div className="flex justify-between">
-            <DatePresets onSelect={setDate} selected={date} presets={presets} />
+            <DatePresets
+              onSelect={setDate}
+              selected={date}
+              presets={presets ?? getDefaultPresets()}
+            />
             <Separator orientation="vertical" className="h-auto w-[px]" />
             <Calendar
               initialFocus
@@ -87,38 +86,40 @@ export function DateRangeWithShortcuts({
   );
 }
 
-export const defaultPresets = [
-  {
-    label: "Today",
-    from: startOfDay(new Date()),
-    to: endOfDay(new Date())
-  },
-  {
-    label: "Yesterday",
-    from: startOfDay(addDays(new Date(), -1)),
-    to: endOfDay(addDays(new Date(), -1))
-  },
-  {
-    label: "Last hour",
-    from: addHours(new Date(), -1),
-    to: new Date()
-  },
-  {
-    label: "Last 7 days",
-    from: startOfDay(addDays(new Date(), -7)),
-    to: endOfDay(new Date())
-  },
-  {
-    label: "Last 14 days",
-    from: startOfDay(addDays(new Date(), -14)),
-    to: endOfDay(new Date())
-  },
-  {
-    label: "Last 30 days",
-    from: startOfDay(addDays(new Date(), -30)),
-    to: endOfDay(new Date())
-  }
-] satisfies DatePreset[];
+function getDefaultPresets() {
+  return [
+    {
+      label: "Today",
+      from: startOfDay(new Date()),
+      to: endOfDay(new Date())
+    },
+    {
+      label: "Yesterday",
+      from: startOfDay(addDays(new Date(), -1)),
+      to: endOfDay(addDays(new Date(), -1))
+    },
+    {
+      label: "Last hour",
+      from: addHours(new Date(), -1),
+      to: new Date()
+    },
+    {
+      label: "Last 7 days",
+      from: startOfDay(addDays(new Date(), -7)),
+      to: endOfDay(new Date())
+    },
+    {
+      label: "Last 14 days",
+      from: startOfDay(addDays(new Date(), -14)),
+      to: endOfDay(new Date())
+    },
+    {
+      label: "Last 30 days",
+      from: startOfDay(addDays(new Date(), -30)),
+      to: endOfDay(new Date())
+    }
+  ] satisfies DatePreset[];
+}
 
 function DatePresets({
   selected,

--- a/frontend/src/components/multi-select.tsx
+++ b/frontend/src/components/multi-select.tsx
@@ -54,7 +54,7 @@ interface MultiSelectProps
    * Placeholder text to be displayed when no values are selected.
    * Optional, defaults to "Select options".
    */
-  placeholder?: string;
+  label?: string;
 
   /**
    * Animation duration in seconds for the visual effects (e.g., bouncing badges).
@@ -94,7 +94,7 @@ export const MultiSelect = ({
   onValueChange,
   variant,
   value = [],
-  placeholder = "Select options",
+  label = "Select options",
   animation = 0,
   maxCount = 3,
   modalPopover = false,
@@ -129,17 +129,38 @@ export const MultiSelect = ({
           {...props}
           onClick={handleTogglePopover}
           className={cn(
-            "flex w-full p-1 pl-4 rounded-md border border-border min-h-10 h-auto items-center justify-between bg-inherit hover:bg-inherit",
+            "flex w-full py-1 px-2 rounded-md border border-border border-dashed min-h-10 h-auto items-center justify-between bg-inherit",
+            "hover:bg-accent",
             className
           )}
         >
-          <div className="flex items-center justify-between w-full mx-auto">
-            <div className="flex items-center">
-              <span className="text-sm text-muted-foreground">
-                {placeholder}
-              </span>
+          <div className="flex items-center gap-1 justify-between w-full mx-auto">
+            <ChevronDownIcon
+              size={15}
+              className="cursor-pointer text-muted-foreground"
+            />
+            <div className="flex items-center gap-1">
+              <span className="text-sm text-card-foreground">{label}</span>
+              {value.length > 0 && (
+                <>
+                  <div className="h-4 bg-border w-px"></div>
+                  {value.length > 2 ? (
+                    <span className="text-sm rounded-md bg-grey/20 px-1 text-card-foreground">
+                      {value.length} selected
+                    </span>
+                  ) : (
+                    value.map((val) => (
+                      <span
+                        key={val}
+                        className="text-sm rounded-md bg-grey/20 px-1 text-card-foreground"
+                      >
+                        {val}
+                      </span>
+                    ))
+                  )}
+                </>
+              )}
             </div>
-            <ChevronDownIcon className="h-4 cursor-pointer text-muted-foreground mx-2" />
           </div>
         </Button>
       </PopoverTrigger>

--- a/frontend/src/components/multi-select.tsx
+++ b/frontend/src/components/multi-select.tsx
@@ -10,6 +10,7 @@ import {
   PopoverTrigger
 } from "~/components/ui/popover";
 import { cn } from "~/lib/utils";
+import { capitalizeText } from "~/utils";
 
 /**
  * Variants for the multi-select component to handle different styles.
@@ -155,7 +156,7 @@ export const MultiSelect = ({
                         key={val}
                         className="text-sm rounded-md bg-grey/20 px-1 text-card-foreground"
                       >
-                        {val}
+                        {capitalizeText(val)}
                       </span>
                     ))
                   )}

--- a/frontend/src/components/multi-select.tsx
+++ b/frontend/src/components/multi-select.tsx
@@ -93,7 +93,7 @@ export const MultiSelect = ({
   options,
   onValueChange,
   variant,
-  value = [],
+  value: values = [],
   label = "Select options",
   animation = 0,
   maxCount = 3,
@@ -107,9 +107,9 @@ export const MultiSelect = ({
   const [isPopoverOpen, setIsPopoverOpen] = React.useState(false);
 
   const toggleOption = (option: string) => {
-    const newSelectedValues = value.includes(option)
-      ? value.filter((v) => v !== option)
-      : [...value, option];
+    const newSelectedValues = values.includes(option)
+      ? values.filter((v) => v !== option)
+      : [...values, option];
     onValueChange(newSelectedValues);
   };
 
@@ -131,6 +131,7 @@ export const MultiSelect = ({
           className={cn(
             "flex w-full py-1 px-2 rounded-md border border-border border-dashed min-h-10 h-auto items-center justify-between bg-inherit",
             "hover:bg-accent",
+            values.length === 0 && "pr-3.5",
             className
           )}
         >
@@ -141,15 +142,15 @@ export const MultiSelect = ({
             />
             <div className="flex items-center gap-1">
               <span className="text-sm text-card-foreground">{label}</span>
-              {value.length > 0 && (
+              {values.length > 0 && (
                 <>
                   <div className="h-4 bg-border w-px"></div>
-                  {value.length > 2 ? (
+                  {values.length > 2 ? (
                     <span className="text-sm rounded-md bg-grey/20 px-1 text-card-foreground">
-                      {value.length} selected
+                      {values.length} selected
                     </span>
                   ) : (
-                    value.map((val) => (
+                    values.map((val) => (
                       <span
                         key={val}
                         className="text-sm rounded-md bg-grey/20 px-1 text-card-foreground"
@@ -181,7 +182,7 @@ export const MultiSelect = ({
             <CommandEmpty>No results found.</CommandEmpty>
             <CommandPrimitive.Group>
               {options.map((option) => {
-                const isSelected = value.includes(option);
+                const isSelected = values.includes(option);
                 return (
                   <CommandItem
                     key={option}

--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -80,12 +80,8 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
   const isEmptySearchParams =
     !searchParams.time_after &&
     !searchParams.time_before &&
-    (LOG_SOURCES.every((source) => searchParams.source?.includes(source)) ||
-      searchParams.source?.length === 0 ||
-      !searchParams.source) &&
-    (LOG_LEVELS.every((source) => searchParams.level?.includes(source)) ||
-      searchParams.level?.length === 0 ||
-      !searchParams.level) &&
+    (searchParams.source?.length === 0 || !searchParams.source) &&
+    (searchParams.level?.length === 0 || !searchParams.level) &&
     (searchParams.content ?? "").length === 0;
 
   const queryClient = useQueryClient();
@@ -384,12 +380,8 @@ const HeaderSection = React.memo(function HeaderSection({
   const isEmptySearchParams =
     !searchParams.time_after &&
     !searchParams.time_before &&
-    (LOG_SOURCES.every((source) => searchParams.source?.includes(source)) ||
-      searchParams.source?.length === 0 ||
-      !searchParams.source) &&
-    (LOG_LEVELS.every((source) => searchParams.level?.includes(source)) ||
-      searchParams.level?.length === 0 ||
-      !searchParams.level) &&
+    (searchParams.source?.length === 0 || !searchParams.source) &&
+    (searchParams.level?.length === 0 || !searchParams.level) &&
     (searchParams.content ?? "").length === 0;
 
   const clearFilters = () => {

--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -380,8 +380,8 @@ const HeaderSection = React.memo(function HeaderSection({
   const isEmptySearchParams =
     !searchParams.time_after &&
     !searchParams.time_before &&
-    (searchParams.source?.length === 0 || !searchParams.source) &&
-    (searchParams.level?.length === 0 || !searchParams.level) &&
+    (searchParams.source ?? []).length === 0 &&
+    (searchParams.level ?? []).length === 0 &&
     (searchParams.content ?? "").length === 0;
 
   const clearFilters = () => {

--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -244,7 +244,7 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
       <div
         className={cn(
           "col-span-12 flex flex-col gap-2",
-          searchParams.isMaximized ? "container px-0 h-[82dvh]" : "h-[65dvh]"
+          searchParams.isMaximized ? "container px-0 h-[82dvh]" : "h-[60dvh]"
         )}
       >
         <HeaderSection startTransition={startTransition} />
@@ -294,7 +294,7 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
                 height: logs.length > 0 ? virtualizer.getTotalSize() : "auto"
               }}
               className={cn(
-                "relative justify-start mb-auto",
+                "relative justify-start",
                 "[&_::highlight(search-results-highlight)]:bg-yellow-400/50"
               )}
             >
@@ -318,7 +318,7 @@ export function DeploymentLogsDetailPage(): React.JSX.Element {
                       )}
                       {virtualRow.index === 0 && (
                         <div
-                          className="w-full py-2 text-center -scale-y-100 text-grey italic"
+                          className="w-full pt-2 text-center -scale-y-100 text-grey italic"
                           ref={autoRefetchRef}
                         >
                           -- LIVE <Ping /> new log entries will appear here --
@@ -376,18 +376,9 @@ const HeaderSection = React.memo(function HeaderSection({
   const navigate = useNavigate();
   const inputRef = React.useRef<React.ComponentRef<"input">>(null);
 
-  const filters = {
-    time_after: searchParams.time_after,
-    time_before: searchParams.time_before,
-    source:
-      searchParams.source ?? (LOG_SOURCES as Writeable<typeof LOG_SOURCES>),
-    level: searchParams.level ?? (LOG_LEVELS as Writeable<typeof LOG_LEVELS>),
-    content: searchParams.content
-  } satisfies DeploymentLogFitlers;
-
   const date: DateRange = {
-    from: filters.time_after,
-    to: filters.time_before
+    from: searchParams.time_after,
+    to: searchParams.time_before
   };
 
   const isEmptySearchParams =
@@ -421,7 +412,7 @@ const HeaderSection = React.memo(function HeaderSection({
     startTransition(() =>
       navigate({
         search: {
-          ...filters,
+          ...searchParams,
           isMaximized: searchParams.isMaximized,
           content
         },
@@ -432,14 +423,14 @@ const HeaderSection = React.memo(function HeaderSection({
 
   return (
     <>
-      <section className="rounded-t-sm w-full flex gap-2 flex-col md:flex-row flex-wrap lg:flex-nowrap">
-        <div className="flex items-center gap-2 order-first">
+      <section className="rounded-t-sm w-full flex gap-2 flex-col items-start">
+        <div className="flex items-center gap-2 flex-wrap">
           <DateRangeWithShortcuts
             date={date}
             setDate={(newDateRange) =>
               navigate({
                 search: {
-                  ...filters,
+                  ...searchParams,
                   isMaximized: searchParams.isMaximized,
                   time_before: newDateRange?.to,
                   time_after: newDateRange?.from
@@ -447,59 +438,70 @@ const HeaderSection = React.memo(function HeaderSection({
                 replace: true
               })
             }
-            className="min-w-[250px] w-full"
+            className="w-[250px] grow"
           />
-        </div>
 
-        <div className="flex w-full items-center relative grow order-2">
-          <SearchIcon size={15} className="absolute left-4 text-grey" />
-
-          <Input
-            className="px-14 w-full text-sm  bg-muted/40 dark:bg-card/30"
-            placeholder="Search for log contents"
-            name="content"
-            defaultValue={searchParams.content}
-            ref={inputRef}
-            onChange={(ev) => {
-              const newQuery = ev.currentTarget.value;
-              if (newQuery !== (filters.content ?? "")) {
-                searchLogsForContent(newQuery);
-              }
-            }}
-          />
-        </div>
-
-        <div className="shrink-0 flex items-center gap-1.5 order-1 lg:order-last">
           <MultiSelect
-            value={filters.level}
+            value={searchParams.level as string[]}
+            className="w-auto"
             options={LOG_LEVELS as Writeable<typeof LOG_LEVELS>}
             onValueChange={(newVal) => {
               navigate({
                 search: {
-                  ...filters,
+                  ...searchParams,
                   isMaximized: searchParams.isMaximized,
                   level: newVal
                 },
                 replace: true
               });
             }}
-            placeholder="log levels"
+            label="levels"
           />
 
           <MultiSelect
-            value={filters.source}
+            value={searchParams.source as string[]}
+            className="w-auto"
             options={LOG_SOURCES as Writeable<typeof LOG_SOURCES>}
             onValueChange={(newVal) => {
               navigate({
                 search: {
-                  ...filters,
+                  ...searchParams,
                   isMaximized: searchParams.isMaximized,
                   source: newVal
                 },
                 replace: true
               });
             }}
-            placeholder="log sources"
+            label="sources"
+          />
+
+          {!isEmptySearchParams && (
+            <Button
+              variant="outline"
+              className="inline-flex w-min gap-1"
+              onClick={clearFilters}
+            >
+              <XIcon size={15} />
+              <span>Reset filters</span>
+            </Button>
+          )}
+        </div>
+
+        <div className="flex gap-2 w-full items-center relative">
+          <SearchIcon size={15} className="absolute left-4 text-grey" />
+
+          <Input
+            className="px-14 w-full md:min-w-150 text-sm  bg-muted/40 dark:bg-card/30"
+            placeholder="Search for log contents"
+            name="content"
+            defaultValue={searchParams.content}
+            ref={inputRef}
+            onChange={(ev) => {
+              const newQuery = ev.currentTarget.value;
+              if (newQuery !== (searchParams.content ?? "")) {
+                searchLogsForContent(newQuery);
+              }
+            }}
           />
 
           <TooltipProvider>
@@ -510,7 +512,7 @@ const HeaderSection = React.memo(function HeaderSection({
                   onClick={() => {
                     navigate({
                       search: {
-                        ...filters,
+                        ...searchParams,
                         isMaximized: !searchParams.isMaximized
                       },
                       replace: true
@@ -535,16 +537,6 @@ const HeaderSection = React.memo(function HeaderSection({
         </div>
       </section>
       <hr className="border-border" />
-      {!isEmptySearchParams && (
-        <Button
-          variant="outline"
-          className="inline-flex w-min gap-1"
-          onClick={clearFilters}
-        >
-          <XIcon size={15} />
-          <span>Reset filters</span>
-        </Button>
-      )}
     </>
   );
 });


### PR DESCRIPTION
## Description

In this PR, we changed the design of the `multi-select` component to be more like shadcn one : 

_theirs_ :
<img width="453" alt="Capture d’écran 2024-11-27 à 03 13 23" src="https://github.com/user-attachments/assets/93fc00fa-8bb6-471f-9497-5e860268d533">

_ours_ : 
<img width="552" alt="Capture d’écran 2024-11-27 à 03 14 22" src="https://github.com/user-attachments/assets/a4b93c5e-4b51-45f3-b3be-f37bc86e280c">

We also change the `date-range-with-shortcut` component time to be relative to each time it is rerendered.

closes #305 
closes #306


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
