### PR TITLE
fix: prevent deleting all Preview metadata when closing PR 

### DIFF
--- a/backend/zane_api/models/archived.py
+++ b/backend/zane_api/models/archived.py
@@ -58,12 +58,10 @@ class ArchivedProject(TimestampArchivedModel):
                 description=project.description,
             )
 
-        for env in project.environments.select_related("preview_metadata").all():
+        for env in project.environments.all():
             archived_version.environments.get_or_create(
                 original_id=env.id, name=env.name
             )
-            if env.preview_metadata is not None:
-                env.preview_metadata.delete()
         return archived_version
 
     def __str__(self):

--- a/backend/zane_api/tests/preview_environments.py
+++ b/backend/zane_api/tests/preview_environments.py
@@ -387,7 +387,7 @@ class PreviewEnvironmentsViewTests(BasePreviewEnvTests):
             ),
             data={"branch_name": "feat/test-1"},
         )
-        self.assertEqual(status.HTTP_403_FORBIDDEN, response.status_code)
+        self.assertEqual(status.HTTP_409_CONFLICT, response.status_code)
         jprint(response.json())
 
     @responses.activate

--- a/backend/zane_api/views/git_services.py
+++ b/backend/zane_api/views/git_services.py
@@ -565,7 +565,7 @@ class ArchiveGitServiceAPIView(APIView):
             )
 
         if service.preview_environments.exists():
-            raise exceptions.PermissionDenied(
+            raise ResourceConflict(
                 "Cannot delete a service that is attached to a preview environment, delete related preview environments before deleting this service."
             )
 

--- a/backend/zane_api/views/git_services.py
+++ b/backend/zane_api/views/git_services.py
@@ -566,7 +566,7 @@ class ArchiveGitServiceAPIView(APIView):
 
         if service.preview_environments.exists():
             raise exceptions.PermissionDenied(
-                "Cannot delete a service attached to at least one preview environment."
+                "Cannot delete a service that is attached to a preview environment, delete related preview environments before deleting this service."
             )
 
         if service.deployments.count() > 0:  # type: ignore

--- a/backend/zane_api/views/projects.py
+++ b/backend/zane_api/views/projects.py
@@ -283,6 +283,11 @@ class ProjectDetailsView(APIView):
         for service in docker_service_list:
             if service.healthcheck is not None:
                 service.healthcheck.delete()
+        # Delete Preview metadata before the services because they hold protected references
+        # to the services
+        for env in project.environments.filter().select_related("preview_metadata"):
+            if env.preview_metadata is not None:
+                env.preview_metadata.delete()
         docker_service_list.delete()
 
         payload = ArchivedProjectDetails(


### PR DESCRIPTION
## Summary

Reported by @AhmedBaset .

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
