### PR TITLE
refactor: simplify proxy configuration for blue/green deployments

### DIFF
--- a/backend/zane_api/temporal/activities.py
+++ b/backend/zane_api/temporal/activities.py
@@ -1837,7 +1837,7 @@ class DockerSwarmActivities:
                                     full_url,
                                     timeout=min(healthcheck_time_left, 5),
                                 )
-                                if response.status_code == status.HTTP_200_OK:
+                                if status.is_success(response.status_code):
                                     deployment_status = (
                                         DockerDeployment.DeploymentStatus.HEALTHY
                                     )

--- a/backend/zane_api/temporal/schedules/activities.py
+++ b/backend/zane_api/temporal/schedules/activities.py
@@ -318,7 +318,10 @@ class DockerDeploymentStatsActivities:
                 return None
 
             task_list = swarm_service.tasks(
-                filters={"label": f"deployment_hash={details.hash}"}
+                filters={
+                    "label": f"deployment_hash={details.hash}",
+                    "desired-state": "running",
+                }
             )
             if len(task_list) == 0:
                 return None


### PR DESCRIPTION
## Description

This is the last PR for fixing the issue with occasional `502 Bad Gateway` errors. Instead of using load balancing with the blue and green deployment while one of them is down, we simply replace the previous deployment with the new deployment when updating the proxy configuration for the service in production.

In this PR, there are also some other changes : 
- Fixed a bug that sometimes arises in production with service metrics, data would become missing after a long time, this is because we would select the incorrect container for the service. it should only get the metrics of containers for tasks that should be running 
- Changed the health check logic to check for all success status codes, not only `200 OK`

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
