### PR TITLE
refactor: remove mix-blend-mode on highlighted logs

### DIFF
--- a/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
+++ b/frontend/src/routes/_dashboard/project_/$project_slug_.services.docker.$service_slug.deployments.$deployment_hash/index.tsx
@@ -580,7 +580,7 @@ const Log = ({ content, level, time, id, content_text }: LogProps) => {
             <AnsiHtml
               aria-hidden="true"
               className={cn(
-                "text-start z-10 mix-blend-color dark:mix-blend-color-dodge  relative",
+                "text-start z-10 relative",
                 "col-start-1 col-end-1 row-start-1 row-end-1",
                 "break-all text-wrap whitespace-pre [text-wrap-mode:wrap]"
               )}
@@ -588,7 +588,7 @@ const Log = ({ content, level, time, id, content_text }: LogProps) => {
             />
             <pre
               className={cn(
-                "text-start -z-1 mix-blend-color dark:mix-blend-color-dodge text-transparent relative",
+                "text-start -z-1 text-transparent relative",
                 "col-start-1 col-end-1 row-start-1 row-end-1",
                 "break-all text-wrap whitespace-pre [text-wrap-mode:wrap]"
               )}
@@ -624,7 +624,7 @@ function LongLogContent({
     <>
       <pre
         className={cn(
-          "text-start z-10 mix-blend-color dark:mix-blend-color-dodge  relative",
+          "text-start z-10  relative",
           "col-start-1 col-end-1 row-start-1 row-end-1",
           "break-all text-wrap whitespace-pre [text-wrap-mode:wrap]"
         )}


### PR DESCRIPTION
## Description

**Before** : 

![Capture d’écran 2024-11-30 à 02 16 44](https://github.com/user-attachments/assets/f22b0359-0f0a-4d48-b167-df6dc3c39001)

**After** : 

![Capture d’écran 2024-11-30 à 02 17 21](https://github.com/user-attachments/assets/f4aacccf-0e49-4705-becd-72a531509049)


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
