### PR TITLE
refactor: cleanup containers and volumes more aggressively

### DIFF
--- a/backend/zane_api/management/commands/create_system_cleanup_schedule.py
+++ b/backend/zane_api/management/commands/create_system_cleanup_schedule.py
@@ -6,7 +6,6 @@ from django.conf import settings
 
 from ...temporal import get_temporalio_client
 from ...temporal import SystemCleanupWorkflow
-from ...utils import Colors
 from temporalio.client import (
     Schedule,
     ScheduleActionStartWorkflow,

--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -757,11 +757,16 @@ class SystemCleanupActivities:
 
     @activity.defn
     async def cleanup_images(self) -> dict:
-        return self.docker_client.images.prune(filters={"dangling": True})
+        return self.docker_client.images.prune(filters={"dangling": False})
 
     @activity.defn
     async def cleanup_volumes(self) -> dict:
-        return self.docker_client.volumes.prune()
+        return self.docker_client.volumes.prune(
+            filters={
+                "all": True,
+                "label!": ["zane-managed"],
+            }
+        )
 
     @activity.defn
     async def cleanup_containers(self) -> dict:

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -635,6 +635,12 @@ class SystemCleanupWorkflow:
             )
 
             await workflow.execute_activity_method(
+                SystemCleanupActivities.cleanup_containers,
+                start_to_close_timeout=timedelta(minutes=5),
+                retry_policy=self.retry_policy,
+            )
+
+            await workflow.execute_activity_method(
                 SystemCleanupActivities.cleanup_volumes,
                 start_to_close_timeout=timedelta(minutes=5),
                 retry_policy=self.retry_policy,
@@ -646,11 +652,6 @@ class SystemCleanupWorkflow:
                 retry_policy=self.retry_policy,
             )
 
-            await workflow.execute_activity_method(
-                SystemCleanupActivities.cleanup_containers,
-                start_to_close_timeout=timedelta(minutes=5),
-                retry_policy=self.retry_policy,
-            )
         finally:
             # release all deployment locks
             await workflow.execute_activity(


### PR DESCRIPTION
## Description

In the previous PR #349, we only removed dangling and unnamed volumes, this doesn't really do anything if you deploy & archive multiple services which leaves tagged but unused images, or volumes that are created outside of zaneops that are not used. this way we free up as much space as possible.

Of course, we prevent removing volumes used by services, as for images, if you put a service to sleep, its image will be cleaned up, but what is cool with docker services is that, they are self healing, when the service wakes up, it will pull the image again.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
