### PR TITLE
fix: make credentials optional when creating a docker service

### DIFF
--- a/frontend/app/routes/services/create-docker-service.tsx
+++ b/frontend/app/routes/services/create-docker-service.tsx
@@ -181,11 +181,15 @@ async function createService(
   envSlug: string,
   formData: FormData
 ) {
+  const registry_credentials_id = formData
+    .get("container_registry_credentials_id")
+    ?.toString();
   const userData = {
     slug: formData.get("slug")?.toString().trim() ?? "",
     image: formData.get("image")?.toString() ?? "",
-    container_registry_credentials_id:
-      formData.get("container_registry_credentials_id")?.toString() ?? ""
+    container_registry_credentials_id: registry_credentials_id
+      ? registry_credentials_id
+      : undefined
   } satisfies RequestInput<
     "post",
     "/api/projects/{project_slug}/{env_slug}/create-service/docker/"


### PR DESCRIPTION
## Summary

This change is included in #533 , but i need to go in canary for now


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
