### PR TITLE
fix: register cleanup compose compose stack metrics activity

### DIFF
--- a/backend/temporal/schedules/workflows.py
+++ b/backend/temporal/schedules/workflows.py
@@ -74,7 +74,7 @@ class MonitorDockerDeploymentWorkflow:
         await workflow.execute_activity_method(
             MonitorDockerDeploymentActivities.save_deployment_status,
             healthcheck_result,
-            start_to_close_timeout=timedelta(seconds=5),
+            start_to_close_timeout=timedelta(seconds=30),
             retry_policy=retry_policy,
         )
         return deployment_status, deployment_status_reason
@@ -104,7 +104,7 @@ class MonitorRegistrySwarmServiceWorkflow:
             MonitorRegistryDeploymentActivites.save_registry_health_check_status,
             healthcheck,
             retry_policy=retry_policy,
-            start_to_close_timeout=timedelta(seconds=10),
+            start_to_close_timeout=timedelta(seconds=30),
         )
 
         return healthcheck
@@ -135,7 +135,7 @@ class MonitorComposeStackWorkflow:
             MonitorComposeStackActivites.save_stack_health_check_status,
             healthcheck,
             retry_policy=retry_policy,
-            start_to_close_timeout=timedelta(seconds=10),
+            start_to_close_timeout=timedelta(seconds=30),
         )
 
         return healthcheck
@@ -220,12 +220,12 @@ class CleanupAppLogsWorkflow:
         )
         service_metrics_deleted_count = await workflow.execute_activity_method(
             CleanupActivities.cleanup_service_metrics,
-            start_to_close_timeout=timedelta(seconds=5),
+            start_to_close_timeout=timedelta(seconds=30),
             retry_policy=retry_policy,
         )
         stack_metrics_deleted_count = await workflow.execute_activity_method(
             CleanupActivities.cleanup_compose_stack_metrics,
-            start_to_close_timeout=timedelta(seconds=5),
+            start_to_close_timeout=timedelta(seconds=30),
             retry_policy=retry_policy,
         )
 

--- a/backend/temporal/workflows/__init__.py
+++ b/backend/temporal/workflows/__init__.py
@@ -172,6 +172,7 @@ def get_workflows_and_activities():
             monitor_activities.save_deployment_status,
             monitor_activities.run_deployment_monitor_healthcheck,
             cleanup_activites.cleanup_service_metrics,
+            cleanup_activites.cleanup_compose_stack_metrics,
             system_cleanup_activities.cleanup_images,
             system_cleanup_activities.cleanup_containers,
             system_cleanup_activities.cleanup_volumes,

--- a/deploy-scripts/Makefile
+++ b/deploy-scripts/Makefile
@@ -36,6 +36,7 @@ setup: ### Launch initial setup before installing zaneops
 	@chmod 777 .fluentd
 	@echo "Step 2️⃣ Done ✅"
 	@echo "Step 3️⃣: Downloading docker compose files for zaneops..."
+	@mkdir -p $(current_dir)/pgbouncer
 	@mkdir -p $(current_dir)/temporalio/config/dynamicconfig
 	@curl https://raw.githubusercontent.com/zane-ops/zane-ops/main/docker/temporalio/entrypoint.sh > ./temporalio/entrypoint.sh
 	@curl https://raw.githubusercontent.com/zane-ops/zane-ops/main/docker/temporalio/admin-tools-entrypoint.sh > ./temporalio/admin-tools-entrypoint.sh
@@ -45,7 +46,9 @@ setup: ### Launch initial setup before installing zaneops
 	@curl https://raw.githubusercontent.com/zane-ops/zane-ops/main/docker/docker-stack.prod-http.yaml > ./docker-stack.prod-http.yaml
 	@curl https://raw.githubusercontent.com/zane-ops/zane-ops/main/docker/fluentd/fluent.conf > ./fluent.conf
 	@curl https://raw.githubusercontent.com/zane-ops/zane-ops/main/docker/loki/config.yaml > ./loki-config.yaml
+	@curl https://raw.githubusercontent.com/zane-ops/zane-ops/main/docker/pgbouncer/entrypoint.sh > ./pgbouncer/entrypoint.sh
 	@chmod -R a+x ./temporalio/*.sh
+	@chmod -R a+x ./pgbouncer/*.sh
 	@echo "Step 3️⃣ Done ✅"
 	@echo "Step 4️⃣: Downloading the env file template..."
 	@if [ ! -f ".env" ]; then \

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -123,7 +123,7 @@ services:
       - DB_PORT=5432
       - POSTGRES_USER=${ZANE_DB_USER:-zane}
       - POSTGRES_PWD=${ZANE_DB_PASSWORD}
-      - POSTGRES_SEEDS=zane.db
+      - POSTGRES_SEEDS=zane.pgbouncer
       - SERVICES=history,matching,frontend,worker
       - BIND_ON_IP=0.0.0.0
     image: temporalio/auto-setup:1.24.2
@@ -175,7 +175,8 @@ services:
       - DB_PORT=5432
       - POSTGRES_USER=${ZANE_DB_USER:-zane}
       - POSTGRES_PWD=${ZANE_DB_PASSWORD}
-      - POSTGRES_SEEDS=zane.db
+      - POSTGRES_SEEDS=zane.pgbouncer
+      - POSTGRES_SEEDS_CREATE=zane.db
       - SKIP_SCHEMA_SETUP=false
       - SKIP_DB_SETUP=false
       - SERVICES=history,matching,frontend,worker
@@ -349,6 +350,9 @@ services:
       zane:
         aliases:
           - zane.pgbouncer
+    volumes:
+      - ./pgbouncer/entrypoint.sh:/entrypoint.sh
+    entrypoint: ["/entrypoint.sh"]
     healthcheck:
       test: ["CMD", "pg_isready", "-h", "localhost"]
       interval: 10s
@@ -368,6 +372,7 @@ services:
         limits:
           cpus: "1"
           memory: 1G
+  
   zane-fluentd:
     image: fluentd:v1.16.2-1.1
     volumes:

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -335,7 +335,7 @@ services:
       start_period: 5s
       timeout: 10s
   zane-pgbouncer:
-    image: edoburu/pgbouncer:v1.23.1-p3
+    image: edoburu/pgbouncer:v1.25.1-p0
     environment:
       <<: *env-vars
       DB_HOST: zane.db

--- a/docker/pgbouncer/entrypoint.sh
+++ b/docker/pgbouncer/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -e
+
+# Generate pgbouncer.ini from env
+cat > /etc/pgbouncer/pgbouncer.ini << EOF
+[databases]
+zane = host=${DB_HOST:-zane.db} port=${DB_PORT:-5432} dbname=zane
+temporal = host=${DB_HOST:-zane.db} port=${DB_PORT:-5432} dbname=temporal
+temporal_visibility = host=${DB_HOST:-zane.db} port=${DB_PORT:-5432} dbname=temporal_visibility
+
+
+[pgbouncer]
+listen_addr = 0.0.0.0
+listen_port = 5432
+auth_type   = ${AUTH_TYPE:-scram-sha-256}
+auth_file   = /etc/pgbouncer/userlist.txt
+pool_mode   = ${POOL_MODE:-transaction}
+max_db_connections = ${MAX_DB_CONNECTIONS:-100}
+default_pool_size  = ${DEFAULT_POOL_SIZE:-50}
+EOF
+
+# Generate userlist.txt from env
+echo "\"${DB_USER}\" \"${DB_PASSWORD}\"" > /etc/pgbouncer/userlist.txt
+
+exec pgbouncer /etc/pgbouncer/pgbouncer.ini

--- a/docker/temporalio/admin-tools-entrypoint.sh
+++ b/docker/temporalio/admin-tools-entrypoint.sh
@@ -23,6 +23,7 @@ set -eux -o pipefail
 : "${MYSQL_TX_ISOLATION_COMPAT:=false}"
 
 : "${POSTGRES_SEEDS:=}"
+: "${POSTGRES_SEEDS_CREATE:=}"
 : "${POSTGRES_USER:=}"
 : "${POSTGRES_PWD:=}"
 
@@ -78,14 +79,14 @@ setup_postgres_schema() {
     SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/${POSTGRES_VERSION_DIR}/temporal/versioned
     # Create database only if its name is different from the user name. Otherwise PostgreSQL container itself will create database.
     if [[ ${DBNAME} != "${POSTGRES_USER}" && ${SKIP_DB_CREATE} != true ]]; then
-        temporal-sql-tool --plugin ${DB} --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" create
+        temporal-sql-tool --plugin ${DB} --ep "${POSTGRES_SEEDS_CREATE}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" create
     fi
     temporal-sql-tool --plugin ${DB} --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" setup-schema -v 0.0
     temporal-sql-tool --plugin ${DB} --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" update-schema -d "${SCHEMA_DIR}"
 
     VISIBILITY_SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/${POSTGRES_VERSION_DIR}/visibility/versioned
     if [[ ${VISIBILITY_DBNAME} != "${POSTGRES_USER}" && ${SKIP_DB_CREATE} != true ]]; then
-        temporal-sql-tool --plugin ${DB} --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" create
+        temporal-sql-tool --plugin ${DB} --ep "${POSTGRES_SEEDS_CREATE}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" create
     fi
     temporal-sql-tool --plugin ${DB} --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
     temporal-sql-tool --plugin ${DB} --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"

--- a/frontend/app/components/change-fields.tsx
+++ b/frontend/app/components/change-fields.tsx
@@ -2055,7 +2055,7 @@ export function EnvVariableChangeItem({
   const [isNewEnvValueShown, setIsNewEnvValueShown] = React.useState(false);
 
   return (
-    <div className="flex flex-col gap-2 items-center md:flex-row overflow-x-auto">
+    <div className="flex flex-col gap-2 items-center overflow-x-auto">
       <div
         className={cn(
           "w-full px-3 py-4 bg-muted rounded-md inline-flex items-start text-start pr-8",
@@ -2109,10 +2109,7 @@ export function EnvVariableChangeItem({
 
       {change.type === "UPDATE" && (
         <>
-          <ArrowDownIcon
-            size={24}
-            className="text-grey md:-rotate-90 flex-none"
-          />
+          <ArrowDownIcon size={24} className="text-grey flex-none" />
 
           <div
             className={cn(


### PR DESCRIPTION
## Summary

**Main changes:** 
- The compose metrics cleanup activity wasn't registered in the temporal worker causing the app cleanup workflow to fail, fixed it.

**Other changes:**
- Updated temporal server to also use pgbouncer in production as raw postgres may cause issues in prod with connection pooling 
- Upgraded pgbouncer to new version


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
