### PR TITLE
fix: metrics collection workflow failing when disk I/O is None

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -818,7 +818,11 @@ class SystemCleanupActivities:
 
     @activity.defn
     async def cleanup_networks(self) -> dict:
-        return self.docker_client.networks.prune()
+        return self.docker_client.networks.prune(
+            filters={
+                "label!": ["zane-managed"],
+            }
+        )
 
 
 class DockerSwarmActivities:

--- a/backend/zane_api/temporal/schedules/activities.py
+++ b/backend/zane_api/temporal/schedules/activities.py
@@ -382,6 +382,7 @@ class DockerDeploymentStatsActivities:
                                 stats.get("blkio_stats", {}).get(
                                     "io_service_bytes_recursive", []
                                 )
+                                or []
                             )
                             if io.get("op") == "read"
                         )
@@ -392,6 +393,7 @@ class DockerDeploymentStatsActivities:
                                 stats.get("blkio_stats", {}).get(
                                     "io_service_bytes_recursive", []
                                 )
+                                or []
                             )
                             if io["op"] == "write"
                         )

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -82,7 +82,7 @@ services:
     command: >
       bash -c "source /venv/bin/activate &&
                uv pip install -r requirements.txt &&
-               python manage.py create_log_cleanup_schedule &&
+               python manage.py create_metrics_cleanup_schedule &&
                python manage.py runserver 0.0.0.0:8000"
     container_name: zane-api
     volumes:

--- a/frontend/app/components/http-log-request-details.tsx
+++ b/frontend/app/components/http-log-request-details.tsx
@@ -51,7 +51,10 @@ export function HttpLogRequestDetails({
     >
       <SheetContent
         side="right"
-        className="z-99 border-border flex flex-col gap-4 overflow-y-auto"
+        className={cn(
+          "z-99 border-border flex flex-col gap-4 overflow-y-auto",
+          import.meta.env.DEV && "[&_[data-slot=close-btn]]:top-10"
+        )}
       >
         {log && <LogRequestDetailsContent log={log} />}
       </SheetContent>

--- a/frontend/app/components/http-log-request-details.tsx
+++ b/frontend/app/components/http-log-request-details.tsx
@@ -94,8 +94,30 @@ function LogRequestDetailsContent({ log }: { log: HttpLog }) {
           <dd className="text-sm">{log.request_id}</dd>
         </div>
 
-        <div className="grid grid-cols-2 items-center gap-x-4 w-full">
-          <dt className="text-grey  inline-flex items-center">Status code</dt>
+        <div className="grid grid-cols-2 items-center gap-x-4 w-full group">
+          <dt className="text-grey inline-flex items-center">
+            <span>Status code</span>
+
+            <TooltipProvider>
+              <Tooltip delayDuration={0}>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    className="px-2.5 py-0.5 md:opacity-0 focus-visible:opacity-100 group-hover:opacity-100"
+                    onClick={() => {
+                      searchParams.set("status", log.status.toString());
+                      searchParams.delete("request_id");
+                      setSearchParams(searchParams, { replace: true });
+                    }}
+                  >
+                    <FilterIcon size={15} />
+                    <span className="sr-only">Add Filter</span>
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Add Filter</TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          </dt>
           <dd
             className={cn("inline-flex items-center gap-1", {
               "text-blue-600": log.status.toString().startsWith("1"),

--- a/frontend/app/components/service-changes-modal.tsx
+++ b/frontend/app/components/service-changes-modal.tsx
@@ -14,7 +14,7 @@ import {
   XIcon
 } from "lucide-react";
 import * as React from "react";
-import { useFetcher } from "react-router";
+import { useFetcher, useNavigate } from "react-router";
 import {
   CommandChangeField,
   ConfigChangeItem,
@@ -50,16 +50,22 @@ import { capitalizeText, pluralize } from "~/utils";
 
 type ServiceChangeModalProps = {
   service: DockerService;
+  project_slug: string;
 };
-export function ServiceChangesModal({ service }: ServiceChangeModalProps) {
+export function ServiceChangesModal({
+  service,
+  project_slug
+}: ServiceChangeModalProps) {
   const fetcher = useFetcher<typeof clientAction>();
   const [isOpen, setIsOpen] = React.useState(false);
   const isDeploying = fetcher.state !== "idle";
+  const navigate = useNavigate();
 
   React.useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data) {
       if (!fetcher.data.errors) {
         setIsOpen(false);
+        navigate(`/project/${project_slug}/services/${service.slug}`);
       }
     }
   }, [fetcher.data, fetcher.state]);

--- a/frontend/app/components/ui/alert.tsx
+++ b/frontend/app/components/ui/alert.tsx
@@ -14,7 +14,9 @@ const alertVariants = cva(
         success: "border-teal-500 text-teal-500",
         info: "border-link text-link",
         destructive:
-          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive"
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+        danger:
+          "border-none text-white [&>svg]:text-white bg-destructive dark:bg-red-800"
       }
     },
     defaultVariants: {

--- a/frontend/app/components/ui/sheet.tsx
+++ b/frontend/app/components/ui/sheet.tsx
@@ -70,7 +70,10 @@ const SheetContent = ({
       className={cn(sheetVariants({ side }), className)}
       {...props}
     >
-      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+      <SheetPrimitive.Close
+        data-slot="close-btn"
+        className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary"
+      >
         <div className="rounded-md p-0.5 border border-border">
           <X className="h-5 w-5" />
         </div>

--- a/frontend/app/routes/projects/project-settings.tsx
+++ b/frontend/app/routes/projects/project-settings.tsx
@@ -323,9 +323,9 @@ function DeleteConfirmationFormDialog({
         <DialogHeader className="pb-4">
           <DialogTitle>Delete this project ?</DialogTitle>
 
-          <Alert variant="warning" className="my-5">
+          <Alert variant="danger" className="my-5">
             <AlertCircleIcon className="h-4 w-4" />
-            <AlertTitle>Warning</AlertTitle>
+            <AlertTitle>Attention !</AlertTitle>
             <AlertDescription>
               Deleting this project will also delete all its services and delete
               all the deployments related to the services, This action is

--- a/frontend/app/routes/services/create-docker-service.tsx
+++ b/frontend/app/routes/services/create-docker-service.tsx
@@ -101,7 +101,6 @@ export default function CreateServicePage({
 
       {currentStep === "CREATED" && (
         <StepServiceCreated
-          actionData={actionData}
           projectSlug={params.projectSlug}
           serviceSlug={serviceSlug}
           onSuccess={(hash) => {
@@ -390,7 +389,6 @@ function StepServiceForm({ onSuccess, actionData }: StepServiceFormProps) {
 }
 
 type StepServiceCreatedProps = {
-  actionData?: Route.ComponentProps["actionData"];
   serviceSlug: string;
   projectSlug: string;
   onSuccess: (deploymentHash: string) => void;
@@ -399,16 +397,15 @@ type StepServiceCreatedProps = {
 function StepServiceCreated({
   serviceSlug,
   projectSlug,
-  actionData,
   onSuccess
 }: StepServiceCreatedProps) {
   // const navigation = useNavigation();
   const fetcher = useFetcher<typeof clientAction>();
-  const errors = getFormErrorsFromResponseData(actionData?.errors);
+  const errors = getFormErrorsFromResponseData(fetcher.data?.errors);
   const isPending = fetcher.state !== "idle";
 
-  if (actionData?.deploymentHash) {
-    onSuccess(actionData.deploymentHash);
+  if (fetcher.data?.deploymentHash) {
+    onSuccess(fetcher.data.deploymentHash);
   }
   return (
     <div className="flex flex-col h-[70vh] justify-center items-center">

--- a/frontend/app/routes/services/service-metrics.tsx
+++ b/frontend/app/routes/services/service-metrics.tsx
@@ -170,7 +170,8 @@ export default function ServiceMetricsPage({
                               month: "short",
                               day: "numeric",
                               hour: "2-digit",
-                              minute: "2-digit"
+                              minute: "2-digit",
+                              second: "2-digit"
                             }
                           ).format(new Date(payload.bucket_epoch));
 
@@ -278,7 +279,8 @@ export default function ServiceMetricsPage({
                               month: "short",
                               day: "numeric",
                               hour: "2-digit",
-                              minute: "2-digit"
+                              minute: "2-digit",
+                              second: "2-digit"
                             }
                           ).format(new Date(payload.bucket_epoch));
                           const { value: value_str, unit } =
@@ -394,7 +396,8 @@ export default function ServiceMetricsPage({
                               month: "short",
                               day: "numeric",
                               hour: "2-digit",
-                              minute: "2-digit"
+                              minute: "2-digit",
+                              second: "2-digit"
                             }
                           ).format(new Date(item.payload.bucket_epoch));
                           const { value: value_str, unit } =
@@ -530,7 +533,8 @@ export default function ServiceMetricsPage({
                               month: "short",
                               day: "numeric",
                               hour: "2-digit",
-                              minute: "2-digit"
+                              minute: "2-digit",
+                              second: "2-digit"
                             }
                           ).format(new Date(item.payload.bucket_epoch));
                           const { value: value_str, unit } =

--- a/frontend/app/routes/services/settings/service-danger-zone-form.tsx
+++ b/frontend/app/routes/services/settings/service-danger-zone-form.tsx
@@ -101,37 +101,6 @@ export function ServiceDangerZoneForm({
           project_slug={project_slug}
         />
       </div>
-      {/* <Form
-        className="flex flex-col gap-2 items-start"
-        method="post"
-        action="../archive-service"
-      > */}
-      {/* <p className="text-red-400 ">
-          Archiving this service will permanently delete all its deployments,
-          This cannot be undone.
-        </p> */}
-
-      {/* <SubmitButton
-          variant="destructive"
-          className={cn(
-            "inline-flex gap-1 items-center",
-            isPending ? "bg-red-400" : "bg-red-500"
-          )}
-          isPending={isPending}
-        >
-          {isPending ? (
-            <>
-              <LoaderIcon className="animate-spin flex-none" size={15} />
-              <span>Archiving...</span>
-            </>
-          ) : (
-            <>
-              <Trash2Icon size={15} className="flex-none" />
-              <span>Delete service</span>
-            </>
-          )}
-        </SubmitButton> */}
-      {/* </Form> */}
     </div>
   );
 }
@@ -182,9 +151,9 @@ function DeleteConfirmationFormDialog({
         <DialogHeader className="pb-4">
           <DialogTitle>Delete this service ?</DialogTitle>
 
-          <Alert variant="warning" className="my-5">
+          <Alert variant="danger" className="my-5">
             <AlertCircleIcon className="h-4 w-4" />
-            <AlertTitle>Warning</AlertTitle>
+            <AlertTitle>Attention !</AlertTitle>
             <AlertDescription>
               Deleting this service will permanently delete all its deployments,
               This action is irreversible.


### PR DESCRIPTION
## Description

In this PR we finally fixed the bug with metrics collection, when `blkio` is `None`, we should set the default value to empty array.
I also fixed a bug with the system collection job : we should not delete networks managed by zaneops. 

I also made some other UX changes in the UI : 
- added a confirmation dialog for when the user want to put service to sleep
  > <img width="574" alt="Screenshot 2025-03-10 at 02 20 30" src="https://github.com/user-attachments/assets/60fcac7a-8f67-44a1-9a9c-3b5403a53355" />
- and more...

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
