### PR TITLE
refactor: allow blue/green deployments for services with only `read-only` volumes

### DIFF
--- a/backend/zane_api/dtos.py
+++ b/backend/zane_api/dtos.py
@@ -153,6 +153,10 @@ class DockerServiceSnapshot:
         )
 
     @property
+    def non_read_only_volumes(self) -> List[VolumeDto]:
+        return list(filter(lambda v: v.mode != "READ_ONLY", self.volumes))
+
+    @property
     def host_volumes(self) -> List[VolumeDto]:
         return list(filter(lambda v: v.host_path is not None, self.volumes))
 

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -236,7 +236,10 @@ class DeployDockerServiceWorkflow:
                 )
 
             if (
-                (len(service.volumes) > 0 or len(service.non_http_ports) > 0)
+                (
+                    len(service.non_read_only_volumes) > 0
+                    or len(service.non_http_ports) > 0
+                )
                 and previous_production_deployment is not None
                 and previous_production_deployment.status
                 != DockerDeployment.DeploymentStatus.FAILED


### PR DESCRIPTION
## Description

Services with only read only volumes don't need to be scaled down as it won't cause a corruption, so we don't need to cause downtime for them. 

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
