### PR TITLE
chore: Add `Buy New License` link to license details page

### DIFF
--- a/frontend/app/lib/constants.tsx
+++ b/frontend/app/lib/constants.tsx
@@ -234,3 +234,6 @@ const buildSchema = z
   .default("oss");
 
 export const BUILD_EDITION = buildSchema.parse(import.meta.env.VITE_BUILD);
+
+export const BUY_LICENSE_LINK =
+  "https://buy.stripe.com/6oU8wO1ABb3W3hubwF4gg02";

--- a/frontend/app/routes/server-admin/license-details.tsx
+++ b/frontend/app/routes/server-admin/license-details.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import {
   CheckIcon,
+  DollarSignIcon,
+  ExternalLinkIcon,
   InfoIcon,
   KeyRoundIcon,
   LoaderIcon,
-  PencilIcon,
   PencilLineIcon,
-  RefreshCwIcon,
   ScaleIcon,
   TriangleAlertIcon,
   XIcon
@@ -21,7 +21,7 @@ import { SimpleConfirmationDialog } from "~/components/delete-confirmation-dialo
 import { StatusBadge } from "~/components/status-badge";
 import { Alert, AlertDescription, AlertTitle } from "~/components/ui/alert";
 import { Button, SubmitButton } from "~/components/ui/button";
-import { Card, CardContent, CardFooter, CardTitle } from "~/components/ui/card";
+import { Card, CardContent, CardFooter } from "~/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -42,7 +42,7 @@ import {
   TooltipProvider,
   TooltipTrigger
 } from "~/components/ui/tooltip";
-import { BUILD_EDITION } from "~/lib/constants";
+import { BUILD_EDITION, BUY_LICENSE_LINK } from "~/lib/constants";
 import { syncLicenseStore } from "~/lib/license-store";
 import { licenseQueries } from "~/lib/queries";
 import { getQueryClient } from "~/lib/query-client";
@@ -97,16 +97,34 @@ export default function LicenseDetailsPage({
       {license ? (
         <LicenseCard license={license} />
       ) : (
-        <div className="border border-dashed border-border h-80 flex flex-col gap-2 items-center justify-center rounded-lg">
-          <h3 className="text-grey text-lg">
-            No license installed on this instance
-          </h3>
+        <div className="text-grey border border-dashed border-border h-80 flex flex-col gap-2 items-center justify-center rounded-lg">
+          <h3 className="text-lg">No license installed on this instance</h3>
           <ActivateLicenseDialog>
             <Button className="gap-2">
               <span>Activate license</span>
               <KeyRoundIcon className="size-4" />
             </Button>
           </ActivateLicenseDialog>
+
+          <div className="flex gap-2 items-center">
+            <Separator className="w-10 " />
+            <small className="">or</small>
+            <Separator className="w-10 " />
+          </div>
+
+          <div className="flex flex-col gap-1 items-center">
+            <a
+              href={BUY_LICENSE_LINK}
+              target="_blank"
+              className="text-link underline inline-flex gap-2 items-center"
+            >
+              Buy new license
+              <ExternalLinkIcon className="size-4" />
+            </a>
+            <p className="text-sm w-40 text-center">
+              Your license key will be emailed to you
+            </p>
+          </div>
         </div>
       )}
     </section>
@@ -280,7 +298,7 @@ export function ActivateLicenseDialog({
     >
       <DialogTrigger asChild>{children}</DialogTrigger>
       <DialogContent>
-        <DialogHeader className="pb-4">
+        <DialogHeader className="pb-0">
           <DialogTitle>
             {type === "install" ? (
               <>Activate a new license</>
@@ -310,6 +328,20 @@ export function ActivateLicenseDialog({
             </Alert>
           )}
         </DialogHeader>
+
+        <p>
+          You can also{" "}
+          <a
+            href={BUY_LICENSE_LINK}
+            target="_blank"
+            className="text-link underline inline-flex gap-2 items-center"
+          >
+            buy a new license
+            <ExternalLinkIcon className="size-4" />
+          </a>{" "}
+          if you don&apos;t have one yet, your license key will be emailed to
+          you.
+        </p>
 
         <fetcher.Form method="post" id="install-form">
           <input type="hidden" name="intent" value="install" />


### PR DESCRIPTION
## Community Contribution License Agreement

By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the MIT and the ZaneOps Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Summary

I forgot to include this in the release version.


### Screenshots (if applicable)

| Name | screenshot  |
| ------------ | ------------ |
| Buy new license link in the details page   |  <img width="1489" height="1061" alt="Screenshot 2026-09-04 at 19 43 47" src="https://github.com/user-attachments/assets/48a4d9d8-90ca-4383-a5af-cbd84b237433" /> |
| Buy new license link in activate license modal   | <img width="1489" height="1061" alt="Screenshot 2026-09-04 at 19 43 51" src="https://github.com/user-attachments/assets/cad86a31-2c04-4198-b1a9-4f9d280affdd" />    |

> [!WARNING]
> Please do not delete the sections below


### ⚠️ If you modify backend code, be sure to run these commands : 

```bash
cd backend
pnpm run openapi # will generate OpenAPI schema at `/openapi/schema.yaml`
pnpm run lock # will update the lockfile if you added a new package
```

### ⚠️ If you modify frontend code, be sure to run these commands : 

```bash
pnpm install --frozen-lockfile # Install the packages at the exact version listed in the lockfile
pnpm run format # format the files using biome
```


## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
