### PR TITLE
🐛 fix errors with pgbouncer and temporal-server

### DIFF
--- a/docker/pgbouncer/entrypoint.sh
+++ b/docker/pgbouncer/entrypoint.sh
@@ -17,6 +17,7 @@ auth_file   = /etc/pgbouncer/userlist.txt
 pool_mode   = ${POOL_MODE:-transaction}
 max_db_connections = ${MAX_DB_CONNECTIONS:-100}
 default_pool_size  = ${DEFAULT_POOL_SIZE:-50}
+ignore_startup_parameters = extra_float_digits
 EOF
 
 # Generate userlist.txt from env


### PR DESCRIPTION
## Summary

fix issues with temporal-server not starting in production because of a bad argument not supported by pgbouncer.

<!-- 
### Screenshots (if applicable)

| screenshot 1 | screenshot 2 |
| ------------ | ------------ |
| << 1 >>      | << 2 >>      |
 -->

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
