### PR TITLE
fix: zane_loki fix mount path

### DIFF
--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -394,7 +394,7 @@ services:
   loki:
     image: grafana/loki:3.4
     volumes:
-      - ./loki-config.yaml:/etc/loki/local-config.yaml
+      - ${ZANE_APP_DIRECTORY:-/var/www/zaneops}/loki-config.yaml:/etc/loki/local-config.yaml
       - loki-data:/loki
     command: -config.file=/etc/loki/local-config.yaml -config.expand-env=true
     networks:


### PR DESCRIPTION
## Summary

fix: update Loki bind mount path in docker-stack.prod.yaml to use ${ZANE_APP_DIRECTORY} so deployments are not tied to compose file location.

fixes #


<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
