### PR TITLE
fix: `iterator.entries().map` isn't implemented in safari

### DIFF
--- a/frontend/app/components/http-log-request-details.tsx
+++ b/frontend/app/components/http-log-request-details.tsx
@@ -338,7 +338,7 @@ function LogRequestDetailsContent({ log }: { log: HttpLog }) {
             </dt>
             <dd className="text-sm">
               <span className="text-grey">{"?"}</span>
-              {queryParams.entries().map(([key, value], index) => (
+              {[...queryParams.entries()].map(([key, value], index) => (
                 <span key={`${key}-${index}`}>
                   <span className="text-link">{key}</span>
                   {value && (


### PR DESCRIPTION
## Description

So we just use an array instead.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
