### PR TITLE
🐛 webhook deploy urls should accept an optional trailing slash 

### DIFF
--- a/backend/zane_api/urls.py
+++ b/backend/zane_api/urls.py
@@ -259,12 +259,12 @@ urlpatterns = [
         name="services.regenerate_deploy_token",
     ),
     re_path(
-        r"^deploy-service/docker/(?P<deploy_token>[a-zA-Z0-9-_]+)?$",
+        r"^deploy-service/docker/(?P<deploy_token>[a-zA-Z0-9-_]+)/?$",
         views.WebhookDeployDockerServiceAPIView.as_view(),
         name="services.docker.webhook_deploy",
     ),
     re_path(
-        r"^deploy-service/git/(?P<deploy_token>[a-zA-Z0-9-_]+)?$",
+        r"^deploy-service/git/(?P<deploy_token>[a-zA-Z0-9-_]+)/?$",
         views.WebhookDeployGitServiceAPIView.as_view(),
         name="services.git.webhook_deploy",
     ),


### PR DESCRIPTION
## Description

The webhook deploy URL regex wasn't correct, making it only work without a trailing slash. 


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
