### PR TITLE
fix: validate env variable names in `x-zane-env`

### DIFF
--- a/backend/compose/processor.py
+++ b/backend/compose/processor.py
@@ -35,10 +35,11 @@ from django.db.models import Q
 import uuid
 from django.db import connection
 import base64
+from zane_api.serializers import EnvVarDictField
 
 
 class ComposeStackSpecSerializer(serializers.Serializer):
-    x_zane_env = serializers.DictField(
+    x_zane_env = EnvVarDictField(
         child=serializers.CharField(allow_blank=True), required=False
     )
 

--- a/backend/compose/views/serializers.py
+++ b/backend/compose/views/serializers.py
@@ -174,16 +174,27 @@ class ComposeStackSerializer(serializers.ModelSerializer):
 
         return attrs
 
+    def validate_user_content(self, user_content: str):
+        try:
+            ComposeSpecProcessor.validate_compose_file_syntax(user_content)
+        except ValidationError as e:
+            raise serializers.ValidationError(e.messages)
+        except serializers.ValidationError as e:
+            formated: dict[str, Any] = ExceptionFormatter(e, self.context, e).run()  # type: ignore
+            raise serializers.ValidationError(
+                [
+                    f"Invalid compose file: `{error['attr']}: {error['detail']}`"
+                    for error in formated["errors"]
+                ]
+            )
+
+        return user_content
+
     @transaction.atomic()
     def create(self, validated_data: dict):
         project = cast(Project, self.context["project"])
         environment = cast(Environment, self.context["environment"])
         user_content = validated_data["user_content"]
-
-        try:
-            ComposeSpecProcessor.validate_compose_file_syntax(user_content)
-        except ValidationError as e:
-            raise serializers.ValidationError({"user_content": e.messages})
 
         slug = validated_data["slug"]
         if ComposeStack.objects.filter(
@@ -497,6 +508,16 @@ class ComposeContentFieldChangeSerializer(BaseFieldChangeSerializer):
             ComposeSpecProcessor.validate_compose_file_syntax(user_content)
         except ValidationError as e:
             raise serializers.ValidationError({"new_value": e.messages})
+        except serializers.ValidationError as e:
+            formated: dict[str, Any] = ExceptionFormatter(e, self.context, e).run()  # type: ignore
+            raise serializers.ValidationError(
+                {
+                    "new_value": [
+                        f"Invalid compose file: `{error['attr']}: {error['detail']}`"
+                        for error in formated["errors"]
+                    ]
+                }
+            )
 
         stack = self.get_stack()
 

--- a/backend/zane_api/serializers.py
+++ b/backend/zane_api/serializers.py
@@ -8,6 +8,7 @@ from drf_spectacular.utils import extend_schema_field
 from drf_standardized_errors.openapi_serializers import ClientErrorEnum
 from rest_framework import serializers
 from . import models
+from django.core.exceptions import ValidationError as DjangoValidationError
 from .validators import validate_env_name, validate_url_path, validate_url_domain
 from git_connectors.serializers import GitAppSerializer, GitRepositorySerializer
 from container_registry.serializers import (
@@ -40,6 +41,20 @@ class URLPathField(serializers.CharField):
 
 class URLDomainField(serializers.CharField):
     default_validators = [validate_url_domain]
+
+
+class EnvVarDictField(serializers.DictField):
+    def to_internal_value(self, data):
+        result = super().to_internal_value(data)
+        errors = {}
+        for key in result:
+            try:
+                validate_env_name(key)
+            except DjangoValidationError as e:
+                errors[key] = e.message
+        if errors:
+            raise serializers.ValidationError(errors)
+        return result
 
 
 class CustomChoiceField(serializers.ChoiceField):

--- a/backend/zane_api/validators.py
+++ b/backend/zane_api/validators.py
@@ -44,7 +44,7 @@ def validate_env_name(value: str):
     pattern = r"^[A-Za-z_][A-Za-z0-9_]*$"
     if not bool(re.match(pattern, value)):
         raise ValidationError(
-            "shoud starts with an underscore (_) or a letter followed by letters, number or underscores(_)"
+            "Environment variable names shoud starts with an underscore (_) or a letter followed by letters, number or underscores(_)"
         )
 
 


### PR DESCRIPTION
## Summary

Validate that env variable names in `x-zane-env` are valid, otherwise they would not work.


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
