### PR TITLE
fix:  env variable code editor should take the full width

### DIFF
--- a/frontend/app/routes/services/services-env-variables.tsx
+++ b/frontend/app/routes/services/services-env-variables.tsx
@@ -56,7 +56,7 @@ import { serviceQueries } from "~/lib/queries";
 import { cn, getFormErrorsFromResponseData } from "~/lib/utils";
 import { queryClient } from "~/root";
 import { getCsrfTokenHeader, pluralize, wait } from "~/utils";
-import { type Route } from "./+types/services-env-variables";
+import type { Route } from "./+types/services-env-variables";
 
 type EnvVariableUI = {
   change_id?: string;
@@ -1038,6 +1038,7 @@ function DotEnvFileFormDialog() {
 
           <CodeEditor
             language="shell"
+            containerClassName="w-full"
             value={contents}
             onChange={(value) => setContents(value ?? "")}
           />


### PR DESCRIPTION
## Summary

Buf introduced in the last PR

### Screenshots (if applicable)

| Before | After |
| ------------ | ------------ |
| <img width="1820" height="1162" alt="Screenshot 2026-02-24 at 07 10 02" src="https://github.com/user-attachments/assets/16adf48c-e77e-4a84-bd56-7300379f2908" />  | <img width="1820" height="1162" alt="Screenshot 2026-02-24 at 07 10 15" src="https://github.com/user-attachments/assets/d084dcfe-b166-440f-b444-cd385643b884" />      |


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
