### PR TITLE
fix: http logs filters

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -48,7 +48,6 @@ lib-detect-testenv==2.0.8
 markdown==3.5.2
 mccabe==0.7.0
 multiprocess==0.70.16
-mypy-extensions==1.0.0
 packaging==23.2
 pathspec==0.12.1
 pip==24.0

--- a/backend/zane_api/views/docker_services.py
+++ b/backend/zane_api/views/docker_services.py
@@ -90,7 +90,7 @@ from ..temporal import (
     workflow_signal,
     CancelDeploymentSignalInput,
 )
-from ..utils import generate_random_chars
+from ..utils import Colors, generate_random_chars
 from io import StringIO
 
 from dotenv import dotenv_values
@@ -1054,8 +1054,10 @@ class DockerServiceHttpLogsAPIView(ListAPIView):
     @extend_schema(
         summary="Get service HTTP logs",
     )
-    def get(self, request, *args, **kwargs):
+    def get(self, request: Request, *args, **kwargs):
         try:
+            print("====== HTTP LOGS SEARCH ======")
+            print(f"Params: {Colors.GREY}{request.query_params}{Colors.ENDC}")
             return super().get(request, *args, **kwargs)
         except exceptions.NotFound as e:
             if "Invalid cursor" in str(e.detail):

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -45,6 +45,7 @@ from ..temporal import (
     get_server_resource_limits,
 )
 from ..utils import (
+    Colors,
     EnhancedJSONEncoder,
     convert_value_to_bytes,
     find_item_in_list,
@@ -603,7 +604,7 @@ class BaseFieldChangeSerializer(serializers.Serializer):
     field = serializers.SerializerMethodField()
 
     def get_service(self):
-        service: DockerRegistryServic | None = self.context.get("service")  # type: ignore
+        service: DockerRegistryService | None = self.context.get("service")  # type: ignore
         if service is None:
             raise serializers.ValidationError("`service` is required in context.")
         return service
@@ -1205,14 +1206,18 @@ class DeploymentHttpLogsFilterSet(django_filters.FilterSet):
         status_prefix_path = r"^\dxx$"
 
         queries = Q()
-        for status in params:
-            if re.match(status_prefix_path, status):
-                prefix = int(status[0])
-                queries = queries | (
-                    Q(status__gte=(prefix * 100), status__lte=(prefix * 100) + 99)
-                )
-            if re.match(r"^\d+$", status):
-                queries = queries | Q(status=int(status))
+        if name == "status":
+            for param in params:
+                if re.match(status_prefix_path, param):
+                    prefix = int(param[0])
+                    queries = queries | (
+                        Q(status__gte=(prefix * 100), status__lte=(prefix * 100) + 99)
+                    )
+                elif re.match(r"^\d+$", param):
+                    queries = queries | Q(status=int(param))
+        else:
+            queries = Q(**{f"{name}__in": params})
+        print(f"Query: {Colors.GREY}{queries}{Colors.ENDC}")
         return queryset.filter(queries)
 
     def filter_query(self, queryset: QuerySet, name: str, value: str):

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -15,7 +15,6 @@ from dotenv import dotenv_values
 from faker import Faker
 from rest_framework import pagination
 from rest_framework.request import Request
-from django.core.exceptions import ValidationError
 
 from ..dtos import DockerServiceSnapshot, DeploymentChangeDto
 


### PR DESCRIPTION
## Description

The filters were not working at all, that was because we modified them to only take into account status filters instead of the other filters too.

We also deleted one unused package : `mypy-extension`

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
