### PR TITLE
Fix refreshing gitlab access token inside temporal activity

### DIFF
--- a/backend/git_connectors/models.py
+++ b/backend/git_connectors/models.py
@@ -362,3 +362,6 @@ class GitlabApp(TimestampedModel):
     def get_authenticated_repository_url(self, repo_url: str):
         access_token = GitlabApp.ensure_fresh_access_token(self)
         return f"https://oauth2:{access_token}@{re.sub(r'https?://', '', repo_url)}"
+    
+    async def aget_authenticated_repository_url(self, repo_url: str):
+        return await sync_to_async(self.get_authenticated_repository_url)(repo_url)

--- a/backend/temporal/activities/git_activities.py
+++ b/backend/temporal/activities/git_activities.py
@@ -288,7 +288,7 @@ class GitActivities:
                             repo_url
                         )
                     elif gitapp.gitlab is not None:
-                        repo_url = gitapp.gitlab.get_authenticated_repository_url(
+                        repo_url = await gitapp.gitlab.aget_authenticated_repository_url(
                             repo_url
                         )
 


### PR DESCRIPTION
## Summary

fixes #510
Please read the context in #510

`app.save()` can't be called in async context. This PR wraps it in `sync_to_async`. 

`/gitlab/{id}/test/` return 500 if `ensure_fresh_access_token` raised exceptions which triggers the error boundary on the frontend not `toast.error`. This PR returns 424 "Failed Dependency", we can watch this code on the frontend and redirect to `{gitlab_url}/oauth/authorize`

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
