### PR TITLE
chore: change the order of links in new service page

### DIFF
--- a/frontend/app/routes/services/create-service.tsx
+++ b/frontend/app/routes/services/create-service.tsx
@@ -2,7 +2,7 @@ import {
   ArrowRightIcon,
   ContainerIcon,
   GithubIcon,
-  GitlabIcon
+  LinkIcon
 } from "lucide-react";
 import { Link } from "react-router";
 import {
@@ -92,20 +92,21 @@ export default function CreateServicePage({ params }: Route.ComponentProps) {
               variant="secondary"
               className="flex gap-2.5 items-center  font-semibold  justify-center p-10"
             >
-              <Link to="./git-public" prefetch="intent">
+              <Link to="./git-private" prefetch="intent">
                 <GithubIcon className="flex-none" />
-                <span>From public Git repo URL</span>
+                <span>From Git provider</span>
                 <ArrowRightIcon className="flex-none" />
               </Link>
             </Button>
+
             <Button
               asChild
               variant="secondary"
               className="flex gap-2.5 items-center  font-semibold  justify-center p-10"
             >
-              <Link to="./git-private" prefetch="intent">
-                <GitlabIcon className="flex-none" />
-                <span>From Git provider</span>
+              <Link to="./git-public" prefetch="intent">
+                <LinkIcon className="flex-none" />
+                <span>From public Git repo URL</span>
                 <ArrowRightIcon className="flex-none" />
               </Link>
             </Button>


### PR DESCRIPTION
## Summary

The git provider option should be first as it is probably the most common option that users want. 
I also changed the icons.

### Screenshots (if applicable)

| before | after |
| ------------ | ------------ |
| <img width="539" height="513" alt="image" src="https://github.com/user-attachments/assets/9b2b1fe2-bb69-4f36-8d90-efb222faa28f" />      | <img width="491" height="417" alt="Screenshot 2025-07-21 at 23 31 54" src="https://github.com/user-attachments/assets/c950c15f-1ea9-41f2-af4b-11dfe3e24b7c" />     |

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
