### PR TITLE
refactor: use container id for healthchecks

### DIFF
--- a/backend/zane_api/middleware.py
+++ b/backend/zane_api/middleware.py
@@ -1,6 +1,5 @@
 from typing import Callable
 from django.http import HttpRequest, HttpResponse
-import os
 from django.conf import settings
 
 

--- a/backend/zane_api/temporal/activities/main_activities.py
+++ b/backend/zane_api/temporal/activities/main_activities.py
@@ -1458,13 +1458,14 @@ class DockerSwarmActivities:
                                     if container.id.startswith(host)  # type: ignore
                                 )
                                 full_url = f"http://{container_hostname_in_network}:{healthcheck.associated_port}{healthcheck.value}"
+                                timeout = min(healthcheck_time_left, 5)
                                 await deployment_log(
                                     deployment=deployment,
-                                    message=f"Running {Colors.GREY}GET {full_url}{Colors.ENDC}",
+                                    message=f"Running {Colors.GREY}GET {full_url} (timeout: {timeout:.2f}s){Colors.ENDC}",
                                 )
                                 response = requests.get(
                                     full_url,
-                                    timeout=min(healthcheck_time_left, 5),
+                                    timeout=timeout,
                                 )
                                 color = (
                                     Colors.GREEN

--- a/backend/zane_api/temporal/activities/main_activities.py
+++ b/backend/zane_api/temporal/activities/main_activities.py
@@ -1419,9 +1419,13 @@ class DockerSwarmActivities:
                             print(
                                 f"Running custom healthcheck {healthcheck.type=} - {healthcheck.value=}"
                             )
+                            container = self.docker_client.containers.get(
+                                most_recent_swarm_task.container_id
+                            )
                             if healthcheck.type == HealthCheck.HealthCheckType.COMMAND:
-                                container = self.docker_client.containers.get(
-                                    most_recent_swarm_task.container_id
+                                await deployment_log(
+                                    deployment=deployment,
+                                    message=f"Running command {Colors.GREY}{healthcheck.value}{Colors.ENDC}",
                                 )
                                 exit_code, output = container.exec_run(
                                     cmd=healthcheck.value,
@@ -1429,7 +1433,11 @@ class DockerSwarmActivities:
                                     stderr=True,
                                     stdin=False,
                                 )
-
+                                color = Colors.GREEN if exit_code == 0 else Colors.RED
+                                await deployment_log(
+                                    deployment=deployment,
+                                    message=f"Command finished with exit_code {color}{exit_code}{Colors.ENDC}",
+                                )
                                 if exit_code == 0:
                                     deployment_status = (
                                         Deployment.DeploymentStatus.HEALTHY
@@ -1440,10 +1448,32 @@ class DockerSwarmActivities:
                                     )
                                 deployment_status_reason = output.decode("utf-8")
                             else:
-                                full_url = f"http://{deployment.network_alias}:{healthcheck.associated_port}{healthcheck.value}"
+                                container_networks = container.attrs["NetworkSettings"][
+                                    "Networks"
+                                ]
+                                dns_names = container_networks["zane"]["DNSNames"]
+                                container_hostname_in_network: str = next(
+                                    host
+                                    for host in dns_names
+                                    if container.id.startswith(host)  # type: ignore
+                                )
+                                full_url = f"http://{container_hostname_in_network}:{healthcheck.associated_port}{healthcheck.value}"
+                                await deployment_log(
+                                    deployment=deployment,
+                                    message=f"Running {Colors.GREY}GET {full_url}{Colors.ENDC}",
+                                )
                                 response = requests.get(
                                     full_url,
                                     timeout=min(healthcheck_time_left, 5),
+                                )
+                                color = (
+                                    Colors.GREEN
+                                    if status.is_success(response.status_code)
+                                    else Colors.RED
+                                )
+                                await deployment_log(
+                                    deployment=deployment,
+                                    message=f"Got response with status code {color}{response.status_code}{Colors.ENDC}",
                                 )
                                 if status.is_success(response.status_code):
                                     deployment_status = (

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -1384,8 +1384,77 @@ class FakeDockerClient:
             )
 
     class FakeContainer:
+        ID = "c1e672fd6962cda72fed881a8b68e8fd2b8a9ef2a479136586323ca05196cc85"
+
         def __init__(self):
             self.status = "running"
+            self.id = self.ID
+
+        @property
+        def attrs(self):
+            return {
+                "Id": self.id,
+                "Image": "sha256:a1b98f5f2c3a5db62a77e13f477ada54cec6edf0e4d4eff58ea69f80f2365fa0",
+                "NetworkSettings": {
+                    "Bridge": "",
+                    "SandboxID": "9a6e75f902744b6d8b4e31b72cf0f31c39caebe9084948fd9f823a0d7cf22046",
+                    "SandboxKey": "/var/run/docker/netns/9a6e75f90274",
+                    "Ports": {},
+                    "HairpinMode": False,
+                    "LinkLocalIPv6Address": "",
+                    "LinkLocalIPv6PrefixLen": 0,
+                    "SecondaryIPAddresses": None,
+                    "SecondaryIPv6Addresses": None,
+                    "EndpointID": "",
+                    "Gateway": "",
+                    "GlobalIPv6Address": "",
+                    "GlobalIPv6PrefixLen": 0,
+                    "IPAddress": "",
+                    "IPPrefixLen": 0,
+                    "IPv6Gateway": "",
+                    "MacAddress": "",
+                    "Networks": {
+                        "net-prj_vTRgvLXXEMh-project_env_YaDEzDSEPrC95kY": {
+                            "IPAMConfig": {"IPv4Address": "10.0.12.51"},
+                            "Links": None,
+                            "Aliases": None,
+                            "MacAddress": "02:42:0a:00:0c:33",
+                            "DriverOpts": None,
+                            "NetworkID": "sg63oes0r3mehdvnwpqxc9zdq",
+                            "EndpointID": "87f0ca0ce7049e18668a871542e54781300079921df8ac9a566fb9083836c151",
+                            "Gateway": "",
+                            "IPAddress": "10.0.12.51",
+                            "IPPrefixLen": 24,
+                            "IPv6Gateway": "",
+                            "GlobalIPv6Address": "",
+                            "GlobalIPv6PrefixLen": 0,
+                            "DNSNames": [
+                                "srv-prj_vTRgvLXXEMh-srv_dkr_SgriNkHcsws-dpl_dkr_P3at6rf5imj.1.picpo7ff7xr4mczb6gb7mhssr",
+                                self.id[:12],
+                            ],
+                        },
+                        "zane": {
+                            "IPAMConfig": {"IPv4Address": "10.0.1.163"},
+                            "Links": None,
+                            "Aliases": None,
+                            "MacAddress": "02:42:0a:00:01:a3",
+                            "DriverOpts": None,
+                            "NetworkID": "cu88hhmmyqi9ae9a99iemha2r",
+                            "EndpointID": "e7c5b911b03e41d35bdc5b7dd8e79a1a1473cef636d3fbf649edb3c6cb555e00",
+                            "Gateway": "",
+                            "IPAddress": "10.0.1.163",
+                            "IPPrefixLen": 24,
+                            "IPv6Gateway": "",
+                            "GlobalIPv6Address": "",
+                            "GlobalIPv6PrefixLen": 0,
+                            "DNSNames": [
+                                "srv-prj_vTRgvLXXEMh-srv_dkr_SgriNkHcsws-dpl_dkr_P3at6rf5imj.1.picpo7ff7xr4mczb6gb7mhssr",
+                                self.id[:12],
+                            ],
+                        },
+                    },
+                },
+            }
 
         def stats(self, *args, **kwargs):
             # these are example stats

--- a/backend/zane_api/tests/networks.py
+++ b/backend/zane_api/tests/networks.py
@@ -156,7 +156,3 @@ class DockerServiceNetworksTests(AuthAPITestCase):
             self.assertEqual(
                 Deployment.DeploymentStatus.HEALTHY, latest_deployment.status
             )
-            responses.assert_call_count(
-                f"http://{latest_deployment.network_alias}:80/".lower(),
-                2,
-            )

--- a/backend/zane_api/tests/service.py
+++ b/backend/zane_api/tests/service.py
@@ -460,7 +460,7 @@ class DockerServiceHealthCheckViewTests(AuthAPITestCase):
     @responses.activate
     async def test_create_service_with_healtheck_path_success(self):
         deployment_url_pattern = re.compile(
-            r".*(blue|green)\.zaneops\.internal", re.IGNORECASE
+            r"http:\/\/[a-z0-9]{12}:\d+/.*", re.IGNORECASE
         )
         responses.add_passthru(settings.CADDY_PROXY_ADMIN_HOST)
         responses.add_passthru(settings.LOKI_HOST)
@@ -482,7 +482,7 @@ class DockerServiceHealthCheckViewTests(AuthAPITestCase):
     @responses.activate
     async def test_create_service_with_healtheck_path_error(self):
         deployment_url_pattern = re.compile(
-            r".*(blue|green)\.zaneops\.internal", re.IGNORECASE
+            r"http:\/\/[a-z0-9]{12}:\d+/.*", re.IGNORECASE
         )
         responses.add_passthru(settings.CADDY_PROXY_ADMIN_HOST)
         responses.add_passthru(settings.LOKI_HOST)


### PR DESCRIPTION
## Description

This is in preparation for the future, using the container ID is much more precise that the deployment alias.
In the future, we will be able to use this for services with multiple replicas and be able to check of them individually.

I also added logs for commands and requests done by the healthchecks.

> [!WARNING]
> Please do not delete the sections below

### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run freeze # will update the `requirements.txt` file if you added new packages
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
