### PR TITLE
feat: show commands to add ssh key after adding the key

### DIFF
--- a/frontend/app/routes/settings/create-ssh-key.tsx
+++ b/frontend/app/routes/settings/create-ssh-key.tsx
@@ -1,5 +1,6 @@
 import {
   AlertCircleIcon,
+  CheckIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
   InfoIcon,
@@ -69,6 +70,13 @@ function CreateSSHKeyForm({
     ];
     return (
       <div className="flex flex-col gap-4">
+        <Alert variant="success">
+          <CheckIcon className="h-4 w-4" />
+          <AlertTitle>Success</AlertTitle>
+          <AlertDescription>
+            SSH key `{actionData.data.slug}` created succesfully !
+          </AlertDescription>
+        </Alert>
         <h3>
           To allow login with this SSH key, please add this public key to your
           ssh folder using these commands:


### PR DESCRIPTION
## Summary

Small QoL that shows the commands to add newly created ssh keys to the server.

### Screenshots 

| - | 
| ------------ |
| <img width="1400" height="1153" alt="Screenshot 2025-12-05 at 02 30 39" src="https://github.com/user-attachments/assets/27793442-fc4b-4fc8-86c5-23bc7fcc429d" /> | 

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
