### PR TITLE
feat: show server limits on the settings page

### DIFF
--- a/frontend/app/routes/deployments/deployment-metrics.tsx
+++ b/frontend/app/routes/deployments/deployment-metrics.tsx
@@ -32,7 +32,7 @@ import { deploymentQueries, metrisSearch, serviceQueries } from "~/lib/queries";
 import { queryClient } from "~/root";
 import {
   convertValueToBytes,
-  format_storage_value,
+  formatStorageValue,
   timeAgoFormatter
 } from "~/utils";
 import type { Route } from "./+types/deployment-metrics";
@@ -254,7 +254,7 @@ export default function DeploymentMetricsPage({
                       )
                     ]}
                     tickFormatter={(value) => {
-                      const { value: value_str, unit } = format_storage_value(
+                      const { value: value_str, unit } = formatStorageValue(
                         Number(value)
                       );
                       // `\u00A0` is a `non breaking space` aka `&nbsp;` TIL !
@@ -291,8 +291,9 @@ export default function DeploymentMetricsPage({
                               minute: "2-digit"
                             }
                           ).format(new Date(payload.bucket_epoch));
-                          const { value: value_str, unit } =
-                            format_storage_value(Number(value));
+                          const { value: value_str, unit } = formatStorageValue(
+                            Number(value)
+                          );
 
                           return (
                             <div className="flex items-start text-sm text-muted-foreground flex-col">
@@ -370,7 +371,7 @@ export default function DeploymentMetricsPage({
                       ) + convertValueToBytes(10, "MEGABYTES")
                     ]}
                     tickFormatter={(value) => {
-                      const { value: value_str, unit } = format_storage_value(
+                      const { value: value_str, unit } = formatStorageValue(
                         Number(value)
                       );
                       // `\u00A0` is a `non breaking space` aka `&nbsp;` TIL !
@@ -407,8 +408,9 @@ export default function DeploymentMetricsPage({
                               minute: "2-digit"
                             }
                           ).format(new Date(item.payload.bucket_epoch));
-                          const { value: value_str, unit } =
-                            format_storage_value(Number(value));
+                          const { value: value_str, unit } = formatStorageValue(
+                            Number(value)
+                          );
 
                           return (
                             <div className="flex items-start text-sm text-muted-foreground flex-col w-full">
@@ -506,7 +508,7 @@ export default function DeploymentMetricsPage({
                       ) + convertValueToBytes(10, "MEGABYTES")
                     ]}
                     tickFormatter={(value) => {
-                      const { value: value_str, unit } = format_storage_value(
+                      const { value: value_str, unit } = formatStorageValue(
                         Number(value)
                       );
                       // `\u00A0` is a `non breaking space` aka `&nbsp;` TIL !
@@ -543,8 +545,9 @@ export default function DeploymentMetricsPage({
                               minute: "2-digit"
                             }
                           ).format(new Date(item.payload.bucket_epoch));
-                          const { value: value_str, unit } =
-                            format_storage_value(Number(value));
+                          const { value: value_str, unit } = formatStorageValue(
+                            Number(value)
+                          );
 
                           return (
                             <div className="flex items-start text-sm text-muted-foreground flex-col w-full">

--- a/frontend/app/routes/services/service-metrics.tsx
+++ b/frontend/app/routes/services/service-metrics.tsx
@@ -32,7 +32,7 @@ import { metrisSearch, serviceQueries } from "~/lib/queries";
 import { queryClient } from "~/root";
 import {
   convertValueToBytes,
-  format_storage_value,
+  formatStorageValue,
   timeAgoFormatter
 } from "~/utils";
 import type { Route } from "./+types/service-metrics";
@@ -245,7 +245,7 @@ export default function ServiceMetricsPage({
                       )
                     ]}
                     tickFormatter={(value) => {
-                      const { value: value_str, unit } = format_storage_value(
+                      const { value: value_str, unit } = formatStorageValue(
                         Number(value)
                       );
                       // `\u00A0` is a `non breaking space` aka `&nbsp;` TIL !
@@ -283,8 +283,9 @@ export default function ServiceMetricsPage({
                               second: "2-digit"
                             }
                           ).format(new Date(payload.bucket_epoch));
-                          const { value: value_str, unit } =
-                            format_storage_value(Number(value));
+                          const { value: value_str, unit } = formatStorageValue(
+                            Number(value)
+                          );
 
                           return (
                             <div className="flex items-start text-sm text-muted-foreground flex-col">
@@ -362,7 +363,7 @@ export default function ServiceMetricsPage({
                       ) + convertValueToBytes(10, "MEGABYTES")
                     ]}
                     tickFormatter={(value) => {
-                      const { value: value_str, unit } = format_storage_value(
+                      const { value: value_str, unit } = formatStorageValue(
                         Number(value)
                       );
                       // `\u00A0` is a `non breaking space` aka `&nbsp;` TIL !
@@ -400,8 +401,9 @@ export default function ServiceMetricsPage({
                               second: "2-digit"
                             }
                           ).format(new Date(item.payload.bucket_epoch));
-                          const { value: value_str, unit } =
-                            format_storage_value(Number(value));
+                          const { value: value_str, unit } = formatStorageValue(
+                            Number(value)
+                          );
 
                           return (
                             <div className="flex items-start text-sm text-muted-foreground flex-col w-full">
@@ -499,7 +501,7 @@ export default function ServiceMetricsPage({
                       ) + convertValueToBytes(10, "MEGABYTES")
                     ]}
                     tickFormatter={(value) => {
-                      const { value: value_str, unit } = format_storage_value(
+                      const { value: value_str, unit } = formatStorageValue(
                         Number(value)
                       );
                       // `\u00A0` is a `non breaking space` aka `&nbsp;` TIL !
@@ -537,8 +539,9 @@ export default function ServiceMetricsPage({
                               second: "2-digit"
                             }
                           ).format(new Date(item.payload.bucket_epoch));
-                          const { value: value_str, unit } =
-                            format_storage_value(Number(value));
+                          const { value: value_str, unit } = formatStorageValue(
+                            Number(value)
+                          );
 
                           return (
                             <div className="flex items-start text-sm text-muted-foreground flex-col w-full">

--- a/frontend/app/routes/services/settings/service-resource-limits-form.tsx
+++ b/frontend/app/routes/services/settings/service-resource-limits-form.tsx
@@ -157,7 +157,7 @@ export function ServiceResourceLimits({
             </div>
             <Slider
               step={0.5}
-              min={0}
+              min={0.1}
               aria-hidden="true"
               value={[cpuLimit ?? resourceLimitsQuery.data?.no_of_cpus ?? 0]}
               disabled={resouceLimitsChange !== undefined}
@@ -169,6 +169,10 @@ export function ServiceResourceLimits({
               }}
               max={resourceLimitsQuery.data?.no_of_cpus}
             />
+            <div className="flex items-center justify-between text-gray-400">
+              <span>0.1</span>
+              <span>{resourceLimitsQuery.data?.no_of_cpus}</span>
+            </div>
           </FieldSet>
           <FieldSet
             name="memory"
@@ -195,6 +199,7 @@ export function ServiceResourceLimits({
                 }}
               />
             </div>
+
             <Slider
               step={100}
               min={0}
@@ -209,6 +214,10 @@ export function ServiceResourceLimits({
               }}
               max={max_memory_in_mb}
             />
+            <div className="flex items-center justify-between text-gray-400">
+              <span>0</span>
+              <span>{max_memory_in_mb}</span>
+            </div>
           </FieldSet>
         </div>
         <div className="flex items-center gap-2 flex-wrap">

--- a/frontend/app/utils.ts
+++ b/frontend/app/utils.ts
@@ -231,7 +231,7 @@ export function metaTitle(title: string) {
   return { title: `${title} | ZaneOps` } as const;
 }
 
-export function format_storage_value(value: number) {
+export function formatStorageValue(value: number) {
   const kb = 1024;
   const mb = 1024 * kb;
   const gb = 1024 * mb;


### PR DESCRIPTION
## Description

This way, the user can easily see what are the values on the slder : 

<img width="911" alt="Screenshot 2025-03-13 at 01 07 37" src="https://github.com/user-attachments/assets/f8758e4d-9447-4ad9-8a06-4927536c4ddd" />


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
