### PR TITLE
fix: Use `startswith` and limit results to `7`

### DIFF
--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -946,7 +946,7 @@ class DockerServiceDeploymentHttpLogsFieldsAPIView(APIView):
 
                 condition = {}
                 if len(value) > 0:
-                    condition = {f"{field}__icontains": value}
+                    condition = {f"{field}__startswith": value}
 
                 values = (
                     HttpLog.objects.filter(
@@ -956,7 +956,7 @@ class DockerServiceDeploymentHttpLogsFieldsAPIView(APIView):
                     )
                     .order_by(field)
                     .values_list(field, flat=True)
-                    .distinct()[:5]
+                    .distinct()[:7]
                 )
 
                 seriaziler = HttpLogFieldsResponseSerializer([item for item in values])
@@ -998,7 +998,7 @@ class DockerServiceHttpLogsFieldsAPIView(APIView):
 
                 condition = {}
                 if len(value) > 0:
-                    condition = {f"{field}__istartswith": value}
+                    condition = {f"{field}__startswith": value}
 
                 values = (
                     HttpLog.objects.filter(
@@ -1007,7 +1007,7 @@ class DockerServiceHttpLogsFieldsAPIView(APIView):
                     )
                     .order_by(field)
                     .values_list(field, flat=True)
-                    .distinct()[:5]
+                    .distinct()[:7]
                 )
 
                 seriaziler = HttpLogFieldsResponseSerializer([item for item in values])


### PR DESCRIPTION
## Description

Exactly as the title.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
