### PR TITLE
feat: upload `404` & `502` error templates on startup

### DIFF
--- a/backend/backend/bootstrap.py
+++ b/backend/backend/bootstrap.py
@@ -5,6 +5,287 @@ class UnknownZaneProxyError(Exception):
     pass
 
 
+DEFAULT_404_FALLBACK = """
+<!DOCTYPE html>
+
+<html>
+
+<head>
+  <meta charset='utf-8'>
+  <meta content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no' name='viewport'>
+  <title>Deployment Not Found</title>
+  <style>
+    :root {
+      --colorDefaultTextColor: #A3A9AC;
+      --colorDefaultTextColorCard: #2D3B41;
+      --colorBgApp: rgb(14, 30, 37);
+      --colorBgInverse: hsl(175, 48%, 98%);
+      --colorTextMuted: rgb(100, 110, 115);
+      --colorError: #D32254;
+      --colorBgCard: #fff;
+      --colorShadow: #0e1e251f;
+      --colorErrorText: rgb(142, 11, 48);
+      --colorCardTitleCard: #2D3B41;
+      --colorStackText: #222;
+      --colorCodeText: #F5F5F5
+    }
+
+    :root {
+      --background: 164 62% 99%;
+      --foreground: 164 67% 0%;
+      --muted: 164 7% 89%;
+      --muted-foreground: 164 0% 26%;
+      --popover: 164 62% 99%;
+      --popover-foreground: 164 67% 0%;
+      --card: 219, 40%, 18%;
+      --toggle: 180, 23%, 95%;
+      --card-foreground: 164 67% 0%;
+      --border: 164 9% 90%;
+      --input: 164 9% 90%;
+      --primary: 164 61% 70%;
+      --primary-foreground: 164 61% 10%;
+      --secondary: 201 94% 80%;
+      --secondary-foreground: 201 94% 20%;
+      --accent: 164 10% 85%;
+      --accent-foreground: 164 10% 25%;
+      --destructive: 11 98% 31%;
+      --destructive-foreground: 11 98% 91%;
+      --ring: 164 61% 70%;
+      --radius: 0.5rem;
+      --loader: #003c57;
+      --status-success: #bbf7d0;
+      --status-error: #fecaca;
+      --status-warning: #fef08a
+    }
+
+    @media (prefers-color-scheme:dark) {
+      :root {
+        --background: 226 19% 13%;
+        --foreground: 231 28% 73%;
+        --muted: 226 12% 17%;
+        --muted-foreground: 226 12% 67%;
+        --popover: 226 19% 10%;
+        --popover-foreground: 231 28% 83%;
+        --card: 164 43% 2%;
+        --card-foreground: 164 30% 100%;
+        --border: 226 9% 18%;
+        --input: 226 9% 21%;
+        --primary: 164 61% 70%;
+        --primary-foreground: 164 61% 10%;
+        --secondary: 201 94% 80%;
+        --secondary-foreground: 201 94% 20%;
+        --accent: 164 18% 21%;
+        --accent-foreground: 164 18% 81%;
+        --destructive: 11 98% 56%;
+        --destructive-foreground: 0 0% 100%;
+        --toggle: 164 43% 2%;
+        --ring: 164 61% 70%;
+        --loader: white
+      }
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, segoe ui, Roboto, Helvetica, Arial, sans-serif, apple color emoji, segoe ui emoji, segoe ui symbol;
+      background: hsl(var(--background));
+      overflow: hidden;
+      margin: 0;
+      padding: 0;
+      font-size: 1rem;
+      line-height: 1.5
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.375rem;
+      line-height: 1.2
+    }
+
+    .main {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      width: 100vw
+    }
+
+    .card {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      width: 75%;
+      max-width: 500px;
+      padding: 24px;
+      background: hsl(var(--card));
+      color: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(14, 30, 37, .16)
+    }
+
+    p:last-of-type {
+      margin-bottom: 0
+    }
+  </style>
+</head>
+
+<body>
+  <div class='main'>
+    <div class='card'>
+      <div class='header'>
+        <h1>Deployment Not Found 🤷</h1>
+      </div>
+      <div class='body'>
+        <p>Looks like you've followed a broken link or entered a URL that doesn't exist yet on ZaneOps.
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>
+"""
+
+DEFAULT_502_FALLBACK = """
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset='utf-8'>
+  <meta content='width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no' name='viewport'>
+  <title>Deployment Not Found</title>
+  <style>
+    :root {
+      --colorDefaultTextColor: #A3A9AC;
+      --colorDefaultTextColorCard: #2D3B41;
+      --colorBgApp: rgb(14, 30, 37);
+      --colorBgInverse: hsl(175, 48%, 98%);
+      --colorTextMuted: rgb(100, 110, 115);
+      --colorError: #D32254;
+      --colorBgCard: #fff;
+      --colorShadow: #0e1e251f;
+      --colorErrorText: rgb(142, 11, 48);
+      --colorCardTitleCard: #2D3B41;
+      --colorStackText: #222;
+      --colorCodeText: #F5F5F5
+    }
+
+    :root {
+      --background: 164 62% 99%;
+      --foreground: 164 67% 0%;
+      --muted: 164 7% 89%;
+      --muted-foreground: 164 0% 26%;
+      --popover: 164 62% 99%;
+      --popover-foreground: 164 67% 0%;
+      --card: 219, 40%, 18%;
+      --toggle: 180, 23%, 95%;
+      --card-foreground: 164 67% 0%;
+      --border: 164 9% 90%;
+      --input: 164 9% 90%;
+      --primary: 164 61% 70%;
+      --primary-foreground: 164 61% 10%;
+      --secondary: 201 94% 80%;
+      --secondary-foreground: 201 94% 20%;
+      --accent: 164 10% 85%;
+      --accent-foreground: 164 10% 25%;
+      --destructive: 11 98% 31%;
+      --destructive-foreground: 11 98% 91%;
+      --ring: 164 61% 70%;
+      --radius: 0.5rem;
+      --loader: #003c57;
+      --status-success: #bbf7d0;
+      --status-error: #fecaca;
+      --status-warning: #fef08a
+    }
+
+    @media (prefers-color-scheme:dark) {
+      :root {
+        --background: 226 19% 13%;
+        --foreground: 231 28% 73%;
+        --muted: 226 12% 17%;
+        --muted-foreground: 226 12% 67%;
+        --popover: 226 19% 10%;
+        --popover-foreground: 231 28% 83%;
+        --card: 164 43% 2%;
+        --card-foreground: 164 30% 100%;
+        --border: 226 9% 18%;
+        --input: 226 9% 21%;
+        --primary: 164 61% 70%;
+        --primary-foreground: 164 61% 10%;
+        --secondary: 201 94% 80%;
+        --secondary-foreground: 201 94% 20%;
+        --accent: 164 18% 21%;
+        --accent-foreground: 164 18% 81%;
+        --destructive: 11 98% 56%;
+        --destructive-foreground: 0 0% 100%;
+        --toggle: 164 43% 2%;
+        --ring: 164 61% 70%;
+        --loader: white
+      }
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, segoe ui, Roboto, Helvetica, Arial, sans-serif, apple color emoji, segoe ui emoji, segoe ui symbol;
+      background: hsl(var(--background));
+      overflow: hidden;
+      margin: 0;
+      padding: 0;
+      font-size: 1rem;
+      line-height: 1.5
+    }
+
+    h1 {
+      margin: 0;
+      font-size: 1.375rem;
+      line-height: 1.2
+    }
+
+    .main {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      width: 100vw
+    }
+
+    .card {
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      width: 75%;
+      max-width: 500px;
+      padding: 24px;
+      background: hsl(var(--card));
+      color: #fff;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(14, 30, 37, .16)
+    }
+
+    p:last-of-type {
+      margin-bottom: 0
+    }
+  </style>
+
+</head>
+
+<body>
+  <div class='main'>
+    <div class='card'>
+      <div class='header'>
+        <h1>Deployment Unavailable ❌</h1>
+      </div>
+      <div class='body'>
+        <p>Looks like you've followed a link to a deployment that has been removed or is not yet available.
+      </div>
+    </div>
+  </div>
+</body>
+
+</html>
+"""
+
+
 def register_zaneops_app_on_proxy(
     proxy_url: str,
     zane_app_domain: str,
@@ -112,6 +393,85 @@ def register_zaneops_app_on_proxy(
     else:
         print(
             f"[{Colors.RED}root.apps.tls{Colors.ENDC}] ❌ Got an error when trying to update the proxy ❌"
+        )
+        print(f"With status code : {Colors.RED}{response.status_code}{Colors.ENDC}")
+        print(f"With response data : {Colors.ORANGE}{response.text}{Colors.ENDC}\n")
+
+    default_404_config = {
+        "@id": "zane-catchall-404",
+        "handle": [
+            {
+                "handler": "headers",
+                "response": {
+                    "set": {"Content-Type": ["text/html"]},
+                    "add": {
+                        "server": ["zaneops"],
+                        "x-zane-request-id": ["{http.request.uuid}"],
+                    },
+                },
+            },
+            {
+                "body": DEFAULT_404_FALLBACK,
+                "handler": "static_response",
+                "status_code": 404,
+            },
+        ],
+    }
+    response = requests.patch(
+        f"{proxy_url}/id/zane-catchall-404", timeout=5, json=default_404_config
+    )
+    if 200 <= response.status_code < 300:
+        print(
+            f"[{Colors.BLUE}zane-catchall-404{Colors.ENDC}] Updated proxy configuration succesfully ✅"
+        )
+    else:
+        print(
+            f"[{Colors.RED}zane-catchall-404{Colors.ENDC}] ❌ Got an error when trying to update the proxy ❌"
+        )
+        print(f"With status code : {Colors.RED}{response.status_code}{Colors.ENDC}")
+        print(f"With response data : {Colors.ORANGE}{response.text}{Colors.ENDC}\n")
+
+    default_502_config = {
+        "@id": "zane-error-502",
+        "match": [{"expression": "{http.error.status_code} in [502]"}],
+        "handle": [
+            {
+                "handler": "headers",
+                "response": {
+                    "set": {"Content-Type": ["text/html"]},
+                    "add": {
+                        "server": ["zaneops"],
+                        "x-zane-request-id": ["{http.request.uuid}"],
+                    },
+                },
+            },
+            {
+                "body": DEFAULT_502_FALLBACK,
+                "handler": "static_response",
+            },
+        ],
+    }
+    response = requests.get(f"{proxy_url}/id/zane-server/errors", timeout=5)
+    if response.status_code == 404 or response.json() is None:
+        response = requests.put(
+            f"{proxy_url}/id/zane-server/errors",
+            json={"routes": [default_502_config]},
+            timeout=5,
+        )
+    else:
+        response = requests.patch(
+            f"{proxy_url}/id/zane-server/errors/routes/0",
+            json=default_502_config,
+            timeout=5,
+        )
+
+    if 200 <= response.status_code < 300:
+        print(
+            f"[{Colors.BLUE}zane-catchall-502{Colors.ENDC}] Updated proxy configuration succesfully ✅"
+        )
+    else:
+        print(
+            f"[{Colors.RED}zane-catchall-502{Colors.ENDC}] ❌ Got an error when trying to update the proxy ❌"
         )
         print(f"With status code : {Colors.RED}{response.status_code}{Colors.ENDC}")
         print(f"With response data : {Colors.ORANGE}{response.text}{Colors.ENDC}\n")

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -58,7 +58,7 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
                 "log": "1:C 30 Jun 2024 03:17:14.369 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo",
                 "container_id": "78dfe81bb4b3994eeb38f65f5a586084a2b4a649c0ab08b614d0f4c2cb499761",
                 "container_name": "/srv-prj_ssbvBaqpbD7-srv_dkr_LeeCqAUZJnJ-dpl_dkr_KRbXo2FJput.1.zm0uncmx8w4wvnokdl6qxt55e",
-                "time": "2024-06-30T03:17:14Z",
+                "time": "2024-06-30T03:16:14Z",
                 "tag": json.dumps(
                     {
                         "deployment_id": deployment.hash,
@@ -162,7 +162,7 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
         self.assertEqual(SimpleLog.LogLevel.INFO, log.level)
         self.assertIsNotNone(log.time)
         self.assertEqual(
-            "1:C 30 Jun 2024 03:17:14.369 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo",
+            simple_logs[0]["log"],
             log.content,
         )
         self.assertIsNotNone(log.service_id)

--- a/backend/zane_api/tests/logs.py
+++ b/backend/zane_api/tests/logs.py
@@ -58,7 +58,7 @@ class SimpleLogCollectViewTests(AuthAPITestCase):
                 "log": "1:C 30 Jun 2024 03:17:14.369 * oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo",
                 "container_id": "78dfe81bb4b3994eeb38f65f5a586084a2b4a649c0ab08b614d0f4c2cb499761",
                 "container_name": "/srv-prj_ssbvBaqpbD7-srv_dkr_LeeCqAUZJnJ-dpl_dkr_KRbXo2FJput.1.zm0uncmx8w4wvnokdl6qxt55e",
-                "time": "2024-06-30T03:16:14Z",
+                "time": "2024-07-01T03:17:14Z",
                 "tag": json.dumps(
                     {
                         "deployment_id": deployment.hash,


### PR DESCRIPTION
## Description

In this PR, we added the template configuration for `502` status which represents the status for when the service has been removed or has not yet started. We also updated the `404` template to be set on startup.

closes #277 

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
