### PR TITLE
fix: install docker compose plugin in the Dockerfile for the app

### DIFF
--- a/docker/app/slim.Dockerfile
+++ b/docker/app/slim.Dockerfile
@@ -97,6 +97,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         docker-ce-cli \
         docker-buildx-plugin \
+        docker-compose-plugin \
         supervisor \
         curl \
         wait-for-it \


### PR DESCRIPTION
## Summary

Without this plugin we cannot run docker compose validation.

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
