### PR TITLE
fix: use the correct path for the venv in the `Makefile`

### DIFF
--- a/deploy.mk
+++ b/deploy.mk
@@ -113,11 +113,11 @@ deploy: ### Install and deploy zaneops based on MODE (https or http)
 	echo -e "====== \x1b[94mDONE Deploying ZaneOps ✅\x1b[0m"
 
 create-user: ### Create the first user to login in into the dashboard
-	@docker exec -it $$(docker ps -qf "name=zane_app") /bin/bash -c "source /venv/bin/activate && python manage.py createsuperuser"
+	@docker exec -it $$(docker ps -qf "name=zane_app") /bin/bash -c "source /app/.venv/bin/activate && python manage.py createsuperuser"
 
 reset-password: ### Reset user password
 	@if [ -z "$(user)" ]; then echo -e "Error: \x1b[33m\$$user\x1b[0m variable is required. Usage: \x1b[96mmake reset-password user=username\x1b[0m"; exit 1; fi
-	@docker exec -it $$(docker ps -qf "name=zane_app") /bin/bash -c "source /venv/bin/activate && python manage.py changepassword $(user)"
+	@docker exec -it $$(docker ps -qf "name=zane_app") /bin/bash -c "source /app/.venv/bin/activate && python manage.py changepassword $(user)"
 
 stop: ### Take down zaneops and scale down all services created in zaneops
 	@echo -e "====== \x1b[94mTaking down zaneops...\x1b[0m ======"


### PR DESCRIPTION
## Summary

The correct path is not `/venv` and should have been `/app/.venv`. This PR will require redownloading the makefile content.

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
