### PR TITLE
fix: build new image version on tag and not on releases

### DIFF
--- a/.github/workflows/build-push-images-tag.yaml
+++ b/.github/workflows/build-push-images-tag.yaml
@@ -201,3 +201,21 @@ jobs:
           docker buildx imagetools create -t ghcr.io/zane-ops/app:${{ needs.extract-version.outputs.tag }} \
             ghcr.io/zane-ops/app:${{ needs.extract-version.outputs.tag }}-amd64 \
             ghcr.io/zane-ops/app:${{ needs.extract-version.outputs.tag }}-arm64
+
+  create-release:
+    if: ${{ github.repository == 'zane-ops/zane-ops' && github.event_name == 'push' }}
+    name: Create GitHub Release
+    needs: [extract-version, create-manifests]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create ${{ needs.extract-version.outputs.tag }} \
+            --repo ${{ github.repository }} \
+            --title "${{ needs.extract-version.outputs.tag }}" \
+            --generate-notes \
+            --draft

--- a/.github/workflows/build-push-images-tag.yaml
+++ b/.github/workflows/build-push-images-tag.yaml
@@ -1,7 +1,8 @@
 name: Build and Push Latest Images
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

This makes sure that the tag is built before the release and create a draft release after a tag have been built.

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
