### PR TITLE
refactor: make `cancel` the last item in the dropdown

### DIFF
--- a/frontend/app/components/deployment-cards.tsx
+++ b/frontend/app/components/deployment-cards.tsx
@@ -324,22 +324,6 @@ export function DockerDeploymentCard({
                   <MenubarContentItem icon={Redo2} text="Redeploy" />
                 </button>
               )}
-              {isCancellable && (
-                <button
-                  form={`cancel-${hash}-form`}
-                  className="w-full"
-                  onClick={(e) => {
-                    e.currentTarget.form?.requestSubmit();
-                  }}
-                  disabled={cancelFetcher.state !== "idle"}
-                >
-                  <MenubarContentItem
-                    className="text-red-500"
-                    icon={Ban}
-                    text="Cancel"
-                  />
-                </button>
-              )}
               <MenubarContentItem
                 icon={Eye}
                 text="Details"
@@ -369,6 +353,22 @@ export function DockerDeploymentCard({
                 text="View metrics"
                 onClick={() => navigate(`./deployments/${hash}/metrics`)}
               />
+              {isCancellable && (
+                <button
+                  form={`cancel-${hash}-form`}
+                  className="w-full"
+                  onClick={(e) => {
+                    e.currentTarget.form?.requestSubmit();
+                  }}
+                  disabled={cancelFetcher.state !== "idle"}
+                >
+                  <MenubarContentItem
+                    className="text-red-500"
+                    icon={Ban}
+                    text="Cancel"
+                  />
+                </button>
+              )}
             </MenubarContent>
           </MenubarMenu>
         </Menubar>
@@ -686,22 +686,7 @@ export function GitDeploymentCard({
                   <MenubarContentItem icon={Redo2} text="Redeploy" />
                 </button>
               )}
-              {isCancellable && (
-                <button
-                  form={`cancel-${hash}-form`}
-                  className="w-full"
-                  onClick={(e) => {
-                    e.currentTarget.form?.requestSubmit();
-                  }}
-                  disabled={cancelFetcher.state !== "idle"}
-                >
-                  <MenubarContentItem
-                    className="text-red-500"
-                    icon={Ban}
-                    text="Cancel"
-                  />
-                </button>
-              )}
+
               <MenubarContentItem
                 icon={Eye}
                 text="Details"
@@ -731,6 +716,22 @@ export function GitDeploymentCard({
                 text="View metrics"
                 onClick={() => navigate(`./deployments/${hash}/metrics`)}
               />
+              {isCancellable && (
+                <button
+                  form={`cancel-${hash}-form`}
+                  className="w-full"
+                  onClick={(e) => {
+                    e.currentTarget.form?.requestSubmit();
+                  }}
+                  disabled={cancelFetcher.state !== "idle"}
+                >
+                  <MenubarContentItem
+                    className="text-red-500"
+                    icon={Ban}
+                    text="Cancel"
+                  />
+                </button>
+              )}
             </MenubarContent>
           </MenubarMenu>
         </Menubar>


### PR DESCRIPTION
## Summary

It being the first option can lead to misclicks

### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| <img width="280" height="359" alt="Screenshot 2025-07-22 at 02 20 24" src="https://github.com/user-attachments/assets/da8816ca-0f30-40dc-b6f0-a90041a2c6ad" />   | <img width="280" height="359" alt="Screenshot 2025-07-22 at 02 20 24" src="https://github.com/user-attachments/assets/da8816ca-0f30-40dc-b6f0-a90041a2c6ad" />   |

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
