### PR TITLE
fix: some UI fixes regarding http logs

### DIFF
--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -946,7 +946,7 @@ class DockerServiceDeploymentHttpLogsFieldsAPIView(APIView):
 
                 condition = {}
                 if len(value) > 0:
-                    condition = {f"{field}__istartswith": value}
+                    condition = {f"{field}__icontains": value}
 
                 values = (
                     HttpLog.objects.filter(

--- a/frontend/app/components/http-log-request-details.tsx
+++ b/frontend/app/components/http-log-request-details.tsx
@@ -167,40 +167,42 @@ function LogRequestDetailsContent({ log }: { log: HttpLog }) {
             <span>User Agent</span>
             <TooltipProvider>
               {log.request_user_agent && (
-                <Tooltip delayDuration={0}>
-                  <TooltipTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      className="px-2.5 py-0.5 md:opacity-0 focus-visible:opacity-100 group-hover:opacity-100"
-                      onClick={() => {
-                        searchParams.set(
-                          "request_user_agent",
-                          log.request_user_agent!
-                        );
-                        searchParams.delete("request_id");
-                        setSearchParams(searchParams, { replace: true });
-                      }}
-                    >
-                      <FilterIcon size={15} />
-                      <span className="sr-only">Add Filter</span>
-                    </Button>
-                  </TooltipTrigger>
-                  <TooltipContent>Add Filter</TooltipContent>
-                </Tooltip>
-              )}
+                <>
+                  <Tooltip delayDuration={0}>
+                    <TooltipTrigger asChild>
+                      <Button
+                        variant="ghost"
+                        className="px-2.5 py-0.5 md:opacity-0 focus-visible:opacity-100 group-hover:opacity-100"
+                        onClick={() => {
+                          searchParams.set(
+                            "request_user_agent",
+                            log.request_user_agent!
+                          );
+                          searchParams.delete("request_id");
+                          setSearchParams(searchParams, { replace: true });
+                        }}
+                      >
+                        <FilterIcon size={15} />
+                        <span className="sr-only">Add Filter</span>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>Add Filter</TooltipContent>
+                  </Tooltip>
 
-              <Tooltip delayDuration={0}>
-                <TooltipTrigger asChild>
-                  <CopyButton
-                    label="Copy value"
-                    value={log.request_user_agent ?? ""}
-                  />
-                </TooltipTrigger>
-                <TooltipContent>Copy value</TooltipContent>
-              </Tooltip>
+                  <Tooltip delayDuration={0}>
+                    <TooltipTrigger asChild>
+                      <CopyButton
+                        label="Copy value"
+                        value={log.request_user_agent}
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent>Copy value</TooltipContent>
+                  </Tooltip>
+                </>
+              )}
             </TooltipProvider>
           </dt>
-          <dd className="text-sm text-grey inline-flex h-full items-center">
+          <dd className="text-sm text-grey inline-flex h-full items-center break-all">
             {log.request_user_agent ?? <span className="font-mono">N/A</span>}
           </dd>
         </div>

--- a/frontend/app/components/multi-select.tsx
+++ b/frontend/app/components/multi-select.tsx
@@ -218,7 +218,9 @@ export const MultiSelect = ({
             <CommandEmpty>No results found.</CommandEmpty>
             <CommandPrimitive.Group>
               {[...visibleOptions]
-                .filter((option) => option.startsWith(inputValue))
+                .filter((option) =>
+                  option.toLowerCase().includes(inputValue.toLowerCase())
+                )
                 .map((option) => {
                   const isSelected = values.includes(option);
                   return (

--- a/frontend/app/components/ui/table.tsx
+++ b/frontend/app/components/ui/table.tsx
@@ -74,6 +74,8 @@ const TableRow = ({
     ref={ref}
     className={cn(
       "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+      "data-[state=selected]:border-l data-[state=selected]:border-l-primary",
+      "data-[state=selected]:border-l-3",
       className
     )}
     {...props}

--- a/frontend/app/routes/deployments/deployment-http-logs.tsx
+++ b/frontend/app/routes/deployments/deployment-http-logs.tsx
@@ -416,6 +416,9 @@ export default function DeploymentHttpLogsPage({
                 return (
                   <TableRow
                     className="border-border cursor-pointer"
+                    data-state={
+                      log.request_id === search.request_id ? "selected" : null
+                    }
                     key={log.id}
                     onClick={() => {
                       if (log.request_id) {

--- a/frontend/app/routes/services/service-http-logs.tsx
+++ b/frontend/app/routes/services/service-http-logs.tsx
@@ -404,6 +404,9 @@ export default function ServiceHttpLogsPage({
                   <TableRow
                     className="border-border cursor-pointer"
                     key={log.id}
+                    data-state={
+                      log.request_id === search.request_id ? "selected" : null
+                    }
                     onClick={() => {
                       if (log.request_id) {
                         searchParams.set("request_id", log.request_id);


### PR DESCRIPTION
## Description

In this PR, we make some changes : 
- Modified the condition for filtering field values for the HTTP logs to use `icontains` 
- fixed text break in the UI for the details of HTTP logs
- added a style in the http log rows for when they are selected

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
