### PR TITLE
fix: override `healthcheck` in service and relax restart policy

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -38,6 +38,7 @@ with workflow.unsafe.imports_passed_through():
         Resources,
         UpdateConfig,
         ConfigReference,
+        Healthcheck as DockerHealthcheckType,
     )
     from django.conf import settings
     from django.utils import timezone
@@ -1597,10 +1598,12 @@ class DockerSwarmActivities:
                     parallelism=1,
                 ),
                 restart_policy=RestartPolicy(
-                    condition="on-failure",
-                    max_attempts=3,
+                    condition="any",
+                    max_attempts=5,
                     delay=int(5e9),  # delay is in nanoseconds
                 ),
+                # this disables the default container healthcheck, instead we control the healthcheck externally
+                healthcheck=DockerHealthcheckType(test=["NONE"]),
                 stop_grace_period=int(30e9),  # stop_grace_period is in nanoseconds
                 log_driver="fluentd",
                 log_driver_options={


### PR DESCRIPTION
## Description

This was an issue I encountered when working trying to deploy https://github.com/solidtime-io/solidtime on zaneops, the default `solidtime` image has its own healthcheck. Since the image is reused by other components, we needed to override the healthcheck to adapt them to these services. However, zaneops didn't do that because we don't rely on docker's default healthcheck. To fix this, we just disable the default healthcheck of the service in favor of our own external healthcheck. I also changed the restart policy to restart on any state (even if the container was stopped succesfully) instead of restarting only on failure.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
