### PR TITLE
chore: more reliable spacing in services page when it's empty

### DIFF
--- a/frontend/app/routes/environments/environment-service-list.tsx
+++ b/frontend/app/routes/environments/environment-service-list.tsx
@@ -228,9 +228,9 @@ export default function EnvironmentServiceListPage({
       <section className="py-8 grid lg:grid-cols-3 md:grid-cols-2 grid-cols-1 place-content-center  gap-8">
         {serviceList.length === 0 && (
           <section className="flex gap-3 h-96 col-span-full flex-col items-center justify-center grow py-20">
-            <div className="text-center">
+            <div className="flex flex-col gap-2 items-center text-center">
               {query.length > 0 ? (
-                <div className="flex flex-col gap-2 items-center">
+                <>
                   <h2 className="text-2xl font-medium">
                     No services match the filter criteria
                   </h2>
@@ -243,17 +243,15 @@ export default function EnvironmentServiceListPage({
                       Clear filters
                     </Link>
                   </Button>
-                </div>
+                </>
               ) : (
                 <>
-                  <div>
-                    <h1 className="text-2xl font-bold">
-                      No services found in this environment
-                    </h1>
-                    <h2 className="text-lg">
-                      Would you like to start by creating one?
-                    </h2>
-                  </div>
+                  <h1 className="text-2xl font-bold">
+                    No services found in this environment
+                  </h1>
+                  <h2 className="text-lg">
+                    Would you like to start by creating one?
+                  </h2>
                   <Button asChild>
                     <Link to="./create-service" prefetch="intent">
                       Create a new service

--- a/frontend/app/routes/services/components/service-urls-form.tsx
+++ b/frontend/app/routes/services/components/service-urls-form.tsx
@@ -368,7 +368,7 @@ function ServiceURLFormItem({
                   >
                     <FieldSetLabel>Forwarded port</FieldSetLabel>
                     <FieldSetInput
-                      placeholder="ex: /"
+                      placeholder="ex: 3000"
                       name="associated_port"
                       defaultValue={associated_port ?? ""}
                     />
@@ -571,7 +571,7 @@ function NewServiceURLForm() {
         >
           <FieldSetLabel>Forwarded port</FieldSetLabel>
           <FieldSetInput
-            placeholder="ex: /"
+            placeholder="ex: 3000"
             name="associated_port"
             defaultValue={80}
           />

--- a/frontend/app/routes/services/services-env-variables.tsx
+++ b/frontend/app/routes/services/services-env-variables.tsx
@@ -123,9 +123,7 @@ export default function ServiceEnvVariablesPage({
                 size="sm"
                 showLabel
                 label={(hasCopied) => (hasCopied ? "Copied" : "Copy as .env")}
-                value={env_variables
-                  .values()
-                  .toArray()
+                value={Array.from(env_variables.values())
                   .map((env) => `${env.name}="${env.value}"`)
                   .join("\n")}
               />
@@ -368,7 +366,7 @@ async function deleteEnvVariable({
   formData: FormData;
 }) {
   const toasId = toast.loading(`Sending change request...`);
-  const { error: error } = await apiClient.PUT(
+  const { error } = await apiClient.PUT(
     "/api/projects/{project_slug}/{env_slug}/request-service-changes/{service_slug}/",
     {
       headers: {


### PR DESCRIPTION
## Summary

The spaces between those elements felt too tight.  

Also, the `.toArray` extension is [newly base-lined](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator/toArray#browser_compatibility). I had about an hour debugging a runtime error in service environment variables page until I figured out that my browser doesn't support it. If we’re OK with this level of bleeding edge let me know to revert it. I made it so no one passes what I had to

fixes #

### Screenshots (if applicable)

| Before | After |
| ------------ | ------------ |
|  <img width="1920" height="1200" alt="Screenshot from 2025-09-10 18-41-02" src="https://github.com/user-attachments/assets/5e91c269-0359-4584-a6a7-11950c2c4b92" />   |<img width="1920" height="1200" alt="Screenshot from 2025-09-10 18-41-12" src="https://github.com/user-attachments/assets/3a42d2bd-751e-4a85-a905-896cc41d7796" />    |
 
 


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
