### PR TITLE
chore: Use API for getting single tag for the auto-update API

### DIFF
--- a/backend/zane_api/views/auto_update_docker_services.py
+++ b/backend/zane_api/views/auto_update_docker_services.py
@@ -1,4 +1,5 @@
 from typing import cast
+from urllib.parse import urlencode
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status, exceptions
@@ -16,11 +17,11 @@ from .serializers import (
 
 
 def check_image_exists(desired_image: str) -> bool:
-    response = requests.get("https://cdn.zaneops.dev/api/releases")
+    params = urlencode(query={"tag": desired_image}, doseq=True)
+    response = requests.get(f"https://cdn.zaneops.dev/api/single-release?{params}")
     if response.status_code == status.HTTP_200_OK:
         data = response.json()
-        available_tags = [item["tag"] for item in data]
-        return desired_image in available_tags
+        return desired_image == data.get("tag")
     else:
         print(f"Failed to fetch data. Status code: {response.status_code}")
         return False


### PR DESCRIPTION
## Summary

For performance reasons, instead of fetching the `/releases` API which returns the whole list of releases we instead call the API that get a single release directly. 

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
