### PR TITLE
fix: do not throw error for settings endpoint

### DIFF
--- a/frontend/app/lib/queries.ts
+++ b/frontend/app/lib/queries.ts
@@ -1391,7 +1391,6 @@ export const serverQueries = {
     queryFn: async () => {
       const { data } = await apiClient.GET("/api/settings/");
       // we throw the error because we want ZaneOps to retry this for multiple times at least
-      if (!data) throw new Error("Unknown error with the API");
       return data;
     },
     staleTime: Number.MAX_SAFE_INTEGER


### PR DESCRIPTION
## Summary

The settings endpoint will throw if you are not authenticated, fixed it in this PR.

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
