### PR TITLE
fix: restart policy for services as zane_app get stuck sometimes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,13 @@ setup: ### Initial setup of the project
 	uv pip install -r ./backend/requirements.txt
 	pnpm install --frozen-lockfile
 	chmod -R a+rx ./docker/temporalio/*.sh
-	
+
+deploy-temporal-ui:
+	docker stack deploy --with-registry-auth --detach=false --compose-file docker-stack.prod-temporal-ui.yaml zane-temporal-ui
+
+stop-temporal-ui:
+	docker stack rm zane-temporal-ui
+
 migrate: ### Run db migration
 	. ./backend/venv/bin/activate && python ./backend/manage.py migrate
 

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -38,7 +38,7 @@ services:
         order: start-first
         failure_action: rollback
       restart_policy:
-        condition: on-failure
+        condition: any
       placement:
         constraints:
           - node.role==manager
@@ -75,7 +75,7 @@ services:
         order: start-first
         failure_action: rollback
       restart_policy:
-        condition: on-failure
+        condition: any
       placement:
         constraints:
           - node.role==manager
@@ -132,7 +132,7 @@ services:
         order: start-first
         failure_action: rollback
       restart_policy:
-        condition: on-failure
+        condition: any
       placement:
         constraints:
           - node.role==manager
@@ -211,7 +211,7 @@ services:
         order: start-first
         failure_action: rollback
       restart_policy:
-        condition: on-failure
+        condition: any
       placement:
         constraints:
           - node.role==manager
@@ -246,7 +246,7 @@ services:
         order: start-first
         failure_action: rollback
       restart_policy:
-        condition: on-failure
+        condition: any
       placement:
         constraints:
           - node.role==manager
@@ -265,7 +265,7 @@ services:
     deploy:
       replicas: 1
       restart_policy:
-        condition: on-failure
+        condition: any
       placement:
         constraints:
           - node.role==manager
@@ -299,7 +299,7 @@ services:
     deploy:
       replicas: 1
       restart_policy:
-        condition: on-failure
+        condition: any
       placement:
         constraints:
           - node.role==manager
@@ -339,7 +339,7 @@ services:
     deploy:
       replicas: 1
       restart_policy:
-        condition: on-failure
+        condition: any
       placement:
         constraints:
           - node.role==manager
@@ -364,7 +364,7 @@ services:
     deploy:
       replicas: 1
       restart_policy:
-        condition: on-failure
+        condition: any
         delay: 5s
         max_attempts: 1
         window: 120s
@@ -394,7 +394,7 @@ services:
     deploy:
       replicas: 1
       restart_policy:
-        condition: on-failure
+        condition: any
         delay: 5s
         max_attempts: 1
         window: 120s


### PR DESCRIPTION
## Description

exactly as the title says. I also added commands for starting the temporal-ui server.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
