### PR TITLE
fix: do not hardcode table name for compose stacks

### DIFF
--- a/backend/compose/processor.py
+++ b/backend/compose/processor.py
@@ -155,7 +155,7 @@ class ComposeStackURLRouteSerializer(serializers.Serializer):
         # The urls field structure is: {service_name: [{domain, base_path, ...}, ...]}
         query = f"""
             SELECT cs.id
-            FROM compose_composestack cs,
+            FROM {ComposeStack._meta.db_table} cs,
                  jsonb_each(cs.urls) AS services(service_name, routes),
                  jsonb_array_elements(services.routes) AS route
             WHERE cs.urls IS NOT NULL

--- a/backend/zane_api/views/proxy.py
+++ b/backend/zane_api/views/proxy.py
@@ -13,6 +13,7 @@ from django.db import connection
 from zane_api.utils import domain_to_wildcard
 from container_registry.models import BuildRegistry
 from typing import cast
+from compose.models import ComposeStack
 
 
 class CertificateCheckSerializer(serializers.Serializer):
@@ -54,9 +55,9 @@ class CheckCertificatesAPIView(APIView):
             # Check compose stack URLs
             # Use PostgreSQL's jsonb_each and jsonb_array_elements to search nested JSON
             # The urls field structure is: {service_name: [{domain, base_path, ...}, ...]}
-            query = """
+            query = f"""
                 SELECT cs.id
-                FROM compose_composestack cs,
+                FROM {ComposeStack._meta.db_table} cs,
                     jsonb_each(cs.urls) AS services(service_name, routes),
                     jsonb_array_elements(services.routes) AS route
                 WHERE cs.urls IS NOT NULL


### PR DESCRIPTION
## Summary

This is not a big deal, but hardcoding table names in raw queries will cause issues if we ever rename the table for compose stacks, so instead we determine this dynamically. 

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
