### PR TITLE
fix: place-content-start in tag list

### DIFF
--- a/frontend/app/routes/compose/compose-stack-template-list.tsx
+++ b/frontend/app/routes/compose/compose-stack-template-list.tsx
@@ -332,7 +332,12 @@ function TagsListForm({ selectedTags, onTagSelectChange }: TagsListFormProps) {
         }}
       />
 
-      <ul className="hidden md:grid md:grid-cols-1 pl-0 list-none gap-1 shrink min-h-0 h-80 max-h-80 overflow-auto">
+      <ul
+        className={cn(
+          "hidden md:grid md:grid-cols-1 pl-0 list-none gap-1 shrink",
+          "min-h-0 h-80 max-h-80 overflow-auto place-content-start"
+        )}
+      >
         {tagList.map((tag) => (
           <li key={tag}>
             <label


### PR DESCRIPTION
## Summary

A simple UI fix.

### Screenshots (if applicable)

| before | after |
| ------------ | ------------ |
| <img width="1470" height="1061" alt="Screenshot 2026-02-26 at 16 51 38" src="https://github.com/user-attachments/assets/590f064d-29dd-4029-b424-acfa62ca2ff6" />    | <img width="1470" height="1061" alt="Screenshot 2026-02-26 at 16 51 56" src="https://github.com/user-attachments/assets/f5eb8fa5-ffa1-4511-a37a-d5ceebf2dc87" />  |


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
