### PR TITLE
fix: allow all zaneops internal domains in the backend

### DIFF
--- a/backend/backend/bootstrap.py
+++ b/backend/backend/bootstrap.py
@@ -289,7 +289,7 @@ DEFAULT_502_FALLBACK = """
 def register_zaneops_app_on_proxy(
     proxy_url: str,
     zane_app_domain: str,
-    zane_front_internal_domain: str,
+    zane_app_internal_domain: str,
     internal_tls: bool = False,
 ):
     url_configurations = [
@@ -304,7 +304,7 @@ def register_zaneops_app_on_proxy(
                             "handle": [
                                 {
                                     "handler": "reverse_proxy",
-                                    "upstreams": [{"dial": zane_front_internal_domain}],
+                                    "upstreams": [{"dial": zane_app_internal_domain}],
                                 }
                             ]
                         }
@@ -324,7 +324,7 @@ def register_zaneops_app_on_proxy(
                             "handle": [
                                 {
                                     "handler": "reverse_proxy",
-                                    "upstreams": [{"dial": zane_front_internal_domain}],
+                                    "upstreams": [{"dial": zane_app_internal_domain}],
                                 }
                             ]
                         }
@@ -371,7 +371,7 @@ def register_zaneops_app_on_proxy(
             "on_demand": {
                 "permission": {
                     "@id": "tls-endpoint",
-                    "endpoint": f"http://{zane_front_internal_domain}/api/_proxy/check-certiticates",
+                    "endpoint": f"http://{zane_app_internal_domain}/api/_proxy/check-certiticates",
                     "module": "http",
                 }
             },

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -357,7 +357,7 @@ CADDY_PROXY_ADMIN_HOST = os.environ.get(
     "http://127.0.0.1:2020" if TESTING else "http://127.0.0.1:2019",
 )
 
-ZANE_FRONT_SERVICE_INTERNAL_DOMAIN = (
+ZANE_APP_SERVICE_INTERNAL_DOMAIN = (
     "host.docker.internal:8000"
     if ENVIRONMENT != PRODUCTION_ENV
     else f"zane.front.zaneops.internal:80"
@@ -384,7 +384,7 @@ if BACKEND_COMPONENT == "API":
     register_zaneops_app_on_proxy(
         proxy_url=CADDY_PROXY_ADMIN_HOST,
         zane_app_domain=ZANE_APP_DOMAIN,
-        zane_front_internal_domain=ZANE_FRONT_SERVICE_INTERNAL_DOMAIN,
+        zane_app_internal_domain=ZANE_APP_SERVICE_INTERNAL_DOMAIN,
         internal_tls=DEBUG,
     )
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -357,7 +357,7 @@ CADDY_PROXY_ADMIN_HOST = os.environ.get(
     "http://127.0.0.1:2020" if TESTING else "http://127.0.0.1:2019",
 )
 
-ZANE_APP_SERVICE_INTERNAL_DOMAIN = (
+ZANE_FRONT_SERVICE_INTERNAL_DOMAIN = (
     "host.docker.internal:8000"
     if ENVIRONMENT != PRODUCTION_ENV
     else f"zane.front.zaneops.internal:80"
@@ -384,7 +384,7 @@ if BACKEND_COMPONENT == "API":
     register_zaneops_app_on_proxy(
         proxy_url=CADDY_PROXY_ADMIN_HOST,
         zane_app_domain=ZANE_APP_DOMAIN,
-        zane_app_internal_domain=ZANE_APP_SERVICE_INTERNAL_DOMAIN,
+        zane_app_internal_domain=ZANE_FRONT_SERVICE_INTERNAL_DOMAIN,
         internal_tls=DEBUG,
     )
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -78,7 +78,7 @@ ALLOWED_HOSTS = (
         "host.docker.internal",
     ]
     if ENVIRONMENT != PRODUCTION_ENV
-    else [f"127.0.0.1", f".{ROOT_DOMAIN}", f"zane.api.zaneops.internal"]
+    else [f"127.0.0.1", f".{ROOT_DOMAIN}", f".zaneops.internal"]
 )
 
 SESSION_COOKIE_DOMAIN = None

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -403,7 +403,7 @@ services:
       resources:
         limits:
           cpus: "1"
-          memory: 1.1G
+          memory: 1.5G
     healthcheck:
       test: ["CMD-SHELL", "curl -f $$(hostname -i):9200/_cluster/health || exit 1"]
       interval: 30s


### PR DESCRIPTION
## Description

This a BUG fix regarding the proxy and elasticsearch, when tested on a production server, we noticed that : 
- Elasticsearch is killed by out of memory errors, as the resource limits where too close to the heap size in the config
- Fix proxy SSL error, the proxy uses `zane.front.zaneops.internal` 

---

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
