### PR TITLE
refactor: do not tag images on build registry with label `zane-managed: true`

### DIFF
--- a/backend/temporal/activities/git_activities.py
+++ b/backend/temporal/activities/git_activities.py
@@ -810,7 +810,8 @@ class GitActivities:
                     service.project_id, parent=service.id
                 )
                 for k, v in resource_labels.items():
-                    docker_build_command.extend(["--label", f"{k}={v}"])
+                    if k != "zane-managed" or build_registry is None:
+                        docker_build_command.extend(["--label", f"{k}={v}"])
 
                 image_name = details.image_tag
                 if build_registry is not None:
@@ -1624,7 +1625,8 @@ class GitActivities:
                     service.project_id, parent=service.id
                 )
                 for k, v in resource_labels.items():
-                    docker_build_command.extend(["--label", f"{k}={v}"])
+                    if k != "zane-managed" or build_registry is None:
+                        docker_build_command.extend(["--label", f"{k}={v}"])
 
                 image_name = details.image_tag
                 if build_registry is not None:


### PR DESCRIPTION
## Summary

This way local images built with the build registry are cleaned up when not needed anymore.


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
