### PR TITLE
fix: onboarding bug missing csrf header

### DIFF
--- a/frontend/app/routes/onboarding.tsx
+++ b/frontend/app/routes/onboarding.tsx
@@ -13,7 +13,7 @@ import {
   getFormErrorsFromResponseData
 } from "~/lib/utils";
 import { queryClient } from "~/root";
-import { metaTitle } from "~/utils";
+import { getCsrfTokenHeader, metaTitle } from "~/utils";
 import type { Route } from "./+types/onboarding";
 
 export const meta: Route.MetaFunction = () => [metaTitle("Welcome to ZaneOps")];
@@ -62,6 +62,9 @@ export async function clientAction({ request }: Route.ClientActionArgs) {
   const { error: errors, data } = await apiClient.POST(
     "/api/auth/create-initial-user/",
     {
+      headers: {
+        ...(await getCsrfTokenHeader())
+      },
       body: credentials
     }
   );


### PR DESCRIPTION
## Summary

Because we forgot to pass the `X-CSRFToken` header when calling the `/auth/create-initial-user` endpoint, new installs would not work and fail the creation of the first user.

What's strange is the fact that this error doesn't happen with `v1.10` even though we haven't modified the onboariding code since at least two versions prior. I may have modified something with the CSRF settings on the backend that would cause this error.


<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
