### PR TITLE
fix: refreshing gitlab access token while updating the comment fails to commit due to sync in async context

### DIFF
--- a/backend/git_connectors/models.py
+++ b/backend/git_connectors/models.py
@@ -383,5 +383,5 @@ class GitlabApp(TimestampedModel):
         access_token = GitlabApp.ensure_fresh_access_token(self)
         return f"https://oauth2:{access_token}@{re.sub(r'https?://', '', repo_url)}"
     
-    async def aget_authenticated_repository_url(self, repo_url: str):
+    async def aget_authenticated_repository_url(self, repo_url: str) -> str:
         return await sync_to_async(self.get_authenticated_repository_url)(repo_url)

--- a/backend/temporal/activities/git_activities.py
+++ b/backend/temporal/activities/git_activities.py
@@ -224,8 +224,9 @@ class GitActivities:
         url_base = f"{gitlab.gitlab_url}/api/v4/projects/{repository.external_id}/merge_requests/{issue_number}/notes"
 
         # 2️⃣ Prepare the request
+        access_token = await git_app.gitlab.aensure_fresh_access_token(git_app.gitlab)
         headers = {
-            "Authorization": f"Bearer {git_app.gitlab.ensure_fresh_access_token(git_app.gitlab)}",
+            "Authorization": f"Bearer {access_token}",
         }
         payload = {
             "body": await current_deployment.aget_pull_request_deployment_comment_body()


### PR DESCRIPTION


## Summary

A follow up to #511

fixes #510

## temporal-main-worker logs
```log
zane_temporal-main-... | upsert_gitlab_pull_request_comment deployment.service.slug='bb4first-web'
zane_temporal-main-... | === Closing dead DB connections after activity execution ===
zane_temporal-main-... | Refreshing gitlab access token for gl_app_bc73P2vJakYPF3
zane_temporal-main-... | === Closing dead DB connections after activity execution ===
zane_temporal-main-... | Completing activity as failed ({'activity_id': '19', 'activity_type': 'upsert_gitlab_pull_request_comment', 'attempt': 1, 'namespace': 'zane', 'task_queue': 'main-task-queue', 'workflow_id': 'deploy-srv_dkr_HKawtxQTQB7-prj_kgLAaUeCoX5', 'workflow_run_id': '35b40751-1d31-462d-ba96-ca6029c8405e', 'workflow_type': 'deploy-git-service-workflow'})
zane_temporal-main-... | Traceback (most recent call last):
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/temporalio/worker/_activity.py", line 297, in _handle_start_activity_task
zane_temporal-main-... |     result = await self._execute_activity(start, running_activity, task_token)
zane_temporal-main-... |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/temporalio/worker/_activity.py", line 589, in _execute_activity
zane_temporal-main-... |     return await impl.execute_activity(input)
zane_temporal-main-... |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/asgiref/sync.py", line 518, in thread_handler
zane_temporal-main-... |     raise exc_info[1]
zane_temporal-main-... |   File "/app/temporal/worker.py", line 36, in execute_activity
zane_temporal-main-... |     result = await super().execute_activity(input)
zane_temporal-main-... |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/temporalio/worker/_interceptor.py", line 123, in execute_activity
zane_temporal-main-... |     return await self.next.execute_activity(input)
zane_temporal-main-... |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/temporalio/worker/_activity.py", line 784, in execute_activity
zane_temporal-main-... |     return await input.fn(*input.args)
zane_temporal-main-... |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
zane_temporal-main-... |   File "/app/temporal/activities/git_activities.py", line 232, in upsert_gitlab_pull_request_comment
zane_temporal-main-... |     "Authorization": f"Bearer {git_app.gitlab.ensure_fresh_access_token(git_app.gitlab)}",
zane_temporal-main-... |                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
zane_temporal-main-... |   File "/app/zane_api/utils.py", line 34, in wrapped
zane_temporal-main-... |     result = func(*args, **kwargs)
zane_temporal-main-... |   File "/app/git_connectors/models.py", line 381, in ensure_fresh_access_token
zane_temporal-main-... |     app.save()
zane_temporal-main-... |     ~~~~~~~~^^
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/django/db/models/base.py", line 902, in save
zane_temporal-main-... |     self.save_base(
zane_temporal-main-... |     ~~~~~~~~~~~~~~^
zane_temporal-main-... |         using=using,
zane_temporal-main-... |         ^^^^^^^^^^^^
zane_temporal-main-... |     ...<2 lines>...
zane_temporal-main-... |         update_fields=update_fields,
zane_temporal-main-... |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
zane_temporal-main-... |     )
zane_temporal-main-... |     ^
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/django/db/models/base.py", line 1008, in save_base
zane_temporal-main-... |     updated = self._save_table(
zane_temporal-main-... |         raw,
zane_temporal-main-... |     ...<4 lines>...
zane_temporal-main-... |         update_fields,
zane_temporal-main-... |     )
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/django/db/models/base.py", line 1138, in _save_table
zane_temporal-main-... |     updated = self._do_update(
zane_temporal-main-... |         base_qs, using, pk_val, values, update_fields, forced_update
zane_temporal-main-... |     )
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/django/db/models/base.py", line 1203, in _do_update
zane_temporal-main-... |     return filtered._update(values) > 0
zane_temporal-main-... |            ~~~~~~~~~~~~~~~~^^^^^^^^
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/django/db/models/query.py", line 1283, in _update
zane_temporal-main-... |     return query.get_compiler(self.db).execute_sql(ROW_COUNT)
zane_temporal-main-... |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/django/db/models/sql/compiler.py", line 2059, in execute_sql
zane_temporal-main-... |     row_count = super().execute_sql(result_type)
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/django/db/models/sql/compiler.py", line 1620, in execute_sql
zane_temporal-main-... |     cursor = self.connection.cursor()
zane_temporal-main-... |   File "/app/.venv/lib/python3.13/site-packages/django/utils/asyncio.py", line 24, in inner
zane_temporal-main-... |     raise SynchronousOnlyOperation(message)
zane_temporal-main-... | django.core.exceptions.SynchronousOnlyOperation: You cannot call this from an async context - use a thread or sync_to_async.
```
<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
