### PR TITLE
fix: `X-Forwarded-For` header can have multiple IPs

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -243,6 +243,11 @@ LOGGING = {
         }
     },
     "loggers": {
+        # Activate only when we really need debugging as it pollutes way too much the logs
+        # "django.db.backends": {
+        #     "handlers": ["console"],
+        #     "level": "DEBUG",
+        # },
         "gunicorn.error": {
             "handlers": ["console"],
             "level": "INFO",

--- a/backend/zane_api/migrations/0172_auto_20250118_0233.py
+++ b/backend/zane_api/migrations/0172_auto_20250118_0233.py
@@ -10,12 +10,16 @@ def populate_client_ip(apps, schema_editor):
     HttpLog.objects.filter(request_headers__icontains="X-Forwarded-For").update(
         request_ip=Func(
             Func(
-                F("request_headers"),
-                Value("X-Forwarded-For"),
-                Value("0"),
-                function="jsonb_extract_path_text",
+                Func(
+                    F("request_headers"),
+                    Value("X-Forwarded-For"),
+                    Value("0"),
+                    function="jsonb_extract_path_text",
+                ),
+                function="split_part",  # PostgreSQL function to split strings
+                template="%(function)s(%(expressions)s, ',', 1)",  # Take the first part before the comma
             ),
-            function="inet",  # Cast the result to inet
+            function="inet",
         )
     )
 

--- a/backend/zane_api/views/logs.py
+++ b/backend/zane_api/views/logs.py
@@ -120,7 +120,7 @@ class LogIngestAPIView(APIView):
                                                         else None
                                                     ),
                                                     request_ip=(
-                                                        client_ip[0]
+                                                        client_ip[0].split(",")[0]
                                                         if isinstance(client_ip, list)
                                                         else client_ip
                                                     ),


### PR DESCRIPTION
## Description

There was a bug with the database migration code, in the migration code we get the IP of the request from the `X-Forwarded-For` header, by reading the JSON value of the `request_headers` field. However, the syntax of that header can have multiple values separated by commas (`,`) ([see syntax](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#syntax)), the first value in the commas is the actual value of the client IP, so we modified the function to take it into account.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
