### PR TITLE
GitLab: Include all user-associated repositories, not only user-created ones

### DIFF
--- a/backend/git_connectors/models.py
+++ b/backend/git_connectors/models.py
@@ -176,7 +176,6 @@ class GitlabApp(TimestampedModel):
             "pagination": "keyset",
             "order_by": "id",
             "membership": "true",
-            "owned": "true",
             "sort": "desc",
         }
 

--- a/backend/git_connectors/views/gitlab.py
+++ b/backend/git_connectors/views/gitlab.py
@@ -181,7 +181,6 @@ class TestGitlabAppAPIView(APIView):
         url = f"{gl_app.gitlab_url}/api/v4/projects"
         params = {
             "membership": "true",
-            "owned": "true",
         }
         headers = {
             "Accept": "application/json",


### PR DESCRIPTION
## Summary

`/projects?owned=true` only returns repositories created by the current user. This limits the result to exclude repos you're a developer or a maintainer but not owner. We should use `membership=true` (which is used already) that returns all repositories that the user has any level of access (owner, maintainer, developer, reporter or guest). As expected, it doesn't include public repos you don't have a role in.

Follow up to #467 

### Screenshots (if applicable)

Before: (only two projects)
<img width="819" height="325" alt="Screenshot from 2025-07-11 21-17-47" src="https://github.com/user-attachments/assets/e5d56d9f-0051-411d-b097-0a7e17e03820" />

After: should return all of these

<img width="1776" height="572" alt="Screenshot from 2025-07-11 21-20-25" src="https://github.com/user-attachments/assets/fd9eaee7-5528-4239-bfe5-a34b603db01a" />


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
