### PR TITLE
fix: redirect correctly when clicking `deploy now`

### DIFF
--- a/frontend/app/components/ui/fieldset.tsx
+++ b/frontend/app/components/ui/fieldset.tsx
@@ -73,9 +73,7 @@ export function FieldSetErrors(
   );
 }
 
-export function FieldSetLabel(
-  props: Omit<React.ComponentProps<"label">, "htmlFor">
-) {
+export function FieldSetLabel(props: React.ComponentProps<"label">) {
   const ctx = React.use(FieldSetContext);
   if (!ctx) {
     throw new Error(
@@ -86,7 +84,7 @@ export function FieldSetLabel(
   const { id } = ctx;
   return (
     <label
-      htmlFor={id}
+      htmlFor={props.htmlFor ?? id}
       {...props}
       className={cn("dark:text-gray-400", props.className)}
     >

--- a/frontend/app/components/ui/fieldset.tsx
+++ b/frontend/app/components/ui/fieldset.tsx
@@ -10,12 +10,14 @@ import { cn } from "~/lib/utils";
 export type FieldSetProps = {
   errors?: string | string[];
   children: React.ReactNode;
+  required?: boolean;
 } & React.ComponentProps<"fieldset">;
 
 type FieldSetContext = {
   id: string;
   name?: string;
   errors?: string | string[];
+  required?: boolean;
 };
 
 const FieldSetContext = React.createContext<FieldSetContext | null>(null);
@@ -25,6 +27,7 @@ export function FieldSet({
   errors,
   children,
   name,
+  required,
   ...props
 }: FieldSetProps) {
   const id = React.useId();
@@ -39,7 +42,7 @@ export function FieldSet({
   );
 
   return (
-    <FieldSetContext value={{ id, errors, name }}>
+    <FieldSetContext value={{ id, errors, name, required }}>
       <fieldset className={className} {...props}>
         {children}
         {!isErrorComponentInChildren && errors && <FieldSetErrors />}
@@ -81,7 +84,18 @@ export function FieldSetLabel(
   }
 
   const { id } = ctx;
-  return <label htmlFor={id} {...props} />;
+  return (
+    <label
+      htmlFor={id}
+      {...props}
+      className={cn("dark:text-gray-400", props.className)}
+    >
+      {props.children}
+      {ctx.required && (
+        <span className="text-amber-600 dark:text-yellow-500">&nbsp;*</span>
+      )}
+    </label>
+  );
 }
 
 export function FieldSetInput(

--- a/frontend/app/components/ui/input.tsx
+++ b/frontend/app/components/ui/input.tsx
@@ -11,7 +11,7 @@ export function Input({
   return (
     <input
       className={cn(
-        "flex h-10 w-full placeholder:text-gray-400  rounded-md border border-input bg-background px-3 py-5 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full placeholder:text-gray-400 dark:placeholder:text-gray-500  rounded-md border border-input bg-background px-3 py-5 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
         "[&[type='datetime-local']]:py-2",
         "aria-[invalid=true]:border-red-500 aria-[invalid=true]:focus:ring-red-500/50",
         className

--- a/frontend/app/routes/layouts/service-layout.tsx
+++ b/frontend/app/routes/layouts/service-layout.tsx
@@ -301,7 +301,7 @@ function DeployServiceForm({ className, service }: DeployServiceFormProps) {
     if (fetcher.state === "idle" && fetcher.data) {
       if (!fetcher.data.errors) {
         navigate(
-          `/project/${params.project_slug}/services/${params.serviceSlug}`
+          `/project/${params.projectSlug}/services/${params.serviceSlug}`
         );
       }
     }

--- a/frontend/app/routes/services/settings/service-configs-form.tsx
+++ b/frontend/app/routes/services/settings/service-configs-form.tsx
@@ -1,10 +1,7 @@
 import Editor, { useMonaco } from "@monaco-editor/react";
 import {
   AlertCircleIcon,
-  ArrowRightIcon,
-  Code,
   FileSlidersIcon,
-  HardDriveIcon,
   LoaderIcon,
   PlusIcon,
   Trash2Icon,
@@ -335,13 +332,12 @@ function ServiceConfigItem({
               </FieldSet>
 
               <FieldSet
+                required
                 name="mount_path"
                 className="flex flex-col gap-1.5 flex-1"
                 errors={errors.new_value?.mount_path}
               >
-                <FieldSetLabel className="text-muted-foreground">
-                  mount path
-                </FieldSetLabel>
+                <FieldSetLabel>mount path</FieldSetLabel>
                 <FieldSetInput
                   placeholder="ex: /data"
                   defaultValue={mount_path}
@@ -362,9 +358,7 @@ function ServiceConfigItem({
                 name="name"
                 className="flex flex-col gap-1.5 flex-1"
               >
-                <FieldSetLabel className="text-muted-foreground">
-                  Name
-                </FieldSetLabel>
+                <FieldSetLabel>Name</FieldSetLabel>
                 <FieldSetInput
                   placeholder="ex: postgresl-data"
                   defaultValue={name}
@@ -572,13 +566,12 @@ function NewServiceConfigForm() {
       </FieldSet>
 
       <FieldSet
+        required
         errors={errors.new_value?.mount_path}
         name="mount_path"
         className="flex flex-col gap-1.5 flex-1"
       >
-        <FieldSetLabel className="text-muted-foreground">
-          mount path
-        </FieldSetLabel>
+        <FieldSetLabel>mount path</FieldSetLabel>
         <FieldSetInput placeholder="ex: /data" />
       </FieldSet>
       <FieldSet
@@ -586,7 +579,7 @@ function NewServiceConfigForm() {
         name="name"
         className="flex flex-col gap-1.5 flex-1"
       >
-        <FieldSetLabel className="text-muted-foreground">Name</FieldSetLabel>
+        <FieldSetLabel>Name</FieldSetLabel>
         <FieldSetInput placeholder="ex: postgresl-data" />
       </FieldSet>
 
@@ -595,9 +588,7 @@ function NewServiceConfigForm() {
         errors={errors.new_value?.contents}
         className="flex flex-col gap-1.5 flex-1"
       >
-        <FieldSetLabel className="text-muted-foreground">
-          contents
-        </FieldSetLabel>
+        <FieldSetLabel>contents</FieldSetLabel>
         <FieldSetTextarea className="sr-only" value={contents} readOnly />
 
         <div

--- a/frontend/app/routes/services/settings/service-healthcheck-form.tsx
+++ b/frontend/app/routes/services/settings/service-healthcheck-form.tsx
@@ -152,13 +152,12 @@ export function ServiceHealthcheckForm({
 
         <div className="flex flex-col md:grid md:grid-cols-4 md:items-start gap-2">
           <FieldSet
+            required
             errors={errors.new_value?.type}
             name="type"
             className="flex flex-col gap-1.5 flex-1"
           >
-            <label htmlFor="healthcheck_type" className="text-muted-foreground">
-              Type
-            </label>
+            <FieldSetLabel htmlFor="healthcheck_type">Type</FieldSetLabel>
             <FieldSetSelect
               name="type"
               disabled={healthcheckChange !== undefined}
@@ -192,6 +191,7 @@ export function ServiceHealthcheckForm({
           </FieldSet>
 
           <FieldSet
+            required
             name="value"
             errors={errors.new_value?.value}
             className={cn(
@@ -222,6 +222,7 @@ export function ServiceHealthcheckForm({
 
           {healthcheckType === "PATH" && (
             <FieldSet
+              required
               name="associated_port"
               errors={errors.new_value?.associated_port}
               className="flex flex-col gap-1.5 flex-1"
@@ -254,9 +255,7 @@ export function ServiceHealthcheckForm({
           name="timeout_seconds"
           className="flex flex-col gap-1.5 flex-1"
         >
-          <FieldSetLabel className="text-muted-foreground">
-            Timeout (in seconds)
-          </FieldSetLabel>
+          <FieldSetLabel>Timeout in seconds</FieldSetLabel>
           <FieldSetInput
             disabled={healthcheckChange !== undefined}
             placeholder={
@@ -280,7 +279,7 @@ export function ServiceHealthcheckForm({
           className="flex flex-col gap-1.5 flex-1"
         >
           <FieldSetLabel className="text-muted-foreground">
-            Interval (in seconds)
+            Interval in seconds
           </FieldSetLabel>
           <FieldSetInput
             placeholder={

--- a/frontend/app/routes/services/settings/service-ports-form.tsx
+++ b/frontend/app/routes/services/settings/service-ports-form.tsx
@@ -284,7 +284,10 @@ function ServicePortItem({
                       className="text-gray-400"
                       htmlFor={`forwarded-${id}`}
                     >
-                      Forwarded port
+                      Forwarded port&nbsp;
+                      <span className="text-amber-600 dark:text-yellow-500">
+                        *
+                      </span>
                     </label>
                     <Input
                       placeholder="ex: 8080"
@@ -306,7 +309,10 @@ function ServicePortItem({
                   </fieldset>
                   <fieldset className="flex-1 inline-flex flex-col gap-1">
                     <label htmlFor={`host-${id}`} className="text-gray-400">
-                      Host port
+                      Host port&nbsp;
+                      <span className="text-amber-600 dark:text-yellow-500">
+                        *
+                      </span>
                     </label>
                     <Input
                       placeholder="ex: 80"
@@ -400,17 +406,19 @@ function NewServicePortForm() {
       <input type="hidden" name="change_field" value="ports" />
       <input type="hidden" name="change_type" value="ADD" />
       <FieldSet
+        required
         errors={errors.new_value?.forwarded}
         className="flex-1 inline-flex flex-col gap-1"
       >
-        <FieldSetLabel className="text-gray-400">Forwarded port</FieldSetLabel>
+        <FieldSetLabel>Forwarded port</FieldSetLabel>
         <FieldSetInput placeholder="ex: 8080" name="forwarded" />
       </FieldSet>
       <FieldSet
+        required
         errors={errors.new_value?.host}
         className="flex-1 inline-flex flex-col gap-1"
       >
-        <FieldSetLabel className="text-gray-400">Host port</FieldSetLabel>
+        <FieldSetLabel>Host port</FieldSetLabel>
         <FieldSetInput placeholder="ex: 8080" name="host" />
       </FieldSet>
 

--- a/frontend/app/routes/services/settings/service-source-form.tsx
+++ b/frontend/app/routes/services/settings/service-source-form.tsx
@@ -96,7 +96,10 @@ export function ServiceSourceForm({
           value={serviceSourcheChange?.id}
         />
         <fieldset className="flex flex-col gap-1.5 flex-1">
-          <label htmlFor="image">Source Image</label>
+          <label htmlFor="image">
+            Source Image&nbsp;
+            <span className="text-amber-600 dark:text-yellow-500">*</span>
+          </label>
           <div className="relative">
             <Input
               id="image"

--- a/frontend/app/routes/services/settings/service-urls-form.tsx
+++ b/frontend/app/routes/services/settings/service-urls-form.tsx
@@ -356,12 +356,11 @@ function ServiceURLFormItem({
                 )}
                 {!isRedirect && (
                   <FieldSet
+                    required
                     errors={errors.new_value?.associated_port}
                     className="flex-1 inline-flex flex-col gap-1"
                   >
-                    <FieldSetLabel className="text-gray-400">
-                      Forwarded port
-                    </FieldSetLabel>
+                    <FieldSetLabel>Forwarded port</FieldSetLabel>
                     <FieldSetInput
                       placeholder="ex: /"
                       name="associated_port"
@@ -371,12 +370,11 @@ function ServiceURLFormItem({
                 )}
 
                 <FieldSet
+                  required
                   errors={errors.new_value?.domain}
                   className="flex-1 inline-flex flex-col gap-1"
                 >
-                  <FieldSetLabel className="text-gray-400">
-                    Domain
-                  </FieldSetLabel>
+                  <FieldSetLabel>Domain</FieldSetLabel>
                   <FieldSetInput
                     name="domain"
                     placeholder="ex: www.mysupersaas.co"
@@ -384,12 +382,11 @@ function ServiceURLFormItem({
                   />
                 </FieldSet>
                 <FieldSet
+                  required
                   errors={errors.new_value?.base_path}
                   className="flex-1 inline-flex flex-col gap-1"
                 >
-                  <FieldSetLabel className="text-gray-400">
-                    Base path
-                  </FieldSetLabel>
+                  <FieldSetLabel>Base path</FieldSetLabel>
                   <FieldSetInput
                     placeholder="ex: /"
                     name="base_path"
@@ -407,8 +404,8 @@ function ServiceURLFormItem({
                       defaultChecked={strip_prefix}
                     />
 
-                    <FieldSetLabel className="text-gray-400 inline-flex gap-1 items-center">
-                      Strip path prefix ?
+                    <FieldSetLabel className="inline-flex gap-1 items-center">
+                      <span>Strip path prefix ?</span>
                       <TooltipProvider>
                         <Tooltip delayDuration={0}>
                           <TooltipTrigger>
@@ -436,7 +433,7 @@ function ServiceURLFormItem({
                       onCheckedChange={(state) => setIsRedirect(Boolean(state))}
                     />
 
-                    <FieldSetLabel className="text-gray-400 inline-flex gap-1 items-center">
+                    <FieldSetLabel className="inline-flex gap-1 items-center">
                       Is redirect ?
                     </FieldSetLabel>
                   </div>
@@ -445,12 +442,11 @@ function ServiceURLFormItem({
                 {isRedirect && (
                   <div className="flex flex-col gap-4 pl-4">
                     <FieldSet
+                      required
                       errors={errors.new_value?.redirect_to?.url}
                       className="flex-1 inline-flex flex-col gap-1"
                     >
-                      <FieldSetLabel className="text-gray-400">
-                        Redirect to url
-                      </FieldSetLabel>
+                      <FieldSetLabel>Redirect to url</FieldSetLabel>
                       <FieldSetInput
                         name="redirect_to_url"
                         placeholder="ex: https://mysupersaas.co/"
@@ -468,7 +464,7 @@ function ServiceURLFormItem({
                           defaultChecked={redirect_to?.permanent}
                         />
 
-                        <FieldSetLabel className="text-gray-400 inline-flex gap-1 items-center">
+                        <FieldSetLabel className=" inline-flex gap-1 items-center">
                           Permanent redirect
                           <TooltipProvider>
                             <Tooltip delayDuration={0}>
@@ -565,12 +561,11 @@ function NewServiceURLForm() {
       )}
       {!isRedirect && (
         <FieldSet
+          required
           errors={errors.new_value?.associated_port}
           className="flex-1 inline-flex flex-col gap-1"
         >
-          <FieldSetLabel className="text-gray-400">
-            Forwarded port
-          </FieldSetLabel>
+          <FieldSetLabel>Forwarded port</FieldSetLabel>
           <FieldSetInput
             placeholder="ex: /"
             name="associated_port"
@@ -583,9 +578,9 @@ function NewServiceURLForm() {
         errors={errors.new_value?.domain}
         className="flex-1 inline-flex flex-col gap-1"
       >
-        <FieldSetLabel className="text-gray-400 inline-flex gap-1">
+        <FieldSetLabel className="inline-flex gap-1">
           <span>Domain</span>
-          <span className="text-card-foreground">
+          <span className="dark:text-card-foreground text-grey">
             (leave empty to generate)
           </span>
         </FieldSetLabel>
@@ -593,10 +588,11 @@ function NewServiceURLForm() {
       </FieldSet>
 
       <FieldSet
+        required
         errors={errors.new_value?.base_path}
         className="flex-1 inline-flex flex-col gap-1"
       >
-        <FieldSetLabel className="text-gray-400">Base path</FieldSetLabel>
+        <FieldSetLabel>Base path</FieldSetLabel>
         <FieldSetInput
           name="base_path"
           placeholder="ex: /api"
@@ -611,7 +607,7 @@ function NewServiceURLForm() {
         <div className="inline-flex gap-2 items-center">
           <FieldSetCheckbox name="strip_prefix" defaultChecked />
 
-          <FieldSetLabel className="text-gray-400 inline-flex gap-1 items-center">
+          <FieldSetLabel className="inline-flex gap-1 items-center">
             Strip path prefix ?
             <TooltipProvider>
               <Tooltip delayDuration={0}>
@@ -641,7 +637,7 @@ function NewServiceURLForm() {
             onCheckedChange={(state) => setIsRedirect(Boolean(state))}
           />
 
-          <FieldSetLabel className="text-gray-400 inline-flex gap-1 items-center">
+          <FieldSetLabel className="inline-flex gap-1 items-center">
             Is redirect ?
           </FieldSetLabel>
         </div>
@@ -649,10 +645,8 @@ function NewServiceURLForm() {
 
       {isRedirect && (
         <div className="flex flex-col gap-4 pl-4">
-          <FieldSet errors={errors.new_value?.redirect_to?.url}>
-            <FieldSetLabel className="text-gray-400">
-              Redirect to url
-            </FieldSetLabel>
+          <FieldSet required errors={errors.new_value?.redirect_to?.url}>
+            <FieldSetLabel>Redirect to url</FieldSetLabel>
 
             <FieldSetInput
               name="redirect_to_url"
@@ -667,7 +661,7 @@ function NewServiceURLForm() {
             <div className="inline-flex items-center gap-2">
               <FieldSetCheckbox name="redirect_to_permanent" />
 
-              <FieldSetLabel className="text-gray-400 inline-flex gap-1 items-center">
+              <FieldSetLabel className="inline-flex gap-1 items-center">
                 Permanent redirect
                 <TooltipProvider>
                   <Tooltip delayDuration={0}>

--- a/frontend/app/routes/services/settings/service-volumes-form.tsx
+++ b/frontend/app/routes/services/settings/service-volumes-form.tsx
@@ -350,7 +350,10 @@ function ServiceVolumeItem({
                   errors={errors.new_value?.container_path}
                 >
                   <FieldSetLabel className="text-muted-foreground">
-                    Container path
+                    Container path&nbsp;
+                    <span className="text-amber-600 dark:text-yellow-500">
+                      *
+                    </span>
                   </FieldSetLabel>
                   <FieldSetInput
                     placeholder="ex: /data"
@@ -499,7 +502,8 @@ function NewServiceVolumeForm() {
         className="flex flex-col gap-1.5 flex-1"
       >
         <FieldSetLabel className="text-muted-foreground">
-          Container path
+          Container path&nbsp;
+          <span className="text-amber-600 dark:text-yellow-500">*</span>
         </FieldSetLabel>
         <FieldSetInput placeholder="ex: /data" />
       </FieldSet>

--- a/frontend/app/routes/services/settings/service-volumes-form.tsx
+++ b/frontend/app/routes/services/settings/service-volumes-form.tsx
@@ -345,16 +345,12 @@ function ServiceVolumeItem({
                 </FieldSet>
 
                 <FieldSet
+                  required
                   name="container_path"
                   className="flex flex-col gap-1.5 flex-1"
                   errors={errors.new_value?.container_path}
                 >
-                  <FieldSetLabel className="text-muted-foreground">
-                    Container path&nbsp;
-                    <span className="text-amber-600 dark:text-yellow-500">
-                      *
-                    </span>
-                  </FieldSetLabel>
+                  <FieldSetLabel>Container path</FieldSetLabel>
                   <FieldSetInput
                     placeholder="ex: /data"
                     defaultValue={container_path}
@@ -365,9 +361,7 @@ function ServiceVolumeItem({
                   errors={errors.new_value?.host_path}
                   className="flex flex-col gap-1.5 flex-1"
                 >
-                  <FieldSetLabel className="text-muted-foreground">
-                    Host path
-                  </FieldSetLabel>
+                  <FieldSetLabel>Host path</FieldSetLabel>
                   <FieldSetInput
                     placeholder="ex: /etc/localtime"
                     defaultValue={host_path ?? ""}
@@ -497,14 +491,12 @@ function NewServiceVolumeForm() {
       </FieldSet>
 
       <FieldSet
+        required
         errors={errors.new_value?.container_path}
         name="container_path"
         className="flex flex-col gap-1.5 flex-1"
       >
-        <FieldSetLabel className="text-muted-foreground">
-          Container path&nbsp;
-          <span className="text-amber-600 dark:text-yellow-500">*</span>
-        </FieldSetLabel>
+        <FieldSetLabel>Container path</FieldSetLabel>
         <FieldSetInput placeholder="ex: /data" />
       </FieldSet>
       <FieldSet
@@ -512,9 +504,7 @@ function NewServiceVolumeForm() {
         errors={errors.new_value?.host_path}
         className="flex flex-col gap-1.5 flex-1"
       >
-        <FieldSetLabel className="text-muted-foreground">
-          Host path
-        </FieldSetLabel>
+        <FieldSetLabel>Host path</FieldSetLabel>
         <FieldSetInput placeholder="ex: /etc/localtime" />
       </FieldSet>
       <FieldSet
@@ -522,7 +512,7 @@ function NewServiceVolumeForm() {
         name="name"
         className="flex flex-col gap-1.5 flex-1"
       >
-        <FieldSetLabel className="text-muted-foreground">Name</FieldSetLabel>
+        <FieldSetLabel>Name</FieldSetLabel>
         <FieldSetInput placeholder="ex: postgresl-data" />
       </FieldSet>
 


### PR DESCRIPTION
## Description

In a recent change I made, the `deploy now` button would redirect incorrectly to a URL with `undefined` in it. So I fixed it.

In this PR, I also made it so that fields that required fields in the settings page are marqued correctly.


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
