### PR TITLE
fix: remove archival storage in temporal

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -33,7 +33,6 @@ services:
       - ./temporalio/config/dynamicconfig:/etc/temporal/config/dynamicconfig/
       - ./temporalio/config/config_template.yaml:/etc/temporal/config/config_template.yaml
       - ./temporalio/entrypoint.sh:/etc/temporal/entrypoint.sh
-      - ./temporalio/archival:/etc/temporal/archival
     networks:
       zane:
         aliases:

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -123,7 +123,6 @@ services:
       - "${ZANE_APP_DIRECTORY:-/var/www/zaneops}/temporalio/config/dynamicconfig/production-sql.yaml:/etc/temporal/config/dynamicconfig/development-sql.yaml"
       - "${ZANE_APP_DIRECTORY:-/var/www/zaneops}/temporalio/config/config_template.yaml:/etc/temporal/config/config_template.yaml"
       - "${ZANE_APP_DIRECTORY:-/var/www/zaneops}/temporalio/entrypoint.sh:/etc/temporal/entrypoint.sh"
-      - temporal-archival:/etc/temporal/archival
     deploy:
       replicas: 1
       update_config:
@@ -421,9 +420,6 @@ volumes:
     labels:
       zane.stack: "true"
   redis-data:
-    labels:
-      zane.stack: "true"
-  temporal-archival:
     labels:
       zane.stack: "true"
   caddy-data:

--- a/docker/docker-stack.yaml
+++ b/docker/docker-stack.yaml
@@ -87,7 +87,6 @@ services:
 volumes:
   caddy-data:
   caddy-config:
-  temporal-archival:
 networks:
   zane:
     external: true

--- a/docker/temporalio/admin-tools-entrypoint.sh
+++ b/docker/temporalio/admin-tools-entrypoint.sh
@@ -32,7 +32,7 @@ set -eux -o pipefail
 
 : "${SKIP_DEFAULT_NAMESPACE_CREATION:=false}"
 : "${DEFAULT_NAMESPACE:=zane}"
-: "${DEFAULT_NAMESPACE_RETENTION:=1d}"
+: "${DEFAULT_NAMESPACE_RETENTION:=7d}"
 
 : "${SKIP_ADD_CUSTOM_SEARCH_ATTRIBUTES:=false}"
 
@@ -102,9 +102,10 @@ register_default_namespace() {
     echo "Registering default namespace: ${DEFAULT_NAMESPACE}."
     if ! temporal operator namespace describe "${DEFAULT_NAMESPACE}"; then
         echo "Default namespace ${DEFAULT_NAMESPACE} not found. Creating..."
-        temporal operator namespace create --retention "${DEFAULT_NAMESPACE_RETENTION}" --description "Default namespace for ZaneOps." --history-archival-state "enabled" --visibility-archival-state "enabled" --history-uri "file:///etc/temporal/archival/history" --visibility-uri "file:///etc/temporal/archival/visibility" "${DEFAULT_NAMESPACE}"
+        temporal operator namespace create --retention "${DEFAULT_NAMESPACE_RETENTION}" --description "Default namespace for ZaneOps." --history-archival-state "disabled" --visibility-archival-state "disabled" "${DEFAULT_NAMESPACE}"
     else
-        echo "Default namespace ${DEFAULT_NAMESPACE} already registered."
+        echo "Default namespace ${DEFAULT_NAMESPACE} already registered, updating..."
+        temporal operator namespace update --retention "${DEFAULT_NAMESPACE_RETENTION}" --description "Default namespace for ZaneOps." --history-archival-state "disabled" --visibility-archival-state "disabled" "${DEFAULT_NAMESPACE}"
     fi
     echo "====== Default namespace ${DEFAULT_NAMESPACE} registration complete : ======"
     echo $(temporal operator namespace describe "${DEFAULT_NAMESPACE}")


### PR DESCRIPTION
## Description

The temporal archival volume gets way too big after some time, and technically, we don't really use it, storing the archival data for workflows is not at all necessary. We also disabled the archival feature in `temporal-admin-tools` service.

 <img width="746" alt="Screenshot 2025-02-09 at 15 56 57" src="https://github.com/user-attachments/assets/e35ac391-2028-4713-8a35-940d10543ee6" />

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
