### PR TITLE
fix: proxy get the real IP instead of the client ip of `10.0.0.2`

### DIFF
--- a/docker/docker-stack.prod-http.yaml
+++ b/docker/docker-stack.prod-http.yaml
@@ -1,4 +1,7 @@
 services:
   proxy:
     ports:
-      - "80:80"
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -46,7 +46,10 @@ services:
         zane.stack: "true"
         zane.role: "proxy"
     ports:
-      - "443:443"
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
     volumes:
       - caddy-data:/data
       - caddy-config:/config

--- a/docker/docker-stack.yaml
+++ b/docker/docker-stack.yaml
@@ -29,8 +29,14 @@ services:
       labels:
         zane.role: "proxy"
     ports:
-      - "80:80"
-      - "443:443"
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
       - "2019:2019"
     volumes:
       - caddy-data:/data


### PR DESCRIPTION
## Description

I ask deepseek and chatGPT and they gave me this solution, I don't understand it fully, but it seems to work 🤷🏾‍♂️ . From what I understand : 
> we can publish the ports using the `mode: host` and it will bypass docker load balancing, allowing us to get the real IP from the client.

Link to the chat discussion : 

> https://chatgpt.com/share/679e8694-b35c-8007-918b-fd3cb47a16cf


### Previously 

<img width="227" alt="Screenshot 2025-02-01 at 22 02 01" src="https://github.com/user-attachments/assets/a6c9e25e-5e83-42e1-b769-0ec4beee8bca" />


### Now  

<img width="233" alt="Screenshot 2025-02-01 at 22 02 08" src="https://github.com/user-attachments/assets/f12c6913-697c-41d7-b68c-73d724f991c6" />


### To update 

```shell
make setup
make deploy
```

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
