### PR TITLE
feat: show environment variables in compose stack service details

### DIFF
--- a/frontend/app/routes/compose/compose-stack-service-details.tsx
+++ b/frontend/app/routes/compose/compose-stack-service-details.tsx
@@ -2,11 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   ArrowRightIcon,
   CableIcon,
-  CheckIcon,
   ContainerIcon,
-  CopyIcon,
-  EditIcon,
-  EllipsisVerticalIcon,
   ExternalLinkIcon,
   EyeIcon,
   EyeOffIcon,
@@ -22,12 +18,10 @@ import {
   NetworkIcon,
   RotateCwIcon,
   TerminalIcon,
-  TimerResetIcon,
-  Trash2Icon,
-  Undo2Icon
+  TimerResetIcon
 } from "lucide-react";
 import * as React from "react";
-import { Link, Navigate, href, useFetcher } from "react-router";
+import { Link, Navigate, href } from "react-router";
 import type { ComposeStackService } from "~/api/types";
 import { Code } from "~/components/code";
 import { CopyButton } from "~/components/copy-button";
@@ -55,8 +49,7 @@ import {
 import { ZANEOPS_INTERNAL_DOMAIN } from "~/lib/constants";
 import { composeStackQueries } from "~/lib/queries";
 import { cn } from "~/lib/utils";
-import type { clientAction } from "~/routes/trigger-update";
-import { formatElapsedTime, pluralize, wait } from "~/utils";
+import { formatElapsedTime, pluralize } from "~/utils";
 import type { Route } from "./+types/compose-stack-service-details";
 
 export default function ComposeStackServiceDetailsPage({


### PR DESCRIPTION
## Summary

I forgot to add this in the last PR for docker-compose. 



> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
