### PR TITLE
fix: resolve the branch name correctly in the auto-deploy webhook

### DIFF
--- a/backend/git_connectors/views/github.py
+++ b/backend/git_connectors/views/github.py
@@ -330,7 +330,7 @@ class GithubWebhookAPIView(APIView):
                 # We only consider pushes to a branch
                 # we ignore tags and other push events
                 if ref.startswith("refs/heads/"):
-                    branch_name = ref.split("/")[-1]
+                    branch_name = ref.replace("refs/heads/", "")
 
                     repository_url = (
                         f"https://github.com/{data["repository"]["full_name"]}.git"

--- a/backend/git_connectors/views/gitlab.py
+++ b/backend/git_connectors/views/gitlab.py
@@ -331,7 +331,7 @@ class GitlabWebhookAPIView(APIView):
                 # We only consider pushes to a branch
                 # we ignore tags and other push events
                 if ref.startswith("refs/heads/"):
-                    branch_name = ref.split("/")[-1]
+                    branch_name = ref.replace("refs/heads/", "")
 
                     repository_url = data["repository"]["git_http_url"]
 

--- a/backend/zane_api/tests/base.py
+++ b/backend/zane_api/tests/base.py
@@ -960,6 +960,7 @@ class AuthAPITestCase(APITestCase):
     async def acreate_git_service(
         self,
         slug="docs",
+        branch_name="main",
         repository_url="https://github.com/zane-ops/docs",
         git_app_id: Optional[str] = None,
     ):
@@ -976,7 +977,7 @@ class AuthAPITestCase(APITestCase):
         create_service_payload = {
             "slug": "docs",
             "repository_url": repository_url,
-            "branch_name": "main",
+            "branch_name": branch_name,
         }
         if git_app_id is not None:
             create_service_payload["git_app_id"] = git_app_id


### PR DESCRIPTION
## Summary

The branch name can have `/` in it, so instead of splitting the ref by `/` we just get all the string after `ref/heads`

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
