### PR TITLE
fix: bug with previous deployment not cleaned up

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -1220,6 +1220,7 @@ class DockerSwarmActivities:
 
         if docker_deployment is not None:
             docker_deployment.status = DockerDeployment.DeploymentStatus.REMOVED
+            docker_deployment.is_current_production = False
             await docker_deployment.asave()
 
     @activity.defn

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -374,13 +374,6 @@ class DeployDockerServiceWorkflow:
                     )
 
                 await workflow.execute_activity_method(
-                    DockerSwarmActivities.cleanup_previous_unclean_deployments,
-                    deployment,
-                    start_to_close_timeout=timedelta(seconds=30),
-                    retry_policy=self.retry_policy,
-                )
-
-                await workflow.execute_activity_method(
                     DockerSwarmActivities.create_deployment_healthcheck_schedule,
                     deployment,
                     start_to_close_timeout=timedelta(seconds=5),
@@ -420,6 +413,12 @@ class DeployDockerServiceWorkflow:
                 DockerSwarmActivities.finish_and_save_deployment,
                 healthcheck_result,
                 start_to_close_timeout=timedelta(seconds=5),
+                retry_policy=self.retry_policy,
+            )
+            await workflow.execute_activity_method(
+                DockerSwarmActivities.cleanup_previous_unclean_deployments,
+                deployment,
+                start_to_close_timeout=timedelta(seconds=30),
                 retry_policy=self.retry_policy,
             )
             next_queued_deployment = await self.queue_next_deployment(deployment)


### PR DESCRIPTION
## Description

Sometimes the previous deployment is not cleaned up, and we don't know why... this PR attemps to fix it.


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
