### PR TITLE
feat: Add Light & Dark mode for the terminal

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -59,6 +59,7 @@
 
 	--animate-accordion-down: accordion-down 0.2s ease-out;
 	--animate-accordion-up: accordion-up 0.2s ease-out;
+	--color-terminal: #ffffff;
 
 	@keyframes accordion-down {
 		from {
@@ -74,6 +75,15 @@
 		}
 		to {
 			height: 0;
+		}
+	}
+}
+
+@layer theme {
+	:root,
+	:host {
+		@variant dark {
+			--color-terminal: #1e1e1e;
 		}
 	}
 }

--- a/frontend/app/components/terminal.tsx
+++ b/frontend/app/components/terminal.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
-import { Terminal as XTermTerminal } from "xterm";
+import { type ITheme, Terminal as XTermTerminal } from "xterm";
 import { FitAddon } from "xterm-addon-fit";
 import "xterm/css/xterm.css";
+import { useTheme } from "~/components/theme-provider";
 import { cn } from "~/lib/utils";
 
 type TerminalProps = {
@@ -9,6 +10,54 @@ type TerminalProps = {
   shellUser?: string | null;
   baseWebSocketURL: string;
   className?: string;
+};
+
+const shellDarkTheme: ITheme = {
+  foreground: "#f8f8f2",
+  background: "#1e1e1e",
+  cursor: "#f8f8f0",
+  cursorAccent: "#1e1e1e",
+  selectionBackground: "#44475a",
+  black: "#21222c",
+  red: "#ff5555",
+  green: "#50fa7b",
+  yellow: "#f1fa8c",
+  blue: "#bd93f9",
+  magenta: "#ff79c6",
+  cyan: "#8be9fd",
+  white: "#f8f8f2",
+  brightBlack: "#6272a4",
+  brightRed: "#ff6e6e",
+  brightGreen: "#69ff94",
+  brightYellow: "#ffffa5",
+  brightBlue: "#d6acff",
+  brightMagenta: "#ff92df",
+  brightCyan: "#a4ffff",
+  brightWhite: "#ffffff"
+};
+
+const shellLightTheme: ITheme = {
+  foreground: "#2e3436",
+  background: "#ffffff",
+  cursor: "#2e3436",
+  cursorAccent: "#ffffff",
+  selectionBackground: "#c1deff",
+  black: "#2e3436",
+  red: "#cc0000",
+  green: "#4e9a06",
+  yellow: "#c4a000",
+  blue: "#3465a4",
+  magenta: "#75507b",
+  cyan: "#06989a",
+  white: "#d3d7cf",
+  brightBlack: "#555753",
+  brightRed: "#ef2929",
+  brightGreen: "#8ae234",
+  brightYellow: "#fce94f",
+  brightBlue: "#729fcf",
+  brightMagenta: "#ad7fa8",
+  brightCyan: "#34e2e2",
+  brightWhite: "#eeeeec"
 };
 
 export function Terminal({
@@ -21,6 +70,8 @@ export function Terminal({
   const term = React.useRef<XTermTerminal>(null);
   const fitAddon = React.useRef<FitAddon>(new FitAddon());
   const socketRef = React.useRef<WebSocket | null>(null);
+
+  const theme = useTheme().theme;
 
   // Send terminal size to backend over WebSocket
   const sendResize = () => {
@@ -49,7 +100,30 @@ export function Terminal({
   }, []);
 
   React.useEffect(() => {
+    if (!term.current) return;
+    const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    let termTheme: ITheme;
+    if (theme === "SYSTEM") {
+      termTheme = darkQuery.matches ? shellDarkTheme : shellLightTheme;
+    } else {
+      termTheme = theme === "DARK" ? shellDarkTheme : shellLightTheme;
+    }
+
+    term.current.options.theme = termTheme;
+  }, [theme]);
+
+  React.useEffect(() => {
     if (!terminalRef.current) return;
+
+    const darkQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    let termTheme: ITheme;
+    if (theme === "SYSTEM") {
+      termTheme = darkQuery.matches ? shellDarkTheme : shellLightTheme;
+    } else {
+      termTheme = theme === "DARK" ? shellDarkTheme : shellLightTheme;
+    }
 
     // 1. Initialize terminal + fit addon
     term.current = new XTermTerminal({
@@ -58,7 +132,8 @@ export function Terminal({
       rows: 24,
       fontFamily:
         '"Geist-Mono", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
-      fontSize: 14
+      fontSize: 14,
+      theme: termTheme
     });
     fitAddon.current = new FitAddon();
     term.current.loadAddon(fitAddon.current);

--- a/frontend/app/routes/deployments/deployment-terminal.tsx
+++ b/frontend/app/routes/deployments/deployment-terminal.tsx
@@ -31,7 +31,7 @@ export default function DeploymentTerminalPage({
   const user = searchParams.get("user")?.toString() ?? undefined;
 
   const isMaximized = searchParams.get("isMaximized") === "true";
-  let webSocketScheme = window.location.protocol === "http:" ? "ws" : "wss";
+  const webSocketScheme = window.location.protocol === "http:" ? "ws" : "wss";
   let apiHost = window.location.host;
 
   if (apiHost.includes("localhost:5173")) {
@@ -134,7 +134,7 @@ export default function DeploymentTerminalPage({
         </Button>
       </form>
 
-      <div className={cn("flex-1 py-2", shellCmd && "bg-black px-2")}>
+      <div className={cn("flex-1 py-2", shellCmd && "bg-terminal px-2")}>
         {shellCmd ? (
           <Terminal
             baseWebSocketURL={baseWebSocketURL}

--- a/frontend/app/routes/settings/server-terminal.tsx
+++ b/frontend/app/routes/settings/server-terminal.tsx
@@ -134,7 +134,7 @@ export default function ServerTerminalPage({
           </Button>
         </form>
 
-        <div className={cn("flex-1 py-2", keySlug && "bg-black px-2")}>
+        <div className={cn("flex-1 py-2", keySlug && "bg-terminal px-2")}>
           {keySlug ? (
             <ServerTerminal
               key_slug={keySlug}
@@ -160,7 +160,7 @@ function ServerTerminal({
   key_slug,
   className
 }: { key_slug: string; className?: string }) {
-  let webSocketScheme = window.location.protocol === "http:" ? "ws" : "wss";
+  const webSocketScheme = window.location.protocol === "http:" ? "ws" : "wss";
   let apiHost = window.location.host;
 
   if (apiHost.includes("localhost:5173")) {


### PR DESCRIPTION
## Summary

New themes for the terminal with light & dark mode.

### Screenshots (if applicable)

| dark mode | light mode |
| ------------ | ------------ |
| <img width="1399" height="1108" alt="terminal-dark" src="https://github.com/user-attachments/assets/2c174f60-8ef7-4a2c-ae80-0d1bf0b55436" />      | <img width="1399" height="1108" alt="terminal-light" src="https://github.com/user-attachments/assets/621a8a1b-b62b-46d8-9935-c26bc19d1b2e" /> |
 

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
