### PR TITLE
fix: do not prevent creating other ports while a http port exists

### DIFF
--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -581,18 +581,6 @@ class URLItemChangeSerializer(BaseChangeItemSerializer):
                 }
             )
 
-        http_ports = [80, 443]
-        if len(snapshot.urls) > 0:
-            for port in snapshot.ports:
-                if port.host not in http_ports:
-                    raise serializers.ValidationError(
-                        {
-                            "new_value": {
-                                "non_field_errors": f"Cannot specify both a custom URL and a port with `host` other than a HTTP port (80/443)"
-                            }
-                        }
-                    )
-
         if (
             change_type == "DELETE"
             and snapshot.healthcheck is not None


### PR DESCRIPTION
## Description

We added this rule so that it wouldn't prevent zero dowtime deployments, but honestly, the user is already warned in the frontend, so if they want to do it, we let them.

fixes #254 


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
