### PR TITLE
fix: do not wait for proxy when updating to a new version

### DIFF
--- a/backend/temporal/activities/service_auto_update.py
+++ b/backend/temporal/activities/service_auto_update.py
@@ -92,7 +92,8 @@ async def wait_for_service_to_be_updated(payload: UpdateDetails):
             current_image = current_service_task.Spec.ContainerSpec.Image
         print(f"service {swarm_service.name=} is updated, YAY !! 🎉")
 
-    await wait_for_service_to_be_updated()
+    if payload.wait_for_update:
+        await wait_for_service_to_be_updated()
 
 
 @activity.defn

--- a/backend/temporal/shared.py
+++ b/backend/temporal/shared.py
@@ -402,6 +402,7 @@ class UpdateDetails:
     desired_version: str
     service_name: str
     service_image: str
+    wait_for_update: bool = False
 
 
 @dataclass

--- a/backend/temporal/workflows/system.py
+++ b/backend/temporal/workflows/system.py
@@ -87,13 +87,13 @@ class AutoUpdateDockerServiceWorkflow:
         )
 
         services_to_update = [
-            ("zane_proxy", "ghcr.io/zane-ops/proxy"),
-            ("zane_app", "ghcr.io/zane-ops/app"),
-            ("zane_temporal-schedule-worker", "ghcr.io/zane-ops/app"),
-            ("zane_temporal-main-worker", "ghcr.io/zane-ops/app"),
+            ("zane_proxy", "ghcr.io/zane-ops/proxy", False),
+            ("zane_app", "ghcr.io/zane-ops/app", True),
+            ("zane_temporal-schedule-worker", "ghcr.io/zane-ops/app", True),
+            ("zane_temporal-main-worker", "ghcr.io/zane-ops/app", True),
         ]
 
-        for service, image in services_to_update:
+        for service, image, _ in services_to_update:
             print(
                 f"Running activity `update_docker_service({service=}, {desired_version=})`"
             )
@@ -125,11 +125,12 @@ class AutoUpdateDockerServiceWorkflow:
                             service_name=service,
                             desired_version=desired_version,
                             service_image=image,
+                            wait_for_update=wait_for_update,
                         ),
                         start_to_close_timeout=timedelta(minutes=5),
                         retry_policy=retry_policy,
                     )
-                    for service, image in services_to_update
+                    for service, image, wait_for_update in services_to_update
                 ]
             )
         finally:


### PR DESCRIPTION
## Summary

There is a bug with the update process where the update for the proxy would never finish, because there are published ports in caddy which will always conflict. So we should not wait for the proxy to update the status on the UI.

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
