### PR TITLE
fix: `project/service-list` endpoint (Again)

### DIFF
--- a/backend/zane_api/tests/project.py
+++ b/backend/zane_api/tests/project.py
@@ -578,3 +578,22 @@ class ProjectResourcesViewTests(AuthAPITestCase):
         )
         self.assertEqual(status.HTTP_200_OK, response.status_code)
         self.assertEqual(1, len(response.json()))
+
+    def test_create_service_without_being_deployed_yet(self):
+        owner = self.loginUser()
+        project, _ = Project.objects.get_or_create(slug="zaneops", owner=owner)
+
+        create_service_payload = {"slug": "caddy", "image": "caddy:2.8-alpine"}
+        response = self.client.post(
+            reverse(
+                "zane_api:services.docker.create", kwargs={"project_slug": project.slug}
+            ),
+            data=create_service_payload,
+        )
+        self.assertEqual(status.HTTP_201_CREATED, response.status_code)
+
+        response = self.client.get(
+            reverse("zane_api:projects.service_list", kwargs={"slug": project.slug}),
+        )
+        self.assertEqual(status.HTTP_200_OK, response.status_code)
+        self.assertEqual(1, len(response.json()))

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -364,7 +364,7 @@ class ProjectServiceListView(APIView):
                 image_change = service.unapplied_changes.filter(
                     field=DockerDeploymentChange.ChangeField.SOURCE
                 ).first()
-                service_image = image_change.new_value.image
+                service_image = image_change.new_value["image"]
 
             parts = service_image.split(":")
             if len(parts) == 1:


### PR DESCRIPTION
## Description

I missed something in #350 , `new_value` is a dict, not an object.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
