### PR TITLE
fix: Occasional 502 Bad Gateway Error on server

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -496,8 +496,6 @@ class ZaneProxyClient:
                 }
             )
 
-        thirty_seconds_in_nano_seconds = 30_000_000_000
-
         if url.redirect_to is not None:
             proxy_handlers.append(
                 {
@@ -522,6 +520,9 @@ class ZaneProxyClient:
                     "prefer": ["gzip"],
                 },
             )
+            # thirty_seconds_in_nano_seconds = 30 * 10**9
+            # one_hour_in_nano_seconds = 3_600 * 10**9
+
             proxy_handlers.append(
                 {
                     "handler": "reverse_proxy",
@@ -583,12 +584,15 @@ class ZaneProxyClient:
                         }
                     ],
                     "flush_interval": -1,
-                    "health_checks": {
-                        "passive": {"fail_duration": thirty_seconds_in_nano_seconds}
-                    },
+                    # "health_checks": {
+                    #     "passive": {
+                    #         "fail_duration": thirty_seconds_in_nano_seconds,
+                    #         "unhealthy_latency": one_hour_in_nano_seconds,
+                    #     }
+                    # },
                     "load_balancing": {
                         "retries": 3,
-                        "selection_policy": {"policy": "first"},
+                        "selection_policy": {"policy": "round_robin"},
                     },
                     "upstreams": [
                         {


### PR DESCRIPTION
## Description

This was difficult to figure out. 
### The bug 

- On production, sometimes, deploments would become unavailable after a certain, returning users `502` errors
- This was because of our load balancing policy which would send request to the old deployment which was already removed instead of sending the request to the current active deployment. 
- The bug is a combination of the load balancing policy which was `first` and the `fail_duration` which was of **30 seconds**. In the span of 30s, if caddy marked our new deployment as unavailable, it would not make any request to that new deployment and instead only make the request to the first upstream, which is referencing the old deployment that have already been cleaned up.
 
### The fix 
- We changed the policy from `first` to `round_robin`, this way caddy would at least switch between upstreams when sending requests to deployments
- We removed the `fail_duration` so that caddy doesn't remember incorrectly the new deployment as unavailable.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
