### PR TITLE
feat: show the percentage of CPU usage relative to the number of CPUs of the machine

### DIFF
--- a/frontend/app/routes/services/service-metrics.tsx
+++ b/frontend/app/routes/services/service-metrics.tsx
@@ -79,7 +79,7 @@ export default function ServiceMetricsPage({
   const filters = metrisSearch.parse({
     time_range: searchParams.get("time_range")
   });
-  const { data: metrics } = useQuery({
+  const { data } = useQuery({
     ...serviceQueries.metrics({
       project_slug,
       service_slug,
@@ -88,6 +88,8 @@ export default function ServiceMetricsPage({
     }),
     initialData: loaderData.metrics
   });
+
+  const metrics = data.map((m) => ({ ...m, avg_cpu: m.avg_cpu / 100 }));
 
   return (
     <div className="flex flex-col gap-4 py-4">
@@ -152,7 +154,10 @@ export default function ServiceMetricsPage({
                   <YAxis
                     tickLine={false}
                     axisLine={false}
-                    domain={[0, 100]}
+                    domain={[
+                      0,
+                      service.resource_limits?.cpus ?? limits.no_of_cpus
+                    ]}
                     allowDataOverflow
                     type="number"
                   />
@@ -190,7 +195,9 @@ export default function ServiceMetricsPage({
                               <span>{formattedDate}</span>
                               <div className="ml-auto flex items-baseline gap-0.5 font-mono font-medium tabular-nums text-card-foreground text-sm">
                                 {Number(value).toFixed(2)}
-                                <span className="font-normal text-grey">%</span>
+                                <span className="font-normal text-grey">
+                                  CPUs
+                                </span>
                               </div>
                             </div>
                           );


### PR DESCRIPTION
## Description

I noticed in production, that the CPUs percentage we show in the frontend is limited to 100% and the data can go over 100%, the over 100% is not a bad thing as it is proportional to the number of CPUs of the machine, so 300% out of 100% means 3 CPUs over for ex 4 CPUs :

<img width="1472" alt="Screenshot 2025-03-19 at 02 55 35" src="https://github.com/user-attachments/assets/0813e543-7392-4e0b-85ee-3db58d54ac8b" />

So instead of limiting ourselves to 100%, we will show instead the number of CPUs used out of the whole  :

<img width="1472" alt="Screenshot 2025-03-19 at 03 05 06" src="https://github.com/user-attachments/assets/64fb47cb-ba6c-4389-8574-ec32c472dab2" />


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
