### PR TITLE
fix: do not run monitoring healthcheck against non production deployments

### DIFF
--- a/backend/zane_api/temporal/schedules/activities.py
+++ b/backend/zane_api/temporal/schedules/activities.py
@@ -149,12 +149,12 @@ class MonitorDockerDeploymentActivities:
                     DockerSwarmTaskState.PREPARING: DockerDeployment.DeploymentStatus.STARTING,
                     DockerSwarmTaskState.STARTING: DockerDeployment.DeploymentStatus.STARTING,
                     DockerSwarmTaskState.RUNNING: DockerDeployment.DeploymentStatus.HEALTHY,
-                    DockerSwarmTaskState.COMPLETE: DockerDeployment.DeploymentStatus.UNHEALTHY,
+                    DockerSwarmTaskState.COMPLETE: DockerDeployment.DeploymentStatus.REMOVED,
                     DockerSwarmTaskState.FAILED: DockerDeployment.DeploymentStatus.UNHEALTHY,
-                    DockerSwarmTaskState.SHUTDOWN: DockerDeployment.DeploymentStatus.UNHEALTHY,
+                    DockerSwarmTaskState.SHUTDOWN: DockerDeployment.DeploymentStatus.REMOVED,
                     DockerSwarmTaskState.REJECTED: DockerDeployment.DeploymentStatus.UNHEALTHY,
                     DockerSwarmTaskState.ORPHANED: DockerDeployment.DeploymentStatus.UNHEALTHY,
-                    DockerSwarmTaskState.REMOVE: DockerDeployment.DeploymentStatus.UNHEALTHY,
+                    DockerSwarmTaskState.REMOVE: DockerDeployment.DeploymentStatus.REMOVED,
                 }
 
                 exited_without_error = 0

--- a/backend/zane_api/temporal/schedules/activities.py
+++ b/backend/zane_api/temporal/schedules/activities.py
@@ -149,12 +149,12 @@ class MonitorDockerDeploymentActivities:
                     DockerSwarmTaskState.PREPARING: DockerDeployment.DeploymentStatus.STARTING,
                     DockerSwarmTaskState.STARTING: DockerDeployment.DeploymentStatus.STARTING,
                     DockerSwarmTaskState.RUNNING: DockerDeployment.DeploymentStatus.HEALTHY,
-                    DockerSwarmTaskState.COMPLETE: DockerDeployment.DeploymentStatus.REMOVED,
+                    DockerSwarmTaskState.COMPLETE: DockerDeployment.DeploymentStatus.UNHEALTHY,
                     DockerSwarmTaskState.FAILED: DockerDeployment.DeploymentStatus.UNHEALTHY,
-                    DockerSwarmTaskState.SHUTDOWN: DockerDeployment.DeploymentStatus.REMOVED,
+                    DockerSwarmTaskState.SHUTDOWN: DockerDeployment.DeploymentStatus.UNHEALTHY,
                     DockerSwarmTaskState.REJECTED: DockerDeployment.DeploymentStatus.UNHEALTHY,
                     DockerSwarmTaskState.ORPHANED: DockerDeployment.DeploymentStatus.UNHEALTHY,
-                    DockerSwarmTaskState.REMOVE: DockerDeployment.DeploymentStatus.REMOVED,
+                    DockerSwarmTaskState.REMOVE: DockerDeployment.DeploymentStatus.UNHEALTHY,
                 }
 
                 exited_without_error = 0
@@ -284,7 +284,10 @@ class MonitorDockerDeploymentActivities:
                 non_retryable=True,
             )
         else:
-            if deployment.status != DockerDeployment.DeploymentStatus.SLEEPING:
+            if (
+                deployment.status != DockerDeployment.DeploymentStatus.SLEEPING
+                and deployment.is_current_production
+            ):
                 deployment.status_reason = healthcheck_result.reason
                 deployment.status = healthcheck_result.status
                 await deployment.asave()


### PR DESCRIPTION
## Description

The monitoring health checks would run after a succesful deployment and override the status of the removed deployment which can be confusing.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
