### PR TITLE
fix: kill build process on timeout instead of waiting on it

### DIFF
--- a/backend/zane_api/process.py
+++ b/backend/zane_api/process.py
@@ -113,5 +113,5 @@ class AyncSubProcessRunner:
 
     async def _terminate(self, process: Process) -> None:
         if process.returncode is None:
-            process.terminate()
+            process.kill()
             self.exit_code = await process.wait()

--- a/backend/zane_api/process.py
+++ b/backend/zane_api/process.py
@@ -48,6 +48,7 @@ class AyncSubProcessRunner:
         self.operation_name = operation_name
         self.result: Any = None
         self.exit_code: Optional[int] = None
+        self._terminate_task: Optional[asyncio.Task[int]] = None
 
     async def run(self) -> Tuple[int | None, Optional[Any]]:
         process = await asyncio.create_subprocess_shell(
@@ -60,11 +61,16 @@ class AyncSubProcessRunner:
             while not await self._process_output(process):
                 continue
         except asyncio.CancelledError:
-            await self._terminate(process)
+            if self._terminate_task is None:
+                self._terminate_task = asyncio.create_task(self._terminate(process))
             raise
         finally:
             if self.exit_code is None:
-                self.exit_code = await process.wait()
+                self.exit_code = await (
+                    process.wait()
+                    if self._terminate_task is None
+                    else self._terminate_task
+                )
 
         return (self.exit_code, self.result)
 
@@ -87,8 +93,8 @@ class AyncSubProcessRunner:
             cancel_task.cancel()
         else:
             if self.cancel_event and self.cancel_event.is_set():
-                await self._terminate(process)
                 read_output_task.cancel()
+                self._terminate_task = asyncio.create_task(self._terminate(process))
 
                 print(
                     f"{Colors.RED}Received cancel_event: {self.cancel_event} {Colors.ENDC}"
@@ -111,7 +117,8 @@ class AyncSubProcessRunner:
 
         return False
 
-    async def _terminate(self, process: Process) -> None:
+    async def _terminate(self, process: Process) -> int:
         if process.returncode is None:
             process.kill()
-            self.exit_code = await process.wait()
+            return await process.wait()
+        return process.returncode

--- a/backend/zane_api/temporal/activities/git_activities.py
+++ b/backend/zane_api/temporal/activities/git_activities.py
@@ -1080,9 +1080,6 @@ class GitActivities:
             task_set.add(heartbeat_task)
             deployment = details.deployment
             service = deployment.service
-            builder_options = cast(
-                NixpacksBuilderOptions, service.railpack_builder_options
-            )
 
             current_deployment = Deployment.objects.filter(
                 hash=deployment.hash, service_id=deployment.service.id


### PR DESCRIPTION
## Description

Fix a bug with docker build always sending heartbeat timeout.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
