### PR TITLE
fix: log unhealthy error when the service is down, and allow infinite restarts

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -1583,10 +1583,10 @@ class DockerSwarmActivities:
             # zane-specific-envs
             envs.extend(
                 [
-                    f"ZANE=true",
+                    "ZANE=true",
                     f"ZANE_DEPLOYMENT_SLOT={deployment.slot}",
                     f"ZANE_DEPLOYMENT_HASH={deployment.hash}",
-                    f"ZANE_DEPLOYMENT_TYPE=docker",
+                    "ZANE_DEPLOYMENT_TYPE=docker",
                     f"ZANE_PRIVATE_DOMAIN={service.network_alias}",
                     f"ZANE_SERVICE_ID={service.id}",
                     f"ZANE_SERVICE_NAME={service.slug}",
@@ -1719,10 +1719,8 @@ class DockerSwarmActivities:
                 ),
                 restart_policy=RestartPolicy(
                     condition="any",
-                    max_attempts=5,
-                    delay=int(5e9),  # delay is in nanoseconds
                 ),
-                # this disables the default container healthcheck, instead we control the healthcheck externally
+                # this disables the default container healthcheck, since we control the healthcheck externally
                 healthcheck=DockerHealthcheckType(test=["NONE"]),
                 stop_grace_period=int(30e9),  # stop_grace_period is in nanoseconds
                 log_driver="fluentd",


### PR DESCRIPTION
## Description

We didn't log errors when the service is stopped, and has no running tasks, so I fixed it. 
I also made it so that there isn't a max attempts of restarts when creating the service. 


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
