### PR TITLE
fix: maxmind db path not being resolved correctly in production

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -508,5 +508,10 @@ APP_DATA_CLEANUP_SCHEDULE_ID = "daily-app-data-cleanup"
 OLD_DOCKER_SYSTEM_PRUNE_SCHEDULE_ID = "hourly-system-cleanup"
 DOCKER_SYSTEM_PRUNE_SCHEDULE_ID = "docker-system-prune"
 
-# GeoIP
-MAXMIND_DB_PATH = os.environ.get("MAXMIND_DB_PATH")
+# GeoIP, the DB is optional : when the operator doesn't provide one,
+# `/dev/null` is bind-mounted at that path, so we only consider GeoIP
+# configured when the path points to a real file
+_maxmind_db_path = os.environ.get("MAXMIND_DB_PATH")
+MAXMIND_DB_PATH = (
+    _maxmind_db_path if _maxmind_db_path and os.path.isfile(_maxmind_db_path) else None
+)

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -8,9 +8,8 @@ x-backend-vars: &env-vars
   LOKI_HOST: http://zane.loki:3100
   ZANE_APP_DOMAIN: ${ZANE_APP_DOMAIN:-127-0-0-1.sslip.io}
   # the operator sets `MAXMIND_DB_HOST_PATH` (path of the DB on the host), we mount it at
-  # a fixed path in the container and tell django about it, empty = GeoIP disabled
-  # Notation: `+` means `MAXMIND_DB_PATH` is set to the hardcoded path if HOST path is provided
-  MAXMIND_DB_PATH: ${MAXMIND_DB_HOST_PATH:+/code/GeoLite2-Country.mmdb}
+  # a fixed path in the container and tell django about it.
+  MAXMIND_DB_PATH: /code/GeoLite2-Country.mmdb
 
 services:
   zane-loki:

--- a/docker/docker-stack.prod.yaml
+++ b/docker/docker-stack.prod.yaml
@@ -24,8 +24,9 @@ x-backend-vars: &env-vars
   ZANE_HTTP_MODE: ${MODE:-https}
   CLOUDFLARE_API_TOKEN: ${CLOUDFLARE_API_TOKEN:-}
   # the operator sets `MAXMIND_DB_HOST_PATH` (path of the DB on the host), we mount it at
-  # a fixed path in the container and tell django about it, empty = GeoIP disabled
-  MAXMIND_DB_PATH: ${MAXMIND_DB_HOST_PATH:+/app/GeoLite2-Country.mmdb}
+  # a fixed path in the container and tell django about it.
+  # When unset, `/dev/null` is mounted instead and django disables GeoIP,
+  MAXMIND_DB_PATH: /app/GeoLite2-Country.mmdb
 
 services:
   zane-proxy:


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the MIT and the ZaneOps Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

We can't use `${VAR:+value}` syntax as `docker stack deploy` doesn't support it, so instead we always set a default value for the db and the API will check if it's a valid file on startup.
  


> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
