### PR TITLE
fix: various bug fixes related to nixpacks builder

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.7-slim
 
-RUN apt update && apt install -y git gcc python3-dev curl htop
+RUN apt update && apt install -y git gcc python3-dev curl
 RUN curl -sSL https://nixpacks.com/install.sh | bash
 RUN curl -fsSL https://get.docker.com | sh
 

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11.7-slim
 
-RUN apt update && apt install -y git gcc python3-dev curl
+RUN apt update && apt install -y git gcc python3-dev curl htop
 RUN curl -sSL https://nixpacks.com/install.sh | bash
 RUN curl -fsSL https://get.docker.com | sh
 

--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -73,7 +73,7 @@ ALLOWED_HOSTS = (
         "host.docker.internal",
     ]
     if ENVIRONMENT != PRODUCTION_ENV
-    else ["127.0.0.1", f".{ROOT_DOMAIN}", ".zaneops.internal"]
+    else ["127.0.0.1", f".{ROOT_DOMAIN}", f".{ZANE_APP_DOMAIN}", ".zaneops.internal"]
 )
 
 SESSION_COOKIE_DOMAIN = None

--- a/backend/zane_api/git_client.py
+++ b/backend/zane_api/git_client.py
@@ -71,6 +71,9 @@ class GitClient:
         cancel_event: asyncio.Event,
     ) -> Repo:
         git_clone_command = f"/usr/bin/git clone --progress --single-branch --branch {branch} {url} {dest_path}"
+        await message_handler(
+            f"Running {Colors.YELLOW}{git_clone_command}{Colors.ENDC}"
+        )
         runner = AyncSubProcessRunner(
             command=git_clone_command,
             cancel_event=cancel_event,

--- a/backend/zane_api/git_client.py
+++ b/backend/zane_api/git_client.py
@@ -1,8 +1,8 @@
-from typing import Awaitable, Callable, Optional, Protocol
+from typing import Callable, Optional
 from git import Git, GitCommandError, RemoteProgress, Repo, Commit
 import asyncio
-from .utils import Colors, read_until
-from threading import Event
+from .utils import Colors
+from .process import AyncSubProcessRunner, OutputHandlerFunction
 
 
 class GitCloneFailedError(GitCommandError):
@@ -11,10 +11,6 @@ class GitCloneFailedError(GitCommandError):
 
 class GitCheckoutFailedError(GitCommandError):
     pass
-
-
-class MessageHandlerType(Protocol):
-    def __call__(self, message: str, error: bool = False) -> Awaitable[None]: ...
 
 
 class GitClient:
@@ -71,88 +67,20 @@ class GitClient:
         url: str,
         dest_path: str,
         branch: str,
-        message_handler: MessageHandlerType,
-        cancel_event: Optional[Event] = None,
+        message_handler: OutputHandlerFunction,
+        cancel_event: asyncio.Event,
     ) -> Repo:
         git_clone_command = f"/usr/bin/git clone --progress --single-branch --branch {branch} {url} {dest_path}"
-        await message_handler(
-            f"Running {Colors.YELLOW}{git_clone_command}{Colors.ENDC}"
+        runner = AyncSubProcessRunner(
+            command=git_clone_command,
+            cancel_event=cancel_event,
+            operation_name="git clone",
+            output_handler=message_handler,
         )
-        process = await asyncio.create_subprocess_shell(
-            git_clone_command,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.STDOUT,
+        exit_code, _ = await runner.run()
+        print(
+            f"Process finished with exit_code={Colors.ORANGE}{exit_code}{Colors.ENDC}"
         )
-
-        while True:
-
-            async def wait_for_cancel_event():
-                if cancel_event is None:
-                    return
-
-                while not cancel_event.is_set():
-                    await asyncio.sleep(0.05)
-
-            async def read_streams(
-                stdout: asyncio.StreamReader | None,
-                stderr: asyncio.StreamReader | None,
-            ):
-
-                async def read_stream(stream: asyncio.StreamReader | None):
-                    return await read_until(stream, [b"\r", b"\n"]) if stream else None
-
-                return await asyncio.gather(
-                    read_stream(stdout),
-                    read_stream(stderr),
-                )
-
-            read_streams_task = asyncio.create_task(
-                read_streams(process.stdout, process.stderr)
-            )
-            cancel_task = asyncio.create_task(wait_for_cancel_event())
-            try:
-                done, _ = await asyncio.wait(
-                    [read_streams_task, cancel_task],
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                if read_streams_task in done:
-                    stdout, stderr = await read_streams_task
-                    cancel_task.cancel()
-                else:
-                    if cancel_event and cancel_event.is_set():
-                        process.terminate()
-                        read_streams_task.cancel()
-                        SIGTERM_EXIT_CODE = 130  # process ended by ctrl+c
-
-                        print(
-                            f"{Colors.RED}Received cancel_event: {cancel_event} {Colors.ENDC}"
-                        )
-                        await message_handler(
-                            f"{Colors.YELLOW}git clone{Colors.ENDC} operation cancelled with exit code: {Colors.RED}{SIGTERM_EXIT_CODE}{Colors.ENDC}."
-                        )
-                        raise GitCloneFailedError(git_clone_command, SIGTERM_EXIT_CODE)
-                    else:
-                        stdout, stderr = await read_streams_task
-            except asyncio.CancelledError:
-                raise GitCloneFailedError(git_clone_command, 128)
-
-            try:
-                if stdout or stderr:
-                    if stdout:
-                        await message_handler(stdout.decode().rstrip())
-                    if stderr:
-                        await message_handler(stderr.decode().rstrip(), error=True)
-                else:
-                    print("Reached EOF")
-                    break
-            except asyncio.IncompleteReadError as e:
-                if e.partial:
-                    await message_handler(e.partial.decode().rstrip())
-                break
-
-        print("Waiting for process to complete...")
-        exit_code = await process.wait()
-        print(f"Process finished with {Colors.ORANGE}{exit_code=}{Colors.ENDC}")
         if exit_code != 0:
             raise GitCloneFailedError(git_clone_command, exit_code)
         else:

--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -835,7 +835,7 @@ class BaseDeployment(models.Model):
 
 
 class Deployment(BaseDeployment):
-    environment_id: str
+    service_id: str
     HASH_PREFIX = "dpl_dkr_"
     urls = Manager["DeploymentURL"]
     changes = Manager["DeploymentChange"]

--- a/backend/zane_api/models/base.py
+++ b/backend/zane_api/models/base.py
@@ -414,9 +414,15 @@ class Service(BaseService):
     def latest_production_deployment(self):
         return (
             self.deployments.filter(is_current_production=True)
-            .select_related("service", "service__project")
+            .select_related(
+                "service",
+                "service__project",
+                "service__environment",
+                "service__healthcheck",
+            )
             .prefetch_related(
                 "service__volumes",
+                "service__configs",
                 "service__urls",
                 "service__ports",
                 "service__env_variables",

--- a/backend/zane_api/process.py
+++ b/backend/zane_api/process.py
@@ -5,7 +5,6 @@ from asyncio.subprocess import Process
 from .utils import Colors
 
 
-# from .utils import Colors, async_noop
 async def async_noop():
     """This function does nothing"""
     ...

--- a/backend/zane_api/process.py
+++ b/backend/zane_api/process.py
@@ -1,0 +1,129 @@
+import asyncio
+import os
+import signal
+from typing import Any, Awaitable, Optional, Protocol, Tuple
+from asyncio.subprocess import Process
+from .utils import Colors, async_noop
+
+
+class OutputHandlerFunction(Protocol):
+    async def __call__(self, message: str, error: bool = False) -> Any: ...
+
+
+class AyncSubProcessRunner:
+    SIGTERM_EXIT_CODE = 130
+
+    def __init__(
+        self,
+        command: str,
+        cancel_event: Optional[asyncio.Event],
+        output_handler: OutputHandlerFunction,
+        operation_name: str,
+    ):
+        self.command = command
+        self.cancel_event = cancel_event
+        self.output_handler = output_handler
+        self.operation_name = operation_name
+        self.result: Any = None
+
+    async def run(self) -> Tuple[int, Optional[Any]]:
+        process = await asyncio.create_subprocess_shell(
+            self.command,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            preexec_fn=os.setsid,  # set session ID
+        )
+
+        try:
+            while True:
+                if await self._process_output(process):
+                    break
+        except asyncio.CancelledError:
+            await self._terminate(process)
+            raise
+        finally:
+            if self.exit_code is None:
+                self.exit_code = await process.wait()
+
+        return (self.exit_code, self.result)
+
+    @staticmethod
+    async def _read_until(stream: asyncio.StreamReader, delimiters: list[bytes]):
+        """
+        Custom replacement for `asyncio.StreamReader.readuntil`
+        accepting multiple delimiters instead of one.
+        Plus it doesn't throw an error if the end data doesn't have
+        the delimiter character.
+        """
+        buffer = bytearray()
+        while True:
+            character = await stream.read(1)
+            if not character:
+                break
+            buffer.extend(character)
+            if character in delimiters:
+                break
+        return bytes(buffer)
+
+    async def _read_stream(self, stream: asyncio.StreamReader | None):
+        """Default stream reader implementation"""
+        return (
+            await self._read_until(stream, delimiters=[b"\r", b"\n"])
+            if stream
+            else None
+        )
+
+    async def _read_process_output(self, process: Process):
+        return await asyncio.gather(
+            self._read_stream(process.stdout),
+            self._read_stream(process.stderr),
+        )
+
+    async def _process_output(self, process: Process) -> bool:
+        """Returns True if EOF reached or cancellation requested"""
+        read_streams_task = asyncio.create_task(self._read_process_output(process))
+
+        cancel_task = asyncio.create_task(
+            self.cancel_event.wait() if self.cancel_event else async_noop()
+        )
+
+        done, _ = await asyncio.wait(
+            [read_streams_task, cancel_task], return_when=asyncio.FIRST_COMPLETED
+        )
+
+        if read_streams_task in done:
+            stdout, stderr = await read_streams_task
+            cancel_task.cancel()
+        else:
+            if self.cancel_event and self.cancel_event.is_set():
+                await self._terminate(process)
+                read_streams_task.cancel()
+
+                print(
+                    f"{Colors.RED}Received cancel_event: {self.cancel_event} {Colors.ENDC}"
+                )
+                await self.output_handler(
+                    f"{Colors.YELLOW}{self.operation_name}{Colors.ENDC} operation cancelled."
+                )
+                return True
+            else:
+                stdout, stderr = await read_streams_task
+
+        if stdout or stderr:
+            if stdout:
+                result = await self.output_handler(stdout.decode().rstrip())
+                if result is not None:
+                    self.result = result
+            if stderr:
+                await self.output_handler(stderr.decode().rstrip(), error=True)
+        else:
+            print("Reached EOF")
+            return True
+
+        return False
+
+    async def _terminate(self, process: Process) -> None:
+        if process.returncode is None:
+            process.terminate()
+            os.killpg(os.getpgid(process.pid), signal.SIGTERM)
+            self.exit_code = await process.wait()

--- a/backend/zane_api/process.py
+++ b/backend/zane_api/process.py
@@ -1,4 +1,5 @@
 import asyncio
+import shlex
 from typing import Any, Optional, Protocol, Tuple
 from asyncio.subprocess import Process
 
@@ -49,11 +50,8 @@ class AyncSubProcessRunner:
         self.exit_code: Optional[int] = None
 
     async def run(self) -> Tuple[int | None, Optional[Any]]:
-        print(
-            f"Running process shell with command {Colors.YELLOW}{self.command}{Colors.ENDC}"
-        )
         process = await asyncio.create_subprocess_exec(
-            *self.command.split(" "),
+            *shlex.split(self.command),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
         )

--- a/backend/zane_api/temporal/activities/git_activities.py
+++ b/backend/zane_api/temporal/activities/git_activities.py
@@ -453,11 +453,14 @@ class GitActivities:
 
                 command = multiline_command(" ".join(cmd_lines))
                 log_message = f"Running {Colors.YELLOW}{command}{Colors.ENDC}"
-                await deployment_log(
-                    deployment=deployment,
-                    message=log_message.splitlines(),
-                    source=RuntimeLogSource.BUILD,
-                )
+                for index, msg in enumerate(log_message.splitlines()):
+                    await deployment_log(
+                        deployment=deployment,
+                        message=(
+                            f"{Colors.YELLOW}{msg}{Colors.ENDC}" if index > 0 else msg
+                        ),
+                        source=RuntimeLogSource.BUILD,
+                    )
 
                 def build_image_with_docker_py():
                     build_output = self.docker_client.api.build(
@@ -755,11 +758,12 @@ class GitActivities:
         # Log executed command with all args
         cmd_string = multiline_command(" ".join(nixpacks_plan_command_args))
         log_message = f"Running {Colors.YELLOW}{cmd_string}{Colors.ENDC}"
-        await deployment_log(
-            deployment=deployment,
-            message=log_message.splitlines(),
-            source=RuntimeLogSource.BUILD,
-        )
+        for index, msg in enumerate(log_message.splitlines()):
+            await deployment_log(
+                deployment=deployment,
+                message=(f"{Colors.YELLOW}{msg}{Colors.ENDC}" if index > 0 else msg),
+                source=RuntimeLogSource.BUILD,
+            )
 
         # Execute process
         with open(nixpacks_plan_path, "w") as file:
@@ -810,11 +814,13 @@ class GitActivities:
         # Log executed command with all args
         cmd_string = multiline_command(" ".join(nixpacks_build_command_args))
         log_message = f"Running {Colors.YELLOW}{cmd_string}{Colors.ENDC}"
-        await deployment_log(
-            deployment=deployment,
-            message=log_message.splitlines(),
-            source=RuntimeLogSource.BUILD,
-        )
+        for index, msg in enumerate(log_message.splitlines()):
+            await deployment_log(
+                deployment=deployment,
+                message=(f"{Colors.YELLOW}{msg}{Colors.ENDC}" if index > 0 else msg),
+                source=RuntimeLogSource.BUILD,
+            )
+
         process = await asyncio.create_subprocess_exec(
             *nixpacks_build_command_args,
             stdout=asyncio.subprocess.PIPE,

--- a/backend/zane_api/temporal/activities/main_activities.py
+++ b/backend/zane_api/temporal/activities/main_activities.py
@@ -1,8 +1,7 @@
 import asyncio
 import json
 from datetime import timedelta
-import re
-from typing import Any, Coroutine, List, Optional, TypedDict
+from typing import Any, Coroutine, List, Optional
 
 from rest_framework import status
 from temporalio import activity, workflow
@@ -63,7 +62,6 @@ with workflow.unsafe.imports_passed_through():
         get_docker_client,
         get_config_resource_name,
         get_env_network_resource_name,
-        get_network_resource_name,
         get_resource_labels,
         get_swarm_service_name_for_deployment,
         get_volume_resource_name,
@@ -516,13 +514,15 @@ class DockerSwarmActivities:
                 deployment,
                 f"Preparing deployment {Colors.ORANGE}{deployment.hash}{Colors.ENDC}...",
             )
-            docker_deployment: Deployment = await Deployment.objects.aget(
-                hash=deployment.hash, service_id=deployment.service.id
+            await Deployment.objects.filter(
+                hash=deployment.hash,
+                service_id=deployment.service.id,
+                status=Deployment.DeploymentStatus.QUEUED,
+            ).aupdate(
+                status=Deployment.DeploymentStatus.PREPARING,
+                started_at=timezone.now(),
             )
-            if docker_deployment.status == Deployment.DeploymentStatus.QUEUED:
-                docker_deployment.status = Deployment.DeploymentStatus.PREPARING
-                docker_deployment.started_at = timezone.now()
-                await docker_deployment.asave()
+
         except Deployment.DoesNotExist:
             raise ApplicationError(
                 "Cannot execute a deploy on a non existent deployment.",
@@ -558,21 +558,15 @@ class DockerSwarmActivities:
         self, healthcheck_result: DeploymentHealthcheckResult
     ) -> tuple[str, str]:
         try:
-            deployment = (
-                await Deployment.objects.filter(hash=healthcheck_result.deployment_hash)
-                .select_related("service")
-                .afirst()
-            )
-
-            if deployment is None:
-                raise Deployment.DoesNotExist(
-                    f"Docker deployment with hash='{healthcheck_result.deployment_hash}' does not exist."
-                )
+            new_deployment_query = Deployment.objects.filter(
+                hash=healthcheck_result.deployment_hash
+            ).select_related("service")
+            deployment = await new_deployment_query.aget()
 
             deployment.status_reason = healthcheck_result.reason
             if (
                 healthcheck_result.status == Deployment.DeploymentStatus.HEALTHY
-                or await deployment.service.deployments.acount() == 1  # type: ignore
+                or await deployment.service.deployments.acount() == 1
             ):
                 deployment.is_current_production = True
 
@@ -583,13 +577,18 @@ class DockerSwarmActivities:
             )
 
             deployment.finished_at = timezone.now()
-            await deployment.asave()
+            await new_deployment_query.aupdate(
+                finished_at=deployment.finished_at,
+                status_reason=deployment.status_reason,
+                is_current_production=deployment.is_current_production,
+                status=deployment.status,
+            )
 
             if deployment.is_current_production:
-                await deployment.service.deployments.filter(  # type: ignore
+                await deployment.service.deployments.filter(
                     ~Q(hash=healthcheck_result.deployment_hash)
                 ).aupdate(is_current_production=False)
-                await deployment.service.deployments.filter(  # type: ignore
+                await deployment.service.deployments.filter(
                     ~Q(hash=healthcheck_result.deployment_hash)
                     & Q(
                         status__in=[
@@ -668,24 +667,25 @@ class DockerSwarmActivities:
 
     @activity.defn
     async def get_previous_queued_deployment(self, deployment: DeploymentDetails):
-        next_deployment = (
-            await Deployment.objects.filter(
+        next_deployment_query = (
+            Deployment.objects.filter(
                 Q(service_id=deployment.service.id)
                 & Q(status=Deployment.DeploymentStatus.QUEUED)
             )
             .select_related("service", "service__environment")
             .order_by("queued_at")
-            .afirst()
         )
+        next_deployment = await next_deployment_query.afirst()
 
         if next_deployment is not None:
             latest_deployment = (
                 await next_deployment.service.alatest_production_deployment
             )
+
             next_deployment.slot = Deployment.get_next_deployment_slot(
                 latest_deployment
             )
-            await next_deployment.asave()
+            await next_deployment_query.aupdate(slot=next_deployment.slot)
 
             return await DeploymentDetails.afrom_deployment(deployment=next_deployment)
         return None
@@ -943,7 +943,7 @@ class DockerSwarmActivities:
 
             await wait_for_service_to_be_down()
             # Change the status to be accurate
-            docker_deployment = (
+            service_deployment = (
                 await Deployment.objects.filter(
                     hash=deployment.hash, service_id=deployment.service_id
                 )
@@ -951,28 +951,30 @@ class DockerSwarmActivities:
                 .afirst()
             )
 
-            if docker_deployment is not None:
+            if service_deployment is not None:
                 try:
                     await asyncio.gather(
                         pause_schedule(
-                            id=docker_deployment.monitor_schedule_id,
+                            id=service_deployment.monitor_schedule_id,
                             note="Paused to prevent zero-downtime deployment",
                         ),
                         pause_schedule(
-                            id=docker_deployment.metrics_schedule_id,
+                            id=service_deployment.metrics_schedule_id,
                             note="Paused to prevent zero-downtime deployment",
                         ),
                     )
-                    print(f"Paused schedule {docker_deployment.monitor_schedule_id=}")
+                    print(f"Paused schedule {service_deployment.monitor_schedule_id=}")
                 except RPCError:
                     print(
-                        f"Error pausing schedule {docker_deployment.monitor_schedule_id=}"
+                        f"Error pausing schedule {service_deployment.monitor_schedule_id=}"
                     )
                     # The schedule probably doesn't exist
                     pass
                 finally:
-                    docker_deployment.status = Deployment.DeploymentStatus.SLEEPING
-                    await docker_deployment.asave()
+                    await Deployment.objects.filter(
+                        hash=service_deployment.hash,
+                        service_id=service_deployment.service_id,
+                    ).aupdate(status=Deployment.DeploymentStatus.SLEEPING)
 
     @activity.defn
     async def scale_back_service_deployment(self, deployment: SimpleDeploymentDetails):
@@ -1010,7 +1012,7 @@ class DockerSwarmActivities:
             swarm_service.update(**update_attributes)
 
             # Change back the status to be accurate
-            docker_deployment: Deployment | None = (
+            service_deployment: Deployment | None = (
                 await Deployment.objects.filter(
                     Q(hash=deployment.hash)
                     & Q(service_id=deployment.service_id)
@@ -1020,12 +1022,14 @@ class DockerSwarmActivities:
                 .afirst()
             )
 
-            if docker_deployment is not None:
-                docker_deployment.status = Deployment.DeploymentStatus.STARTING
-                await docker_deployment.asave()
+            if service_deployment is not None:
+                await Deployment.objects.filter(
+                    hash=service_deployment.hash,
+                    service_id=service_deployment.service_id,
+                ).aupdate(status=Deployment.DeploymentStatus.SLEEPING)
                 try:
                     await unpause_schedule(
-                        id=docker_deployment.monitor_schedule_id,
+                        id=service_deployment.monitor_schedule_id,
                         note="Unpaused due to failed healthcheck",
                     )
                 except RPCError:
@@ -1269,7 +1273,7 @@ class DockerSwarmActivities:
         self,
         deployment: DeploymentDetails,
     ) -> tuple[Deployment.DeploymentStatus, str]:
-        docker_deployment = (
+        service_deployment = (
             await Deployment.objects.filter(
                 hash=deployment.hash, service_id=deployment.service.id
             )
@@ -1277,7 +1281,7 @@ class DockerSwarmActivities:
             .afirst()
         )
 
-        if docker_deployment is None:
+        if service_deployment is None:
             raise ApplicationError(
                 "Cannot check a status of a non existent deployment.",
                 non_retryable=True,
@@ -1285,14 +1289,14 @@ class DockerSwarmActivities:
 
         swarm_service = self.docker_client.services.get(
             get_swarm_service_name_for_deployment(
-                deployment_hash=docker_deployment.hash,
-                project_id=docker_deployment.service.project.id,
-                service_id=docker_deployment.service.id,
+                deployment_hash=service_deployment.hash,
+                project_id=service_deployment.service.project.id,
+                service_id=service_deployment.service.id,
             )
         )
 
         start_time = monotonic()
-        healthcheck = docker_deployment.service.healthcheck
+        healthcheck = service_deployment.service.healthcheck
 
         healthcheck_timeout = (
             healthcheck.timeout_seconds
@@ -1314,14 +1318,14 @@ class DockerSwarmActivities:
 
             await deployment_log(
                 deployment,
-                f"Healthcheck for deployment {Colors.ORANGE}{docker_deployment.hash}{Colors.ENDC}"
+                f"Healthcheck for deployment {Colors.ORANGE}{service_deployment.hash}{Colors.ENDC}"
                 f" | {Colors.BLUE}ATTEMPT #{healthcheck_attempts}{Colors.ENDC}"
                 f" | healthcheck_time_left={Colors.ORANGE}{format_seconds(healthcheck_time_left)}{Colors.ENDC} 💓",
             )
 
             task_list = swarm_service.tasks(
                 filters={
-                    "label": f"deployment_hash={docker_deployment.hash}",
+                    "label": f"deployment_hash={service_deployment.hash}",
                     "desired-state": "running",
                 }
             )
@@ -1360,7 +1364,7 @@ class DockerSwarmActivities:
 
                 all_tasks = swarm_service.tasks(
                     filters={
-                        "label": f"deployment_hash={docker_deployment.hash}",
+                        "label": f"deployment_hash={service_deployment.hash}",
                     }
                 )
                 if deployment_status == Deployment.DeploymentStatus.STARTING:
@@ -1368,8 +1372,10 @@ class DockerSwarmActivities:
                     if len(all_tasks) > 1:
                         deployment_status = Deployment.DeploymentStatus.RESTARTING
 
-                    docker_deployment.status = deployment_status
-                    await docker_deployment.asave()
+                    service_deployment.status = deployment_status
+                    await Deployment.objects.filter(
+                        hash=deployment.hash, service_id=deployment.service.id
+                    ).aupdate(status=deployment_status)
 
                 deployment_status_reason = (
                     most_recent_swarm_task.Status.Err
@@ -1447,14 +1453,14 @@ class DockerSwarmActivities:
                     )
                     await deployment_log(
                         deployment,
-                        f"Healthcheck for deployment {Colors.ORANGE}{docker_deployment.hash}{Colors.ENDC}"
+                        f"Healthcheck for deployment {Colors.ORANGE}{service_deployment.hash}{Colors.ENDC}"
                         f" | {Colors.BLUE}ATTEMPT #{healthcheck_attempts}{Colors.ENDC} "
                         f"| finished with result : {Colors.GREY}{deployment_status_reason}{Colors.ENDC}",
                         error=status_color == Colors.RED,
                     )
                     await deployment_log(
                         deployment,
-                        f"Healthcheck for deployment {Colors.ORANGE}{docker_deployment.hash}{Colors.ENDC}"
+                        f"Healthcheck for deployment {Colors.ORANGE}{service_deployment.hash}{Colors.ENDC}"
                         f" | {Colors.BLUE}ATTEMPT #{healthcheck_attempts}{Colors.ENDC} "
                         f"| finished with status {status_color}{deployment_status}{Colors.ENDC}",
                         error=status_color == Colors.RED,
@@ -1463,14 +1469,14 @@ class DockerSwarmActivities:
 
             await deployment_log(
                 deployment,
-                f"Healthcheck for deployment {Colors.ORANGE}{docker_deployment.hash}{Colors.ENDC}"
+                f"Healthcheck for deployment {Colors.ORANGE}{service_deployment.hash}{Colors.ENDC}"
                 f" | {Colors.BLUE}ATTEMPT #{healthcheck_attempts}{Colors.ENDC} "
                 f"| finished with result : {Colors.GREY}{deployment_status_reason}{Colors.ENDC}",
                 error=True,
             )
             await deployment_log(
                 deployment,
-                f"Healthcheck for deployment deployment {Colors.ORANGE}{docker_deployment.hash}{Colors.ENDC}"
+                f"Healthcheck for deployment deployment {Colors.ORANGE}{service_deployment.hash}{Colors.ENDC}"
                 f" | {Colors.BLUE}ATTEMPT #{healthcheck_attempts}{Colors.ENDC} "
                 f"| FAILED, Retrying in {Colors.ORANGE}{format_seconds(settings.DEFAULT_HEALTHCHECK_WAIT_INTERVAL)}{Colors.ENDC} 🔄",
                 error=True,
@@ -1484,13 +1490,13 @@ class DockerSwarmActivities:
         )
         await deployment_log(
             deployment,
-            f"Healthcheck for deployment {Colors.ORANGE}{docker_deployment.hash}{Colors.ENDC}"
+            f"Healthcheck for deployment {Colors.ORANGE}{service_deployment.hash}{Colors.ENDC}"
             f" | {Colors.BLUE}ATTEMPT #{healthcheck_attempts}{Colors.ENDC} "
             f"| finished with result : {Colors.GREY}{deployment_status_reason}{Colors.ENDC} ✅",
         )
         await deployment_log(
             deployment,
-            f"Healthcheck for deployment {Colors.ORANGE}{docker_deployment.hash}{Colors.ENDC}"
+            f"Healthcheck for deployment {Colors.ORANGE}{service_deployment.hash}{Colors.ENDC}"
             f" | {Colors.BLUE}ATTEMPT #{healthcheck_attempts}{Colors.ENDC} "
             f"| finished with status {status_color}{deployment_status}{Colors.ENDC} ✅",
         )

--- a/backend/zane_api/temporal/activities/main_activities.py
+++ b/backend/zane_api/temporal/activities/main_activities.py
@@ -144,12 +144,7 @@ class SystemCleanupActivities:
 
     @activity.defn
     async def cleanup_images(self) -> dict:
-        return self.docker_client.images.prune(
-            filters={
-                "dangling": False,
-                "label!": ["zane-managed"],
-            }
-        )
+        return self.docker_client.images.prune(filters={"dangling": True})
 
     @activity.defn
     async def cleanup_volumes(self) -> dict:

--- a/backend/zane_api/temporal/activities/main_activities.py
+++ b/backend/zane_api/temporal/activities/main_activities.py
@@ -48,7 +48,7 @@ with workflow.unsafe.imports_passed_through():
     from time import monotonic
     from django.db.models import Q, Case, When, Value, F
     from ...utils import (
-        find_item_in_list,
+        find_item_in_sequence,
         format_seconds,
         DockerSwarmTask,
         DockerSwarmTaskState,
@@ -1150,7 +1150,7 @@ class DockerSwarmActivities:
 
             for volume in service.docker_volumes:
                 # Only include volumes that will not be deleted
-                docker_volume = find_item_in_list(
+                docker_volume = find_item_in_sequence(
                     lambda v: v.name == get_volume_resource_name(volume.id),  # type: ignore
                     docker_volume_list,
                 )
@@ -1177,7 +1177,7 @@ class DockerSwarmActivities:
             )
             for config in service.configs:
                 # Only include configs that will not be deleted
-                docker_config = find_item_in_list(
+                docker_config = find_item_in_sequence(
                     lambda v: v.name
                     == get_config_resource_name(config.id, config.version),  # type: ignore
                     docker_config_list,

--- a/backend/zane_api/temporal/activities/main_activities.py
+++ b/backend/zane_api/temporal/activities/main_activities.py
@@ -144,7 +144,12 @@ class SystemCleanupActivities:
 
     @activity.defn
     async def cleanup_images(self) -> dict:
-        return self.docker_client.images.prune(filters={"dangling": True})
+        return self.docker_client.images.prune(
+            filters={
+                "dangling": True,
+                "label!": ["zane-managed"],
+            }
+        )
 
     @activity.defn
     async def cleanup_volumes(self) -> dict:

--- a/backend/zane_api/temporal/constants.py
+++ b/backend/zane_api/temporal/constants.py
@@ -52,3 +52,6 @@ VOLUME_SIZE_COMMAND = "sh -c 'df -B1 /mnt | tail -1 | awk \"{{print \\$2}}\"'"
 ONE_HOUR = 3600  # seconds
 
 REPOSITORY_CLONE_LOCATION = "repo"
+
+NIXPACKS_BINARY_LOCATION = "/usr/local/bin/nixpacks"
+DOCKER_BINARY_LOCATION = "/usr/bin/docker"

--- a/backend/zane_api/temporal/constants.py
+++ b/backend/zane_api/temporal/constants.py
@@ -53,5 +53,5 @@ ONE_HOUR = 3600  # seconds
 
 REPOSITORY_CLONE_LOCATION = "repo"
 
-NIXPACKS_BINARY_LOCATION = "/usr/local/bin/nixpacks"
-DOCKER_BINARY_LOCATION = "/usr/bin/docker"
+NIXPACKS_BINARY_PATH = "/usr/local/bin/nixpacks"
+DOCKER_BINARY_PATH = "/usr/bin/docker"

--- a/backend/zane_api/temporal/helpers.py
+++ b/backend/zane_api/temporal/helpers.py
@@ -10,7 +10,7 @@ from ..models import (
 )
 from ..utils import (
     strip_slash_if_exists,
-    find_item_in_list,
+    find_item_in_sequence,
     cache_result,
     excerpt,
     escape_ansi,
@@ -542,7 +542,7 @@ class ZaneProxyClient:
 
             # if the domain doesn't exist we create the config for the domain
             if response.status_code == status.HTTP_404_NOT_FOUND:
-                deployment_url = find_item_in_list(
+                deployment_url = find_item_in_sequence(
                     lambda u: u.domain == url.domain, deployment.urls
                 )
                 if deployment_url is not None:

--- a/backend/zane_api/temporal/helpers.py
+++ b/backend/zane_api/temporal/helpers.py
@@ -249,17 +249,6 @@ class ZaneProxyClient:
     MAX_ETAG_ATTEMPTS = 3
 
     @classmethod
-    def get_service(cls):
-        client = get_docker_client()
-
-        services_list = client.services.list(filters={"label": ["zane.role=proxy"]})
-
-        if len(services_list) == 0:
-            raise docker.errors.NotFound("Proxy Service is not up")
-        proxy_service = services_list[0]
-        return proxy_service
-
-    @classmethod
     def _get_id_for_deployment(cls, deployment_hash: str, domain: str):
         return f"{deployment_hash}-{domain}"
 

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -19,6 +19,7 @@ from ..dtos import (
     StaticDirectoryBuilderOptions,
     NixpacksDirectoryBuilderOptions,
     DockerfileBuilderOptions,
+    EnvVariableDto,
 )
 
 
@@ -54,6 +55,7 @@ class GitBuildDetails:
     build_context_dir: str
     image_tag: str
     build_stage_target: Optional[str] = None
+    default_env_variables: List[EnvVariableDto] | None = None
 
 
 @dataclass
@@ -99,6 +101,7 @@ class NixpacksBuilderGeneratedResult:
     dockerfile_contents: str
     caddyfile_path: Optional[str] = None
     caddyfile_contents: Optional[str] = None
+    variables: List[EnvVariableDto] = field(default_factory=list)
 
 
 @dataclass

--- a/backend/zane_api/temporal/shared.py
+++ b/backend/zane_api/temporal/shared.py
@@ -99,6 +99,7 @@ class NixpacksBuilderGeneratedResult:
     build_context_dir: str
     dockerfile_path: str
     dockerfile_contents: str
+    nixpacks_plan_contents: dict
     caddyfile_path: Optional[str] = None
     caddyfile_contents: Optional[str] = None
     variables: List[EnvVariableDto] = field(default_factory=list)

--- a/backend/zane_api/temporal/worker.py
+++ b/backend/zane_api/temporal/worker.py
@@ -59,6 +59,7 @@ async def run_worker():
     client = await Client.connect(
         settings.TEMPORALIO_SERVER_URL,
         namespace=settings.TEMPORALIO_WORKER_NAMESPACE,
+        keep_alive_config=KeepAliveConfig(timeout_millis=120_000),
     )
     print(f"worker connected ✅")
     worker = Worker(

--- a/backend/zane_api/temporal/worker.py
+++ b/backend/zane_api/temporal/worker.py
@@ -59,7 +59,6 @@ async def run_worker():
     client = await Client.connect(
         settings.TEMPORALIO_SERVER_URL,
         namespace=settings.TEMPORALIO_WORKER_NAMESPACE,
-        keep_alive_config=KeepAliveConfig(timeout_millis=120_000),
     )
     print(f"worker connected ✅")
     worker = Worker(

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -1087,13 +1087,6 @@ class DeployGitServiceWorkflow:
                         start_to_close_timeout=timedelta(seconds=30),
                         retry_policy=self.retry_policy,
                     )
-                if self.image_built is not None:
-                    await workflow.execute_activity_method(
-                        GitActivities.cleanup_built_image,
-                        self.image_built,
-                        start_to_close_timeout=timedelta(seconds=30),
-                        retry_policy=self.retry_policy,
-                    )
 
             final_deployment_status, reason = await workflow.execute_activity_method(
                 DockerSwarmActivities.finish_and_save_deployment,
@@ -1597,7 +1590,6 @@ def get_workflows_and_activities():
             git_activities.clone_repository_and_checkout_to_commit,
             git_activities.update_deployment_commit_message_and_author,
             git_activities.build_service_with_dockerfile,
-            git_activities.cleanup_built_image,
             git_activities.generate_default_files_for_dockerfile_builder,
             git_activities.generate_default_files_for_static_builder,
             git_activities.generate_default_files_for_nixpacks_builder,

--- a/backend/zane_api/temporal/workflows.py
+++ b/backend/zane_api/temporal/workflows.py
@@ -192,7 +192,7 @@ class DeployDockerServiceWorkflow:
 
         async def check_for_cancellation(
             last_completed_step: DockerDeploymentStep,
-        ):
+        ) -> bool:
             """
             This function allows us to pause and potentially bypass the workflow's execution
             during testing. It is useful for stopping the workflow at specific points to
@@ -225,7 +225,7 @@ class DeployDockerServiceWorkflow:
                 print(
                     f"result check_for_cancellation({pause_at_step=}, {last_completed_step=}) = {self.cancellation_requested}"
                 )
-            return self.cancellation_requested
+            return self.cancellation_requested == deployment.hash
 
         try:
             await workflow.execute_activity_method(
@@ -659,7 +659,7 @@ class DeployGitServiceWorkflow:
 
         async def check_for_cancellation(
             last_completed_step: GitDeploymentStep,
-        ):
+        ) -> bool:
             """
             This function allows us to pause and potentially bypass the workflow's execution
             during testing. It is useful for stopping the workflow at specific points to
@@ -690,7 +690,7 @@ class DeployGitServiceWorkflow:
                 print(
                     f"result check_for_cancellation({pause_at_step=}, {last_completed_step=}) = {self.cancellation_requested}"
                 )
-            return self.cancellation_requested
+            return self.cancellation_requested == deployment.hash
 
         async def monitor_cancellation(
             activity_handle: ActivityHandle,

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -1102,9 +1102,11 @@ class FakeProcess:
         dest_path = all_args[-1]
         variables: dict[str, str] = {}
 
-        env_regex = r"--env\s+(\S+)"
+        env_regex = r"--env\s+(\'[\S+\s+]+\'|\S+)"
         env_matches: List[str] = re.findall(env_regex, self.command)
         for matched in env_matches:
+            if matched.startswith("'") and matched.endswith("'"):
+                matched = matched[1:-1]  # do not include quotes
             key, value = matched.split("=")
             variables[key] = value
 

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -54,7 +54,7 @@ from ..temporal.activities import (
     get_swarm_service_name_for_deployment,
     get_volume_resource_name,
 )
-from ..utils import Colors, find_item_in_list, random_word
+from ..utils import Colors, find_item_in_sequence, random_word
 from git import GitCommandError
 
 
@@ -388,7 +388,7 @@ class AuthAPITestCase(APITestCase):
         self.workflow_schedules: List[WorkflowScheduleHandle] = []
 
     def get_workflow_schedule_by_id(self, id: str):
-        return find_item_in_list(
+        return find_item_in_sequence(
             lambda handle: handle.id == id, self.workflow_schedules
         )
 
@@ -436,7 +436,7 @@ class AuthAPITestCase(APITestCase):
             )
 
         async def pause_schedule(id: str, note: str | None = None):
-            schedule_handle = find_item_in_list(
+            schedule_handle = find_item_in_sequence(
                 lambda handle: handle.id == id, self.workflow_schedules
             )
             if schedule_handle is not None:
@@ -444,7 +444,7 @@ class AuthAPITestCase(APITestCase):
                 schedule_handle.note = note
 
         async def unpause_schedule(id: str, note: str | None = None):
-            schedule_handle = find_item_in_list(
+            schedule_handle = find_item_in_sequence(
                 lambda handle: handle.id == id, self.workflow_schedules
             )
             if schedule_handle is not None:
@@ -452,7 +452,7 @@ class AuthAPITestCase(APITestCase):
                 schedule_handle.note = note
 
         async def delete_schedule(id: str):
-            schedule_handle = find_item_in_list(
+            schedule_handle = find_item_in_sequence(
                 lambda handle: handle.id == id, self.workflow_schedules
             )
             if schedule_handle is not None:
@@ -1367,7 +1367,7 @@ class FakeDockerClient:
             return self.attached_volumes.get(get_volume_resource_name(volume.id))
 
         def get_attached_config(self, config: Config):
-            return find_item_in_list(
+            return find_item_in_sequence(
                 lambda c: c["ConfigID"]
                 == get_config_resource_name(config.id, config.version),
                 self.configs,

--- a/backend/zane_api/tests/changes.py
+++ b/backend/zane_api/tests/changes.py
@@ -95,7 +95,6 @@ target = {
     "slug": "demo",
     "image": "nginxdemos/hello",
     "command": None,
-    "healthcheck": None,
     "project_id": "prj_v6nBYFktpca",
     "credentials": None,
     "environment": {
@@ -189,7 +188,9 @@ target = {
 
 class DockerDeploymentChangesTests(AuthAPITestCase):
 
-    def test_compute_redeploy_changes_correctly(self):
+    def test_compute_redeploy_changes_with_old_url_schemas_adapt_urls_to_new_format_with_associated_port(
+        self,
+    ):
         changes = compute_docker_changes_from_snapshots(current, target)
         current_snapshot = DockerServiceSnapshot.from_dict(current)
 

--- a/backend/zane_api/tests/git_service_builder.py
+++ b/backend/zane_api/tests/git_service_builder.py
@@ -495,11 +495,12 @@ class NixPacksBuilderViewTests(AuthAPITestCase):
         self.assertIsNotNone(url_change)
         self.assertEqual(80, url_change.new_value.get("associated_port"))
 
-        # Should create PORT env variable
-        env_change: DeploymentChange = DeploymentChange.objects.filter(
-            service=created_service, field=DeploymentChange.ChangeField.ENV_VARIABLES
-        ).first()
-        self.assertIsNone(env_change)
+        # Should create PORT & HOST env variable
+        env_changes = DeploymentChange.objects.filter(
+            service=created_service,
+            field=DeploymentChange.ChangeField.ENV_VARIABLES,
+        )
+        self.assertEqual(2, env_changes.count())
 
     def test_request_service_change_with_nixpacks_builder(self):
         p, service = self.create_git_service()

--- a/backend/zane_api/tests/git_service_builder.py
+++ b/backend/zane_api/tests/git_service_builder.py
@@ -9,7 +9,7 @@ from ..models import (
     Deployment,
     DeploymentChange,
 )
-from ..utils import jprint
+from ..utils import jprint, find_item_in_sequence
 from ..temporal.helpers import generate_caddyfile_for_static_website
 from ..dtos import StaticDirectoryBuilderOptions
 
@@ -425,13 +425,25 @@ class NixPacksBuilderViewTests(AuthAPITestCase):
         self.assertEqual(3000, url_change.new_value.get("associated_port"))
 
         # Should create PORT env variable
-        env_change: DeploymentChange = DeploymentChange.objects.filter(
+        env_changes = DeploymentChange.objects.filter(
             service=created_service, field=DeploymentChange.ChangeField.ENV_VARIABLES
-        ).first()
-        self.assertIsNotNone(env_change)
-        self.assertEqual(DeploymentChange.ChangeType.ADD, env_change.type)
-        self.assertEqual("PORT", env_change.new_value.get("key"))
-        self.assertEqual("3000", env_change.new_value.get("value"))
+        )
+        self.assertEqual(2, env_changes.count())
+
+        port_env_change = find_item_in_sequence(
+            lambda ch: ch.new_value.get("key") == "PORT", env_changes.all()
+        )
+        host_env_change = find_item_in_sequence(
+            lambda ch: ch.new_value.get("key") == "HOST", env_changes.all()
+        )
+        self.assertIsNotNone(port_env_change)
+        self.assertIsNotNone(host_env_change)
+
+        self.assertEqual(DeploymentChange.ChangeType.ADD, port_env_change.type)
+        self.assertEqual("3000", port_env_change.new_value.get("value"))
+
+        self.assertEqual(DeploymentChange.ChangeType.ADD, host_env_change.type)
+        self.assertEqual("0.0.0.0", host_env_change.new_value.get("value"))
 
     def test_create_service_with_nixpacks_and_static_builder_generates_caddyfile_and_uses_port_80(
         self,
@@ -495,12 +507,12 @@ class NixPacksBuilderViewTests(AuthAPITestCase):
         self.assertIsNotNone(url_change)
         self.assertEqual(80, url_change.new_value.get("associated_port"))
 
-        # Should create PORT & HOST env variable
+        # Should not create env variables changes
         env_changes = DeploymentChange.objects.filter(
             service=created_service,
             field=DeploymentChange.ChangeField.ENV_VARIABLES,
         )
-        self.assertEqual(2, env_changes.count())
+        self.assertEqual(0, env_changes.count())
 
     def test_request_service_change_with_nixpacks_builder(self):
         p, service = self.create_git_service()

--- a/backend/zane_api/utils.py
+++ b/backend/zane_api/utils.py
@@ -359,8 +359,3 @@ async def read_until(stream: asyncio.StreamReader, delimiters: list[bytes]):
         if character in delimiters:
             break
     return bytes(buffer)
-
-
-async def async_noop():
-    """This function does nothing"""
-    ...

--- a/backend/zane_api/utils.py
+++ b/backend/zane_api/utils.py
@@ -359,3 +359,8 @@ async def read_until(stream: asyncio.StreamReader, delimiters: list[bytes]):
         if character in delimiters:
             break
     return bytes(buffer)
+
+
+async def async_noop():
+    """This function does nothing"""
+    ...

--- a/backend/zane_api/utils.py
+++ b/backend/zane_api/utils.py
@@ -8,7 +8,7 @@ import string
 from dataclasses import dataclass
 from enum import Enum
 from functools import wraps
-from typing import Any, Callable, TypeVar, List, Optional, Literal
+from typing import Any, Callable, Sequence, TypeVar, List, Optional, Literal
 import re
 from django.core.cache import cache
 
@@ -201,7 +201,9 @@ def jprint(value: Any):
 T = TypeVar("T")
 
 
-def find_item_in_list(predicate: Callable[[T], bool], sequence: List[T]) -> Optional[T]:
+def find_item_in_sequence(
+    predicate: Callable[[T], bool], sequence: Sequence[T]
+) -> Optional[T]:
     return next(
         (item for item in sequence if predicate(item)),
         None,

--- a/backend/zane_api/utils.py
+++ b/backend/zane_api/utils.py
@@ -358,8 +358,17 @@ def multiline_command(command: str) -> str:
         return command
 
     # Start with the base command (first two tokens)
-    lines = [f"{tokens[0]} {tokens[1]} \\"]
-    i = 2
+    first_line = []
+    i = 0
+    for token in tokens:
+        if token.startswith("-"):
+            break
+
+        i += 1
+        first_line.append(token)
+
+    lines = [f"{' '.join(first_line)} \\"]
+
     while i < len(tokens):
         token = tokens[i]
         # If token is a flag and next token exists and doesn't start with '-', join them.
@@ -368,10 +377,7 @@ def multiline_command(command: str) -> str:
             and (i + 1) < len(tokens)
             and not tokens[i + 1].startswith("-")
         ):
-            line = f"\t{token} {tokens[i + 1]} \\"
-            i += 2
-        elif token.startswith(">"):
-            line = f"\t{token} {tokens[i + 1]} \\"
+            line = f"\t{token} {shlex.quote(tokens[i + 1])} \\"
             i += 2
         else:
             line = f"\t{token} \\"

--- a/backend/zane_api/views/git_services.py
+++ b/backend/zane_api/views/git_services.py
@@ -246,6 +246,17 @@ class CreateGitServiceAPIView(APIView):
                                             service=service,
                                         ),
                                     )
+                                    extra_changes.append(
+                                        DeploymentChange(
+                                            field=DeploymentChange.ChangeField.ENV_VARIABLES,
+                                            new_value={
+                                                "key": "HOST",
+                                                "value": "0.0.0.0",
+                                            },
+                                            type=DeploymentChange.ChangeType.ADD,
+                                            service=service,
+                                        ),
+                                    )
                                 DeploymentChange.objects.bulk_create(extra_changes)
 
                             case _:

--- a/backend/zane_api/views/git_services.py
+++ b/backend/zane_api/views/git_services.py
@@ -427,8 +427,14 @@ class ReDeployGitServiceAPIView(APIView):
         data = cast(ReturnDict, form.data)
 
         latest_deployment: Deployment = service.latest_production_deployment  # type: ignore
+
+        current_snapshot = (
+            latest_deployment.service_snapshot
+            if latest_deployment.status != Deployment.DeploymentStatus.FAILED
+            else cast(ReturnDict, ServiceSerializer(service).data)
+        )
         changes = compute_docker_changes_from_snapshots(
-            latest_deployment.service_snapshot,  # type: ignore
+            current_snapshot,  # type: ignore
             deployment.service_snapshot,  # type: ignore
         )
 

--- a/backend/zane_api/views/helpers.py
+++ b/backend/zane_api/views/helpers.py
@@ -108,7 +108,7 @@ def compute_docker_service_snapshot(
                     else None
                 )
             case _:
-                dto_class: type[VolumeDto] = field_dto_map[change.field]  # type: ignore
+                dto_class: type[VolumeDto | URLDto | ConfigDto | EnvVariableDto | PortConfigurationDto] = field_dto_map[change.field]  # type: ignore
                 items: list = getattr(service_snapshot, change.field)
 
                 if change.type == "ADD":

--- a/backend/zane_api/views/serializers.py
+++ b/backend/zane_api/views/serializers.py
@@ -48,7 +48,7 @@ from ..utils import (
     Colors,
     EnhancedJSONEncoder,
     convert_value_to_bytes,
-    find_item_in_list,
+    find_item_in_sequence,
     format_storage_value,
 )
 from ..git_client import GitClient
@@ -942,7 +942,7 @@ class ConfigItemChangeSerializer(BaseChangeItemSerializer):
                 }
             )
 
-        volume_with_same_container_path = find_item_in_list(
+        volume_with_same_container_path = find_item_in_sequence(
             lambda v: v.container_path == new_value.get("mount_path"),
             snapshot.volumes,
         )

--- a/frontend/app/components/service-cards.tsx
+++ b/frontend/app/components/service-cards.tsx
@@ -210,7 +210,8 @@ export function GitServiceCard({
                     "animate-ping absolute inline-flex h-full w-full rounded-full  opacity-75",
                     {
                       "bg-green-400": status === "HEALTHY",
-                      "bg-red-400": status === "UNHEALTHY",
+                      "bg-red-500":
+                        status === "UNHEALTHY" || status === "FAILED",
                       "bg-yellow-400": status === "SLEEPING",
                       "bg-secondary/60": status === "DEPLOYING"
                     }
@@ -223,7 +224,7 @@ export function GitServiceCard({
                   "relative inline-flex rounded-full h-4 w-4 bg-green-500",
                   {
                     "bg-green-500": status === "HEALTHY",
-                    "bg-red-500": status === "UNHEALTHY",
+                    "bg-red-500": status === "UNHEALTHY" || status === "FAILED",
                     "bg-yellow-500": status === "SLEEPING",
                     "bg-gray-400":
                       status === "NOT_DEPLOYED_YET" || status === "CANCELLED",
@@ -236,6 +237,7 @@ export function GitServiceCard({
           <TooltipContent>
             <div>
               {status === "HEALTHY" && "✅ Healthy"}
+              {status === "FAILED" && "❌ Failed"}
               {status === "SLEEPING" && "🌙 Sleeping"}
               {status === "UNHEALTHY" && "❌ Unhealthy"}
               {status === "DEPLOYING" && "⏳ Deploying..."}

--- a/frontend/app/routes/layouts/dashboard-layout.tsx
+++ b/frontend/app/routes/layouts/dashboard-layout.tsx
@@ -127,7 +127,9 @@ export default function DashboardLayout({ loaderData }: Route.ComponentProps) {
     if (
       import.meta.env.PROD &&
       latestVersion?.tag &&
-      loaderData.previousVersion !== "canary" &&
+      loaderData.previousVersion &&
+      loaderData.previousVersion !== "canary" && // ignore canary as it is the latest version
+      !loaderData.previousVersion.startsWith("pr-") && // ignore pr branch versions
       loaderData.previousVersion !== latestVersion.tag
     ) {
       toast.success("New version of ZaneOps available !", {

--- a/frontend/app/routes/layouts/deployment-layout.tsx
+++ b/frontend/app/routes/layouts/deployment-layout.tsx
@@ -120,9 +120,9 @@ export default function DeploymentLayoutPage({
     "STARTING",
     "RESTARTING"
   ];
-  const isCancellable = cancellableDeploymentsStatuses.includes(
-    deployment.status
-  );
+  const isCancellable =
+    !deployment.finished_at &&
+    cancellableDeploymentsStatuses.includes(deployment.status);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- Fixed this bug : https://github.com/zane-ops/zane-ops/issues/437#issuecomment-2797912613
- Fixed a bug with Git service cards not showing `FAILED` when a deployment is failed, instead it shows a green chip with no text inside of it
- Refactored out the common parts of the subprocess execution logic to a common class that is tasked to run the subprocess instead, this way it is reusable elsewhere
- Fix a bug with cancellation logic for deployments, previously the cancellation would cancel every queued & running deployment, now it only cancels the requested deployment
- The update toast is not showed if in PR branch version
- Fixed redeployments to only compute changes from the latest production deployment 
- We pass all envs generated by nixpacks to the `docker build` process now 

fixes #437 


> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
